### PR TITLE
chore(impr): rm pre-commit test run @coderabbitai

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,8 +2,9 @@ prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') -
 bun format-and-lint:fix
 git update-index --again
 if git diff --cached --name-only | grep -q '^apps/web/'; then
-  echo "🔵 Running tests for the web application."
-  echo "🔴 Ensure to have no ENV var missing."
-  echo "🟡 Check test errors if any."
-  cd apps/web && bun test
+  echo "🔵 Pre commit test run temporally removed. Continuing..."
+  # echo "🔵 Running tests for the web application."
+  # echo "🔴 Ensure to have no ENV var missing."
+  # echo "🟡 Check test errors if any."
+  # cd apps/web && bun test
 fi


### PR DESCRIPTION
# Changelog:
- Removing the test run in the web application at the pre-commit cript in favor of reducir the amount of contributors cases having difficulties submitting due to a concurrency protection in the next and redis server. 