### PR TITLE
fix: make milestone foreign key constraints deferrable

### DIFF
--- a/services/supabase/migrations/20250306000000_fix_circular_dependency.sql
+++ b/services/supabase/migrations/20250306000000_fix_circular_dependency.sql
@@ -1,6 +1,9 @@
 -- Migration to resolve circular foreign key dependency between project_milestones and escrow_milestones
 -- By making constraints deferrable, we allow flexible insertion order while maintaining referential integrity
 -- Deferrable constraints are checked at the end of the transaction rather than after each statement
+-- Note: This migration MUST run within a transaction to ensure atomic changes and constraint consistency
+
+BEGIN;
 
 -- Drop existing foreign key constraints if they exist
 ALTER TABLE project_milestones
@@ -22,4 +25,6 @@ ALTER TABLE escrow_milestones
 ADD CONSTRAINT escrow_milestones_project_milestone_id_fkey
 FOREIGN KEY (project_milestone_id)
 REFERENCES project_milestones(id)
-DEFERRABLE INITIALLY DEFERRED; 
+DEFERRABLE INITIALLY DEFERRED;
+
+COMMIT; 

--- a/services/supabase/migrations/20250306000000_fix_circular_dependency.sql
+++ b/services/supabase/migrations/20250306000000_fix_circular_dependency.sql
@@ -1,0 +1,19 @@
+-- Drop existing foreign key constraints
+ALTER TABLE project_milestones
+DROP CONSTRAINT project_milestones_milestone_id_fkey;
+
+ALTER TABLE escrow_milestones
+DROP CONSTRAINT escrow_milestones_project_milestone_id_fkey;
+
+-- Recreate foreign key constraints as deferrable
+ALTER TABLE project_milestones
+ADD CONSTRAINT project_milestones_milestone_id_fkey
+FOREIGN KEY (milestone_id)
+REFERENCES escrow_milestones(id)
+DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE escrow_milestones
+ADD CONSTRAINT escrow_milestones_project_milestone_id_fkey
+FOREIGN KEY (project_milestone_id)
+REFERENCES project_milestones(id)
+DEFERRABLE INITIALLY DEFERRED; 

--- a/services/supabase/migrations/20250306000000_fix_circular_dependency.sql
+++ b/services/supabase/migrations/20250306000000_fix_circular_dependency.sql
@@ -1,11 +1,17 @@
--- Drop existing foreign key constraints
+-- Migration to resolve circular foreign key dependency between project_milestones and escrow_milestones
+-- By making constraints deferrable, we allow flexible insertion order while maintaining referential integrity
+-- Deferrable constraints are checked at the end of the transaction rather than after each statement
+
+-- Drop existing foreign key constraints if they exist
 ALTER TABLE project_milestones
-DROP CONSTRAINT project_milestones_milestone_id_fkey;
+DROP CONSTRAINT IF EXISTS project_milestones_milestone_id_fkey;
 
 ALTER TABLE escrow_milestones
-DROP CONSTRAINT escrow_milestones_project_milestone_id_fkey;
+DROP CONSTRAINT IF EXISTS escrow_milestones_project_milestone_id_fkey;
 
 -- Recreate foreign key constraints as deferrable
+-- This allows us to insert records in either table first, as long as both records exist
+-- by the end of the transaction, solving the chicken-and-egg problem
 ALTER TABLE project_milestones
 ADD CONSTRAINT project_milestones_milestone_id_fkey
 FOREIGN KEY (milestone_id)


### PR DESCRIPTION
## Problem
Circular foreign key dependency between `project_milestones` and `escrow_milestones` tables prevents record insertion.

## Solution
Make foreign key constraints deferrable to allow flexible insertion order while maintaining referential integrity.

### Changes
- Drop and recreate foreign key constraints with `DEFERRABLE INITIALLY DEFERRED`
- No schema restructuring required
- No data migration needed

### Migration
- Safe to apply with no downtime
- Reversible if needed

**Closes #267**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Improved data integrity by adjusting foreign key constraints, allowing for more flexible record insertion and smoother processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->