### PR TITLE
fix: update get_admin method to return Option<Address>

### DIFF
--- a/apps/contract/contracts/reputation/src/lib.rs
+++ b/apps/contract/contracts/reputation/src/lib.rs
@@ -49,8 +49,10 @@ impl ReputationContract {
         streak: u32,
     ) -> Result<(), ReputationError> {
         // Verify admin access
-        let admin = ReputationStorage::get_admin(&env);
-        admin.require_auth();
+        let admin = ReputationStorage::get_admin(&env).unwrap_or_else(|| {
+    panic!("Admin not initialized");
+   });
+   admin.require_auth();
 
         // Get current score and update
         let current_score = ReputationStorage::get_score(&env, &user_id).unwrap_or(0);
@@ -114,8 +116,11 @@ impl ReputationContract {
         threshold: u32,
     ) -> Result<(), ReputationError> {
         // Verify admin access
-        let admin = ReputationStorage::get_admin(&env);
-        admin.require_auth();
+       let admin = ReputationStorage::get_admin(&env).unwrap_or_else(|| {
+    panic!("Admin not initialized");
+});
+admin.require_auth();
+
 
         if tier == TierLevel::None {
             return Err(ReputationError::InvalidTier);
@@ -135,8 +140,11 @@ impl ReputationContract {
 
     pub fn add_admin(env: Env, new_admin: Address) -> Result<(), ReputationError> {
         // Verify admin access
-        let admin = ReputationStorage::get_admin(&env);
-        admin.require_auth();
+       let admin = ReputationStorage::get_admin(&env).unwrap_or_else(|| {
+    panic!("Admin not initialized");
+});
+admin.require_auth();
+
         // Validates that the address is an Account address with a non-zero identifier.
         Self::validate_admin_address(&new_admin)?;
         // Update admin
@@ -150,8 +158,11 @@ impl ReputationContract {
 
     pub fn update_nft_contract(env: Env, new_contract_id: Address) -> Result<(), ReputationError> {
         // Verify admin access
-        let admin = ReputationStorage::get_admin(&env);
-        admin.require_auth();
+       let admin = ReputationStorage::get_admin(&env).unwrap_or_else(|| {
+    panic!("Admin not initialized");
+});
+admin.require_auth();
+
         // Validates that the address is a Contract address with a non-zero identifier.
         Self::validate_nft_contract_address(&new_contract_id)?;
         // Get current contract ID

--- a/apps/contract/contracts/reputation/src/lib.rs
+++ b/apps/contract/contracts/reputation/src/lib.rs
@@ -121,11 +121,8 @@ impl ReputationContract {
         threshold: u32,
     ) -> Result<(), ReputationError> {
         // Verify admin access
-       let admin = ReputationStorage::get_admin(&env).unwrap_or_else(|| {
-    panic!("Admin not initialized");
-});
-admin.require_auth();
-
+        let admin = Self::get_admin_or_panic(&env);
+        admin.require_auth();
 
         if tier == TierLevel::None {
             return Err(ReputationError::InvalidTier);

--- a/apps/contract/contracts/reputation/src/lib.rs
+++ b/apps/contract/contracts/reputation/src/lib.rs
@@ -16,6 +16,13 @@ pub struct ReputationContract;
 
 #[contractimpl]
 impl ReputationContract {
+    // Helper function to get admin or panic with a clear message
+    fn get_admin_or_panic(env: &Env) -> Address {
+        ReputationStorage::get_admin(env).unwrap_or_else(|| {
+            panic!("Admin not initialized");
+        })
+    }
+
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -49,10 +56,8 @@ impl ReputationContract {
         streak: u32,
     ) -> Result<(), ReputationError> {
         // Verify admin access
-        let admin = ReputationStorage::get_admin(&env).unwrap_or_else(|| {
-    panic!("Admin not initialized");
-   });
-   admin.require_auth();
+        let admin = Self::get_admin_or_panic(&env);
+        admin.require_auth();
 
         // Get current score and update
         let current_score = ReputationStorage::get_score(&env, &user_id).unwrap_or(0);

--- a/apps/contract/contracts/reputation/src/storage.rs
+++ b/apps/contract/contracts/reputation/src/storage.rs
@@ -8,9 +8,9 @@ impl ReputationStorage {
         env.storage().instance().set(&ADMIN_KEY, admin);
     }
 
-    pub fn get_admin(env: &Env) -> Address {
-        env.storage().instance().get(&ADMIN_KEY).unwrap()
-    }
+    pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&ADMIN_KEY)
+}
 
     pub fn set_nft_contract_id(env: &Env, contract_id: &Address) {
         env.storage().instance().set(&NFT_CONTRACT_KEY, contract_id);


### PR DESCRIPTION
- Change get_admin return type from Address to Option<Address>
- Update all calling code to handle Option return type
- Remove unwrap() calls that could cause runtime panics
- Improves error handling consistency across the module

Fixes #453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for admin access by ensuring the app now fails explicitly with a clear message if the admin is not initialized, rather than continuing silently.

- **Refactor**
	- Standardized the retrieval of the admin address, making the logic more robust and consistent across admin-related actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->