### PR TITLE
Update Content-Security-Policy connect-src origins in Next.js config

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -29,7 +29,7 @@ const nextConfig = {
                 style-src 'self' 'unsafe-inline';
                 img-src 'self' data: blob:;
                 font-src 'self' data:;
-                connect-src 'self' https://kyc.example.com https://api.example.com https://*.vercel.app;
+                connect-src 'self' https://flagcdn.com https://*.kindfi.org https://*.supabase.co https://*.vercel.app;
                 frame-ancestors 'self';
                 upgrade-insecure-requests;
               `.replace(/\s{2,}/g, ' '),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security settings to allow connections to new external domains, including `flagcdn.com`, all subdomains of `kindfi.org`, and all subdomains of `supabase.co`, while maintaining access to all subdomains of `vercel.app`. Connections to `kyc.example.com` and `api.example.com` are no longer permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->