### PR TITLE
FIX: Harden Avatar fallback to handle missing/empty names gracefully in testimonial card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 
 .vscode-test
+.vscode
 
 # yarn v2
 

--- a/apps/web/components/base/impact-maker-card.tsx
+++ b/apps/web/components/base/impact-maker-card.tsx
@@ -2,10 +2,9 @@
 
 import { motion } from 'framer-motion'
 import { RiMedalLine } from 'react-icons/ri'
-import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
 import { Badge } from '~/components/base/badge-impact'
 import type { ImpactMaker } from '~/lib/types/impact/impact-makers.types'
-import { getAvatarFallback } from '~/lib/utils'
+import { UserAvatar } from './user-avatar'
 
 interface ImpactMakerCardProps {
 	maker: ImpactMaker
@@ -22,10 +21,12 @@ export function ImpactMakerCard({ maker, index }: ImpactMakerCardProps) {
 			className="rounded-3xl bg-white p-8 shadow-lg"
 		>
 			<div className="flex items-center gap-4">
-				<Avatar className="h-16 w-16">
-					<AvatarImage src={maker.image} alt={maker.name} />
-					<AvatarFallback>{getAvatarFallback(maker.name)}</AvatarFallback>
-				</Avatar>
+				<UserAvatar
+					src={maker.image}
+					alt={maker.name}
+					name={maker.name}
+					className="h-16 w-16"
+				/>
 
 				<div>
 					<h3 className="text-xl font-bold">{maker.name}</h3>

--- a/apps/web/components/base/impact-maker-card.tsx
+++ b/apps/web/components/base/impact-maker-card.tsx
@@ -5,6 +5,7 @@ import { RiMedalLine } from 'react-icons/ri'
 import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
 import { Badge } from '~/components/base/badge-impact'
 import type { ImpactMaker } from '~/lib/types/impact/impact-makers.types'
+import { getAvatarFallback } from '~/lib/utils'
 
 interface ImpactMakerCardProps {
 	maker: ImpactMaker
@@ -23,7 +24,7 @@ export function ImpactMakerCard({ maker, index }: ImpactMakerCardProps) {
 			<div className="flex items-center gap-4">
 				<Avatar className="h-16 w-16">
 					<AvatarImage src={maker.image} alt={maker.name} />
-					<AvatarFallback>{maker.name.charAt(0)}</AvatarFallback>
+					<AvatarFallback>{getAvatarFallback(maker.name)}</AvatarFallback>
 				</Avatar>
 
 				<div>

--- a/apps/web/components/base/user-avatar.tsx
+++ b/apps/web/components/base/user-avatar.tsx
@@ -1,0 +1,18 @@
+import { getAvatarFallback } from '~/lib/utils'
+import { Avatar, AvatarFallback, AvatarImage } from './avatar'
+
+interface UserAvatarProps {
+	src: string
+	alt: string
+	name: string
+	className?: string
+}
+
+export function UserAvatar({ src, alt, name, className }: UserAvatarProps) {
+	return (
+		<Avatar className={className ? className : 'h-8 w-8 flex-shrink-0'}>
+			<AvatarImage src={src} alt={alt ?? 'User Avatar'} />
+			<AvatarFallback>{getAvatarFallback(name)}</AvatarFallback>
+		</Avatar>
+	)
+}

--- a/apps/web/components/sections/projects/detail/comment-form.tsx
+++ b/apps/web/components/sections/projects/detail/comment-form.tsx
@@ -5,7 +5,6 @@ import clsx from 'clsx'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import * as z from 'zod'
-import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
 import { Button } from '~/components/base/button'
 import {
 	Form,
@@ -15,7 +14,7 @@ import {
 	FormMessage,
 } from '~/components/base/form'
 import { Textarea } from '~/components/base/textarea'
-import { getAvatarFallback } from '~/lib/utils'
+import { UserAvatar } from '~/components/base/user-avatar'
 
 interface CommentFormProps {
 	userAvatar?: string
@@ -72,13 +71,11 @@ export function CommentForm({
 			})}
 		>
 			<div className="flex gap-3">
-				<Avatar className="h-8 w-8 flex-shrink-0">
-					<AvatarImage
-						src={userAvatar || '/images/placeholder.png'}
-						alt={userName}
-					/>
-					<AvatarFallback>{getAvatarFallback(userName)}</AvatarFallback>
-				</Avatar>
+				<UserAvatar
+					src={userAvatar || '/images/placeholder.png'}
+					alt={userName}
+					name={userName}
+				/>
 				<div className="flex-1">
 					<Form {...form}>
 						<form onSubmit={form.handleSubmit(handleFormSubmit)}>

--- a/apps/web/components/sections/projects/detail/comment-form.tsx
+++ b/apps/web/components/sections/projects/detail/comment-form.tsx
@@ -15,6 +15,7 @@ import {
 	FormMessage,
 } from '~/components/base/form'
 import { Textarea } from '~/components/base/textarea'
+import { getAvatarFallback } from '~/lib/utils'
 
 interface CommentFormProps {
 	userAvatar?: string
@@ -76,7 +77,7 @@ export function CommentForm({
 						src={userAvatar || '/images/placeholder.png'}
 						alt={userName}
 					/>
-					<AvatarFallback>{userName.charAt(0)}</AvatarFallback>
+					<AvatarFallback>{getAvatarFallback(userName)}</AvatarFallback>
 				</Avatar>
 				<div className="flex-1">
 					<Form {...form}>

--- a/apps/web/components/sections/projects/detail/comment-thread.tsx
+++ b/apps/web/components/sections/projects/detail/comment-thread.tsx
@@ -4,12 +4,11 @@ import clsx from 'clsx'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ChevronDown, ChevronUp, MessageCircle } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
 import { Button } from '~/components/base/button'
+import { UserAvatar } from '~/components/base/user-avatar'
 import { CommentForm } from '~/components/sections/projects/detail/comment-form'
 import { LikeButton } from '~/components/sections/projects/detail/like-button'
 import type { Comment } from '~/lib/types/project/project-detail.types'
-import { getAvatarFallback } from '~/lib/utils'
 
 interface CommentThreadProps {
 	comments: Comment[]
@@ -108,15 +107,11 @@ function CommentItem({
 		>
 			<div className="bg-white rounded-lg p-4">
 				<div className="flex items-start gap-3 mb-3 flex-wrap min-w-0">
-					<Avatar className="h-8 w-8">
-						<AvatarImage
-							src={comment.author.avatar || '/placeholder.svg'}
-							alt={comment.author.name}
-						/>
-						<AvatarFallback>
-							{getAvatarFallback(comment.author.name)}
-						</AvatarFallback>
-					</Avatar>
+					<UserAvatar
+						src={comment.author.avatar || '/images/placeholder.png'}
+						alt={comment.author.name}
+						name={comment.author.name}
+					/>
 					<div className="flex-1">
 						<div className="flex flex-wrap items-center gap-2">
 							<h4 className="font-medium">{comment.author.name}</h4>

--- a/apps/web/components/sections/projects/detail/comment-thread.tsx
+++ b/apps/web/components/sections/projects/detail/comment-thread.tsx
@@ -9,6 +9,7 @@ import { Button } from '~/components/base/button'
 import { CommentForm } from '~/components/sections/projects/detail/comment-form'
 import { LikeButton } from '~/components/sections/projects/detail/like-button'
 import type { Comment } from '~/lib/types/project/project-detail.types'
+import { getAvatarFallback } from '~/lib/utils'
 
 interface CommentThreadProps {
 	comments: Comment[]
@@ -112,7 +113,9 @@ function CommentItem({
 							src={comment.author.avatar || '/placeholder.svg'}
 							alt={comment.author.name}
 						/>
-						<AvatarFallback>{comment.author.name.charAt(0)}</AvatarFallback>
+						<AvatarFallback>
+							{getAvatarFallback(comment.author.name)}
+						</AvatarFallback>
 					</Avatar>
 					<div className="flex-1">
 						<div className="flex flex-wrap items-center gap-2">

--- a/apps/web/components/sections/projects/detail/tabs/team-tab.tsx
+++ b/apps/web/components/sections/projects/detail/tabs/team-tab.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'framer-motion'
 import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
 import type { TeamMember } from '~/lib/types/project/project-detail.types'
+import { getAvatarFallback } from '~/lib/utils'
 import { memberRole } from '~/lib/utils/member-role'
 
 interface TeamTabProps {
@@ -41,7 +42,7 @@ export function TeamTab({ team }: TeamTabProps) {
 									alt={member.displayName ?? 'User Avatar'}
 								/>
 								<AvatarFallback>
-									{member.displayName?.charAt(0).toUpperCase() ?? 'U'}
+									{getAvatarFallback(member.displayName)}
 								</AvatarFallback>
 							</Avatar>
 

--- a/apps/web/components/sections/projects/detail/tabs/team-tab.tsx
+++ b/apps/web/components/sections/projects/detail/tabs/team-tab.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
+import { UserAvatar } from '~/components/base/user-avatar'
 import type { TeamMember } from '~/lib/types/project/project-detail.types'
-import { getAvatarFallback } from '~/lib/utils'
 import { memberRole } from '~/lib/utils/member-role'
 
 interface TeamTabProps {
@@ -36,15 +35,12 @@ export function TeamTab({ team }: TeamTabProps) {
 							transition={{ duration: 0.2 }}
 						>
 							{/* Avatar */}
-							<Avatar className="h-20 w-20 mb-4">
-								<AvatarImage
-									src={member.avatar || '/images/placeholder.png'}
-									alt={member.displayName ?? 'User Avatar'}
-								/>
-								<AvatarFallback>
-									{getAvatarFallback(member.displayName)}
-								</AvatarFallback>
-							</Avatar>
+							<UserAvatar
+								src={member.avatar || '/images/placeholder.png'}
+								alt={member.displayName}
+								name={member.displayName}
+								className="h-20 w-20 mb-4"
+							/>
 
 							{/* Name + role icon */}
 							<div className="flex items-center gap-2 mb-1">

--- a/apps/web/components/sections/projects/detail/tabs/updates-tab.tsx
+++ b/apps/web/components/sections/projects/detail/tabs/updates-tab.tsx
@@ -4,12 +4,11 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { ChevronDown, ChevronUp, MessageCircle } from 'lucide-react'
 import { useState } from 'react'
 import { useSetState } from 'react-use'
-import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
 import { Button } from '~/components/base/button'
+import { UserAvatar } from '~/components/base/user-avatar'
 import { CommentForm } from '~/components/sections/projects/detail/comment-form'
 import { CommentThread } from '~/components/sections/projects/detail/comment-thread'
 import type { Comment, Update } from '~/lib/types/project/project-detail.types'
-import { getAvatarFallback } from '~/lib/utils'
 
 interface UpdatesTabProps {
 	updates: Update[]
@@ -121,15 +120,11 @@ export function UpdatesTab({ updates }: UpdatesTabProps) {
 								</h3>
 
 								<div className="flex items-center gap-3 mb-4 min-w-0">
-									<Avatar className="h-8 w-8">
-										<AvatarImage
-											src={update.author.avatar || '/placeholder.svg'}
-											alt={update.author.name}
-										/>
-										<AvatarFallback>
-											{getAvatarFallback(update.author.name)}
-										</AvatarFallback>
-									</Avatar>
+									<UserAvatar
+										src={update.author.avatar || '/placeholder.svg'}
+										alt={update.author.name}
+										name={update.author.name}
+									/>
 									<div>
 										<p className="font-medium text-sm break-words">
 											{update.author.name}

--- a/apps/web/components/sections/projects/detail/tabs/updates-tab.tsx
+++ b/apps/web/components/sections/projects/detail/tabs/updates-tab.tsx
@@ -9,6 +9,7 @@ import { Button } from '~/components/base/button'
 import { CommentForm } from '~/components/sections/projects/detail/comment-form'
 import { CommentThread } from '~/components/sections/projects/detail/comment-thread'
 import type { Comment, Update } from '~/lib/types/project/project-detail.types'
+import { getAvatarFallback } from '~/lib/utils'
 
 interface UpdatesTabProps {
 	updates: Update[]
@@ -126,7 +127,7 @@ export function UpdatesTab({ updates }: UpdatesTabProps) {
 											alt={update.author.name}
 										/>
 										<AvatarFallback>
-											{update.author.name.charAt(0)}
+											{getAvatarFallback(update.author.name)}
 										</AvatarFallback>
 									</Avatar>
 									<div>

--- a/apps/web/components/shared/feature-creator-card.tsx
+++ b/apps/web/components/shared/feature-creator-card.tsx
@@ -2,9 +2,9 @@
 
 import { motion } from 'framer-motion'
 import { BadgeCheck } from 'lucide-react'
-import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
 import { Card } from '~/components/base/card'
 import { CTAButtons } from '~/components/shared/cta-buttons'
+import { UserAvatar } from '../base/user-avatar'
 
 export interface FeatureCreatorCardProps {
 	name: string
@@ -49,13 +49,14 @@ export const FeatureCreatorCard = ({
 				transition={{ type: 'spring', stiffness: 300 }}
 			>
 				<div className="flex flex-row items-center">
-					<Avatar className="w-20 h-20">
-						{avatarUrl ? (
-							<AvatarImage src={avatarUrl} alt={`${name}'s avatar`} />
-						) : (
-							<AvatarFallback />
-						)}
-					</Avatar>
+					{avatarUrl && (
+						<UserAvatar
+							src={avatarUrl}
+							alt={`${name}'s avatar`}
+							name={name}
+							className="h-20 w-20"
+						/>
+					)}
 					<div className="text-left ml-4">
 						<h2 className="flex items-center text-xl font-bold">
 							{name}

--- a/apps/web/components/shared/impact-maker.tsx
+++ b/apps/web/components/shared/impact-maker.tsx
@@ -5,6 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
 import { Badge } from '~/components/base/badge-impact'
 import { levelColors } from '~/lib/constants/impact-data/makers'
 import type { ImpactMaker } from '~/lib/types/impact/impact-makers.types'
+import { getAvatarFallback } from '~/lib/utils'
 
 interface ImpactMakerCardProps {
 	maker: ImpactMaker
@@ -23,7 +24,7 @@ export function ImpactMakerCard({ maker, index }: ImpactMakerCardProps) {
 			<div className="flex items-start gap-4">
 				<Avatar className="h-16 w-16">
 					<AvatarImage src={maker.image} alt={maker.name} />
-					<AvatarFallback>{maker.name.charAt(0)}</AvatarFallback>
+					<AvatarFallback>{getAvatarFallback(maker.name)}</AvatarFallback>
 				</Avatar>
 
 				<div className="flex-1">

--- a/apps/web/components/shared/impact-maker.tsx
+++ b/apps/web/components/shared/impact-maker.tsx
@@ -1,11 +1,10 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
 import { Badge } from '~/components/base/badge-impact'
 import { levelColors } from '~/lib/constants/impact-data/makers'
 import type { ImpactMaker } from '~/lib/types/impact/impact-makers.types'
-import { getAvatarFallback } from '~/lib/utils'
+import { UserAvatar } from '../base/user-avatar'
 
 interface ImpactMakerCardProps {
 	maker: ImpactMaker
@@ -22,10 +21,12 @@ export function ImpactMakerCard({ maker, index }: ImpactMakerCardProps) {
 			className="rounded-2xl bg-white p-6 shadow-lg"
 		>
 			<div className="flex items-start gap-4">
-				<Avatar className="h-16 w-16">
-					<AvatarImage src={maker.image} alt={maker.name} />
-					<AvatarFallback>{getAvatarFallback(maker.name)}</AvatarFallback>
-				</Avatar>
+				<UserAvatar
+					src={maker.image}
+					alt={maker.name}
+					name={maker.name}
+					className="h-16 w-16"
+				/>
 
 				<div className="flex-1">
 					<h3 className="text-xl font-semibold">{maker.name}</h3>

--- a/apps/web/components/shared/layout/header/header.tsx
+++ b/apps/web/components/shared/layout/header/header.tsx
@@ -25,6 +25,7 @@ import {
 	SheetTrigger,
 } from '~/components/base/sheet'
 import { useAuth } from '~/hooks/use-auth'
+import { getAvatarFallback } from '~/lib/utils'
 import { Navigation } from './navigation'
 
 export const Header = () => {
@@ -185,7 +186,7 @@ const MobileUserMenu = ({ user }: { user: User }) => {
 			<div className="flex items-center space-x-4">
 				<Avatar className="h-8 w-8">
 					<AvatarFallback suppressHydrationWarning>
-						{user.email?.[0].toUpperCase()}
+						{getAvatarFallback(user.email)}
 					</AvatarFallback>
 				</Avatar>
 				<div className="space-y-1">

--- a/apps/web/components/shared/testimonial-card-impact.tsx
+++ b/apps/web/components/shared/testimonial-card-impact.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'framer-motion'
 import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
 import type { Testimonial } from '~/lib/types/impact/impact-testimonial.types'
+import { getAvatarFallback } from '~/lib/utils'
 
 interface TestimonialCardProps {
 	testimonial: Testimonial
@@ -20,7 +21,7 @@ export function TestimonialCard({ testimonial, index }: TestimonialCardProps) {
 		>
 			<Avatar className="mb-4 w-20 h-20">
 				<AvatarImage src={testimonial.image} alt={testimonial.name} />
-				<AvatarFallback>{testimonial.name.charAt(0)}</AvatarFallback>
+				<AvatarFallback>{getAvatarFallback(testimonial.name)}</AvatarFallback>
 			</Avatar>
 
 			<div className="text-center">

--- a/apps/web/components/shared/testimonial-card-impact.tsx
+++ b/apps/web/components/shared/testimonial-card-impact.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
 import type { Testimonial } from '~/lib/types/impact/impact-testimonial.types'
-import { getAvatarFallback } from '~/lib/utils'
+import { UserAvatar } from '../base/user-avatar'
 
 interface TestimonialCardProps {
 	testimonial: Testimonial
@@ -19,10 +18,12 @@ export function TestimonialCard({ testimonial, index }: TestimonialCardProps) {
 			viewport={{ once: true }}
 			className="flex flex-col items-center p-8 bg-white rounded-2xl shadow-lg"
 		>
-			<Avatar className="mb-4 w-20 h-20">
-				<AvatarImage src={testimonial.image} alt={testimonial.name} />
-				<AvatarFallback>{getAvatarFallback(testimonial.name)}</AvatarFallback>
-			</Avatar>
+			<UserAvatar
+				src={testimonial.image}
+				alt={testimonial.name}
+				name={testimonial.name}
+				className="mb-4 w-20 h-20"
+			/>
 
 			<div className="text-center">
 				<h3 className="text-xl font-semibold">{testimonial.name}</h3>

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -53,3 +53,10 @@ export async function getAccountSequence(secretKey: string): Promise<number> {
 	)
 	return account.sequenceNumber
 }
+
+export function getAvatarFallback(name: string | undefined): string {
+	if (!name || name.trim() === '') {
+		return 'U' // Default AvatarFallback for a user with undefined or empty name
+	}
+	return name.trim().charAt(0).toUpperCase()
+}


### PR DESCRIPTION
This PR fixes the issue with potential breakage when an undefined or empty string is passed to the `AvatarFallback` component.

- Created a getAvatarFallback utility function in `apps/web/lib/utils.ts`
- Called the `getAvatarFallback` function on all strings passed to all `AvatarFallback` instances
- Included `.vscode` in the `.gitignore` file to avoid local settings being pushed

Related Issues
Closes https://github.com/kindfi-org/kindfi/issues/626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified avatar experience with a new UserAvatar across profiles, comments, updates, teams, testimonials, and impact maker cards.
  - Smarter fallback initials and consistent sizing; improved accessibility with better alt handling.
- Bug Fixes
  - Reduced broken/empty avatars via reliable placeholders and name-based fallbacks, including in the mobile user menu.
  - Feature Creator cards now hide the avatar when no image is available.
- Refactor
  - Centralized avatar fallback logic for consistency across the app.
- Chores
  - Updated ignore rules to exclude local .vscode settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->