### PR TITLE
feat : improve accessibility "use user's display name in avatar alt text"

### DIFF
--- a/apps/web/components/shared/qa/user-info.tsx
+++ b/apps/web/components/shared/qa/user-info.tsx
@@ -1,5 +1,4 @@
 'use client'
-
 import { formatDistanceToNow } from 'date-fns'
 import { User as UserIcon } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
@@ -30,6 +29,7 @@ export function UserInfo({
 	let avatarUrl: string | null = null
 	let displayName: string = ''
 	let role: string | undefined
+
 	if ('display_name' in authorData) {
 		const profile = authorData as ProfileRow
 		avatarUrl = profile.image_url
@@ -41,11 +41,14 @@ export function UserInfo({
 			authorData.full_name || `User ${authorData.id.substring(0, 6)}`
 	}
 
+	// Create accessible alt text with proper fallback handling
+	const avatarAltText = displayName ? `${displayName}'s avatar` : 'User avatar'
+
 	return (
 		<div className="flex gap-2 items-center">
 			<Avatar className={avatarSize}>
 				{avatarUrl ? (
-					<AvatarImage src={avatarUrl} alt="User avatar" />
+					<AvatarImage src={avatarUrl} alt={avatarAltText} />
 				) : (
 					<AvatarFallback>
 						<UserIcon className={iconSize} aria-hidden="true" />

--- a/apps/web/components/shared/qa/user-info.tsx
+++ b/apps/web/components/shared/qa/user-info.tsx
@@ -41,8 +41,13 @@ export function UserInfo({
 			authorData.full_name || `User ${authorData.id.substring(0, 6)}`
 	}
 
-	// Create accessible alt text with proper fallback handling
-	const avatarAltText = displayName ? `${displayName}'s avatar` : 'User avatar'
+	// Accessible alt text: prefer real names; fall back to a generic label if none provided
+	const directName =
+		'display_name' in authorData
+			? (authorData as ProfileRow).display_name
+			: authorData.full_name
+	const nameForAlt = directName?.trim()
+	const avatarAltText = nameForAlt ? `Avatar of ${nameForAlt}` : 'User avatar'
 
 	return (
 		<div className="flex gap-2 items-center">


### PR DESCRIPTION
feat: improve accessibility "use user's display name in avatar alt text"

fixes #623 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar accessibility: alt text now uses the user’s name when available, with a sensible fallback, enhancing screen reader support and descriptive labels when avatars appear.

* **Style**
  * Minor formatting cleanup for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->