### PR TITLE
feat(audit): add structured audit logging for escrow and NFT operations

### DIFF
--- a/apps/web/app/api/escrow/dispute/assign/route.ts
+++ b/apps/web/app/api/escrow/dispute/assign/route.ts
@@ -5,10 +5,16 @@ import { after, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { AppError } from '~/lib/error'
+import { AuditLogger } from '~/lib/services/audit-logger'
 import type { MediatorAssignmentPayload } from '~/lib/types/escrow/escrow-payload.types'
+import { generateUniqueId } from '~/lib/utils/id'
 import { validateMediatorAssignment } from '~/lib/validators/dispute'
 
 export async function POST(req: NextRequest) {
+	const auditLogger = new AuditLogger()
+	const correlationId = generateUniqueId('audit-')
+	const startTime = Date.now()
+
 	try {
 		// Authenticate user from session - never trust client-provided user IDs
 		const session = await getServerSession(nextAuthOption)
@@ -24,6 +30,14 @@ export async function POST(req: NextRequest) {
 		const validationResult = validateMediatorAssignment(assignmentData)
 
 		if (!validationResult.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.dispute.assign_mediator',
+				resourceType: 'dispute',
+				actorId: session.user.id,
+				status: 'validation_error',
+				durationMs: Date.now() - startTime,
+			})
 			return NextResponse.json(
 				{
 					error: 'Invalid mediator assignment data',
@@ -96,6 +110,17 @@ export async function POST(req: NextRequest) {
 			}
 		})
 
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.dispute.assign_mediator',
+			resourceType: 'dispute',
+			resourceId: disputeId,
+			actorId: session.user.id,
+			status: 'success',
+			durationMs: Date.now() - startTime,
+			metadata: { mediatorId },
+		})
+
 		return NextResponse.json(
 			{
 				success: true,
@@ -110,6 +135,16 @@ export async function POST(req: NextRequest) {
 		)
 	} catch (error) {
 		console.error('Mediator Assignment Error:', error)
+
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.dispute.assign_mediator',
+			resourceType: 'dispute',
+			status: 'failure',
+			errorCode: error instanceof AppError ? String(error.statusCode) : '500',
+			durationMs: Date.now() - startTime,
+			metadata: { error: error instanceof Error ? error.message : String(error) },
+		})
 
 		if (error instanceof AppError) {
 			return NextResponse.json(

--- a/apps/web/app/api/escrow/dispute/resolve/route.ts
+++ b/apps/web/app/api/escrow/dispute/resolve/route.ts
@@ -2,17 +2,30 @@ import { supabase } from '@packages/lib/supabase'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { AppError } from '~/lib/error'
+import { AuditLogger } from '~/lib/services/audit-logger'
 import { createEscrowRequest } from '~/lib/stellar/utils/create-escrow'
 import type { DisputeResolutionPayload } from '~/lib/types/escrow/escrow-payload.types'
+import { generateUniqueId } from '~/lib/utils/id'
 import { validateDisputeResolution } from '~/lib/validators/dispute'
 
 export async function POST(req: NextRequest) {
+	const auditLogger = new AuditLogger()
+	const correlationId = generateUniqueId('audit-')
+	const startTime = Date.now()
+
 	try {
 		// 1. Parse and validate the dispute resolution data
 		const resolutionData = await req.json()
 		const validationResult = validateDisputeResolution(resolutionData)
 
 		if (!validationResult.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.dispute.resolve',
+				resourceType: 'dispute',
+				status: 'validation_error',
+				durationMs: Date.now() - startTime,
+			})
 			return NextResponse.json(
 				{
 					error: 'Invalid dispute resolution data',
@@ -77,6 +90,23 @@ export async function POST(req: NextRequest) {
 		// The client will sign the transaction and send it to the /escrow/dispute/sign endpoint
 		// to finalize the signature and update the database
 
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.dispute.resolve',
+			resourceType: 'dispute',
+			resourceId: disputeId,
+			actorId: mediatorId,
+			status: 'success',
+			durationMs: Date.now() - startTime,
+			metadata: {
+				resolution,
+				approverAmount,
+				serviceProviderAmount,
+				escrowContractAddress,
+				signer: AuditLogger.maskAddress(signer),
+			},
+		})
+
 		return NextResponse.json(
 			{
 				success: true,
@@ -103,12 +133,30 @@ export async function POST(req: NextRequest) {
 		console.error('Dispute Resolution Error:', error)
 
 		if (error instanceof AppError) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.dispute.resolve',
+				resourceType: 'dispute',
+				status: 'failure',
+				errorCode: String(error.statusCode),
+				durationMs: Date.now() - startTime,
+				metadata: { error: error.message },
+			})
 			return NextResponse.json(
 				{ error: error.message, details: error.details },
 				{ status: error.statusCode },
 			)
 		}
 
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.dispute.resolve',
+			resourceType: 'dispute',
+			status: 'failure',
+			errorCode: '500',
+			durationMs: Date.now() - startTime,
+			metadata: { error: error instanceof Error ? error.message : String(error) },
+		})
 		return NextResponse.json(
 			{
 				error: error instanceof Error ? error.message : 'Internal server error',

--- a/apps/web/app/api/escrow/dispute/route.ts
+++ b/apps/web/app/api/escrow/dispute/route.ts
@@ -2,19 +2,32 @@ import { supabase } from '@packages/lib/supabase'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { AppError } from '~/lib/error'
+import { AuditLogger } from '~/lib/services/audit-logger'
 import { createEscrowRequest } from '~/lib/stellar/utils/create-escrow'
 import type { DisputePayload } from '~/lib/types/escrow/escrow-payload.types'
 import { listDisputesQuerySchema } from '~/lib/schemas/escrow-dispute.schemas'
+import { generateUniqueId } from '~/lib/utils/id'
 import { validateDispute } from '~/lib/validators/dispute'
 import { validateRequest } from '~/lib/utils/validation'
 
 export async function POST(req: NextRequest) {
+	const auditLogger = new AuditLogger()
+	const correlationId = generateUniqueId('audit-')
+	const startTime = Date.now()
+
 	try {
 		// 1. Parse and validate the dispute data
 		const disputeData = await req.json()
 		const validationResult = validateDispute(disputeData)
 
 		if (!validationResult.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.dispute.create',
+				resourceType: 'dispute',
+				status: 'validation_error',
+				durationMs: Date.now() - startTime,
+			})
 			return NextResponse.json(
 				{
 					error: 'Invalid dispute data',
@@ -96,6 +109,17 @@ export async function POST(req: NextRequest) {
 			throw new Error('Failed to retrieve unsigned transaction XDR')
 		}
 
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.dispute.create',
+			resourceType: 'dispute',
+			resourceId: escrowId,
+			actorId: AuditLogger.maskAddress(signer),
+			status: 'success',
+			durationMs: Date.now() - startTime,
+			metadata: { milestoneId, escrowContractAddress },
+		})
+
 		// 6. Return the unsigned transaction to the client for signing
 		// The client will sign the transaction and send it to the /escrow/dispute/sign endpoint
 		// to finalize the signature and update the database
@@ -120,12 +144,30 @@ export async function POST(req: NextRequest) {
 		console.error('Dispute Filing Error:', error)
 
 		if (error instanceof AppError) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.dispute.create',
+				resourceType: 'dispute',
+				status: 'failure',
+				errorCode: String(error.statusCode),
+				durationMs: Date.now() - startTime,
+				metadata: { error: error.message },
+			})
 			return NextResponse.json(
 				{ error: error.message, details: error.details },
 				{ status: error.statusCode },
 			)
 		}
 
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.dispute.create',
+			resourceType: 'dispute',
+			status: 'failure',
+			errorCode: '500',
+			durationMs: Date.now() - startTime,
+			metadata: { error: error instanceof Error ? error.message : String(error) },
+		})
 		return NextResponse.json(
 			{
 				error: error instanceof Error ? error.message : 'Internal server error',

--- a/apps/web/app/api/escrow/dispute/sign/route.ts
+++ b/apps/web/app/api/escrow/dispute/sign/route.ts
@@ -2,17 +2,30 @@ import { supabase } from '@packages/lib/supabase'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { AppError } from '~/lib/error'
+import { AuditLogger } from '~/lib/services/audit-logger'
 import { sendTransaction } from '~/lib/stellar/utils/send-transaction'
 import type { DisputeSignPayload } from '~/lib/types/escrow/escrow-payload.types'
+import { generateUniqueId } from '~/lib/utils/id'
 import { validateDisputeSign } from '~/lib/validators/dispute'
 
 export async function POST(req: NextRequest) {
+	const auditLogger = new AuditLogger()
+	const correlationId = generateUniqueId('audit-')
+	const startTime = Date.now()
+
 	try {
 		// 1. Parse and validate the dispute sign data
 		const signData = await req.json()
 		const validationResult = validateDisputeSign(signData)
 
 		if (!validationResult.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.dispute.sign',
+				resourceType: 'dispute',
+				status: 'validation_error',
+				durationMs: Date.now() - startTime,
+			})
 			return NextResponse.json(
 				{
 					error: 'Invalid dispute sign data',
@@ -146,6 +159,22 @@ export async function POST(req: NextRequest) {
 				}
 			}
 
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.dispute.sign',
+				resourceType: 'dispute',
+				resourceId: dispute.id,
+				actorId: filerAddress ? AuditLogger.maskAddress(filerAddress) : undefined,
+				status: 'success',
+				durationMs: Date.now() - startTime,
+				metadata: {
+					type: 'file',
+					transactionHash: txResponse.txHash,
+					escrowId,
+					milestoneId,
+				},
+			})
+
 			return NextResponse.json(
 				{
 					success: true,
@@ -256,6 +285,23 @@ export async function POST(req: NextRequest) {
 				}
 			}
 
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.dispute.sign',
+				resourceType: 'dispute',
+				resourceId: disputeId,
+				actorId: mediatorId ?? undefined,
+				status: 'success',
+				durationMs: Date.now() - startTime,
+				metadata: {
+					type: 'resolve',
+					transactionHash: txResponse.txHash,
+					resolution,
+					approverAmount,
+					serviceProviderAmount,
+				},
+			})
+
 			return NextResponse.json(
 				{
 					success: true,
@@ -276,6 +322,16 @@ export async function POST(req: NextRequest) {
 		)
 	} catch (error) {
 		console.error('Dispute Sign Error:', error)
+
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.dispute.sign',
+			resourceType: 'dispute',
+			status: 'failure',
+			errorCode: error instanceof AppError ? String(error.statusCode) : '500',
+			durationMs: Date.now() - startTime,
+			metadata: { error: error instanceof Error ? error.message : String(error) },
+		})
 
 		if (error instanceof AppError) {
 			return NextResponse.json(

--- a/apps/web/app/api/escrow/fund/[transactionHash]/route.ts
+++ b/apps/web/app/api/escrow/fund/[transactionHash]/route.ts
@@ -2,18 +2,31 @@ import { supabase } from '@packages/lib/supabase'
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
 import { type NextRequest, NextResponse } from 'next/server'
 import { AppError } from '~/lib/error'
+import { AuditLogger } from '~/lib/services/audit-logger'
 import { escrowFundUpdateSchema } from '~/lib/schemas/escrow.schemas'
+import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
 
 export async function POST(
 	req: NextRequest,
 	{ params }: { params: Promise<{ transactionHash: string }> },
 ) {
+	const auditLogger = new AuditLogger()
+	const correlationId = generateUniqueId('audit-')
+	const startTime = Date.now()
+
 	try {
 		const transactionHash = (await params).transactionHash
 		const body = await req.json()
 		const validation = validateRequest(escrowFundUpdateSchema, body)
 		if (!validation.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.fund.update',
+				resourceType: 'transaction',
+				status: 'validation_error',
+				durationMs: Date.now() - startTime,
+			})
 			return validation.response
 		}
 		const { escrowId, status } = validation.data
@@ -66,6 +79,16 @@ export async function POST(
 			}
 		}
 
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.fund.update',
+			resourceType: 'transaction',
+			resourceId: transactionHash,
+			status: 'success',
+			durationMs: Date.now() - startTime,
+			metadata: { escrowId, newStatus: status },
+		})
+
 		return NextResponse.json(
 			{ message: 'Transaction updated', data },
 			{ status: 200 },
@@ -73,6 +96,15 @@ export async function POST(
 	} catch (error) {
 		if (error instanceof AppError) {
 			console.error('Escrow Fund error:', error)
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.fund.update',
+				resourceType: 'transaction',
+				status: 'failure',
+				errorCode: String(error.statusCode),
+				durationMs: Date.now() - startTime,
+				metadata: { error: error.message },
+			})
 			return NextResponse.json(
 				{
 					error: error.message,
@@ -83,6 +115,15 @@ export async function POST(
 		}
 
 		console.error('Internal server error during escrow fund:', error)
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.fund.update',
+			resourceType: 'transaction',
+			status: 'failure',
+			errorCode: '500',
+			durationMs: Date.now() - startTime,
+			metadata: { error: error instanceof Error ? error.message : String(error) },
+		})
 		return NextResponse.json(
 			{
 				error:

--- a/apps/web/app/api/escrow/fund/route.ts
+++ b/apps/web/app/api/escrow/fund/route.ts
@@ -3,17 +3,30 @@ import { Networks } from '@stellar/stellar-sdk'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { AppError } from '~/lib/error'
+import { AuditLogger } from '~/lib/services/audit-logger'
 import { createEscrowRequest } from '~/lib/stellar/utils/create-escrow'
 import { sendTransaction } from '~/lib/stellar/utils/send-transaction'
 import { signTransaction } from '~/lib/stellar/utils/sign-transaction'
 import { escrowFundSchema } from '~/lib/schemas/escrow.schemas'
+import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
 
 export async function POST(req: NextRequest) {
+	const auditLogger = new AuditLogger()
+	const correlationId = generateUniqueId('audit-')
+	const startTime = Date.now()
+
 	try {
 		const body = await req.json()
 		const validation = validateRequest(escrowFundSchema, body)
 		if (!validation.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.fund',
+				resourceType: 'transaction',
+				status: 'validation_error',
+				durationMs: Date.now() - startTime,
+			})
 			return validation.response
 		}
 		const { signer, fundParams, metadata } = validation.data
@@ -64,6 +77,22 @@ export async function POST(req: NextRequest) {
 			)
 		}
 
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.fund',
+			resourceType: 'transaction',
+			resourceId: dbResult.id,
+			actorId: fundParams.userId,
+			status: 'success',
+			durationMs: Date.now() - startTime,
+			metadata: {
+				transactionHash: txResponse.txHash,
+				amount,
+				escrowContract,
+				signer: AuditLogger.maskAddress(signer),
+			},
+		})
+
 		return NextResponse.json(
 			{
 				transactionId: dbResult.id,
@@ -76,6 +105,15 @@ export async function POST(req: NextRequest) {
 		console.error('Escrow Fund Error:', error)
 
 		if (error instanceof AppError) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.fund',
+				resourceType: 'transaction',
+				status: 'failure',
+				errorCode: String(error.statusCode),
+				durationMs: Date.now() - startTime,
+				metadata: { error: error.message },
+			})
 			return NextResponse.json(
 				{ error: error.message, details: error.details },
 				{ status: error.statusCode },
@@ -83,6 +121,16 @@ export async function POST(req: NextRequest) {
 		}
 
 		console.error('Internal server error during escrow initialization:', error)
+
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.fund',
+			resourceType: 'transaction',
+			status: 'failure',
+			errorCode: '500',
+			durationMs: Date.now() - startTime,
+			metadata: { error: error instanceof Error ? error.message : String(error) },
+		})
 
 		return NextResponse.json(
 			{

--- a/apps/web/app/api/escrow/initialize/route.ts
+++ b/apps/web/app/api/escrow/initialize/route.ts
@@ -2,22 +2,35 @@ import { supabase } from '@packages/lib/supabase'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { AppError } from '~/lib/error'
+import { AuditLogger } from '~/lib/services/audit-logger'
 import { createEscrowRequest } from '~/lib/stellar/utils/create-escrow'
 import { sendTransaction } from '~/lib/stellar/utils/send-transaction'
 import { escrowInitializeSchema } from '~/lib/schemas/escrow.schemas'
+import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
 
 export async function POST(req: NextRequest) {
+	const auditLogger = new AuditLogger()
+	const correlationId = generateUniqueId('audit-')
+	const startTime = Date.now()
+
 	try {
 		const body = await req.json()
 		const validation = validateRequest(escrowInitializeSchema, body)
 		if (!validation.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.initialize',
+				resourceType: 'escrow',
+				status: 'validation_error',
+				durationMs: Date.now() - startTime,
+			})
 			return validation.response
 		}
 		const initializationData = body
 
 		/* 2. Create the escrow contract through the initialize escrow - Trustless Work API
-		- The Trustless Work API will return an unsigned transaction XDR	
+		- The Trustless Work API will return an unsigned transaction XDR
 		*/
 		const responseCreateEscrowRequest = await createEscrowRequest({
 			action: 'initiate',
@@ -65,6 +78,16 @@ export async function POST(req: NextRequest) {
 				.update({ current_state: 'INITIALIZED' })
 				.eq('id', dbResult.id)
 
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.initialize',
+				resourceType: 'escrow',
+				resourceId: dbResult.id,
+				status: 'success',
+				durationMs: Date.now() - startTime,
+				metadata: { contractAddress: response.contract_id },
+			})
+
 			return NextResponse.json(
 				{
 					escrowId: dbResult.id,
@@ -77,6 +100,15 @@ export async function POST(req: NextRequest) {
 	} catch (error) {
 		if (error instanceof AppError) {
 			console.error('Escrow initialization error:', error)
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.initialize',
+				resourceType: 'escrow',
+				status: 'failure',
+				errorCode: String(error.statusCode),
+				durationMs: Date.now() - startTime,
+				metadata: { error: error.message },
+			})
 			return NextResponse.json(
 				{
 					error: (error as AppError).message,
@@ -87,6 +119,15 @@ export async function POST(req: NextRequest) {
 		}
 
 		console.error('Internal server error during escrow initialization:', error)
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.initialize',
+			resourceType: 'escrow',
+			status: 'failure',
+			errorCode: '500',
+			durationMs: Date.now() - startTime,
+			metadata: { error: error instanceof Error ? error.message : String(error) },
+		})
 		return NextResponse.json(
 			{
 				error: 'Internal server error during escrow initialization',

--- a/apps/web/app/api/escrow/review/route.ts
+++ b/apps/web/app/api/escrow/review/route.ts
@@ -2,15 +2,28 @@ import { supabase } from '@packages/lib/supabase'
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
 import { type NextRequest, NextResponse } from 'next/server'
 import { AppError } from '~/lib/error'
+import { AuditLogger } from '~/lib/services/audit-logger'
 import { createEscrowRequest } from '~/lib/stellar/utils/create-escrow'
 import { milestoneReviewSchema } from '~/lib/schemas/escrow.schemas'
+import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
 
 export async function POST(req: NextRequest) {
+	const auditLogger = new AuditLogger()
+	const correlationId = generateUniqueId('audit-')
+	const startTime = Date.now()
+
 	try {
 		const body = await req.json()
 		const validation = validateRequest(milestoneReviewSchema, body)
 		if (!validation.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.review',
+				resourceType: 'milestone',
+				status: 'validation_error',
+				durationMs: Date.now() - startTime,
+			})
 			return validation.response
 		}
 		const {
@@ -157,6 +170,17 @@ export async function POST(req: NextRequest) {
 			}
 		}
 
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.review',
+			resourceType: 'milestone',
+			resourceId: milestoneId,
+			actorId: reviewerId,
+			status: 'success',
+			durationMs: Date.now() - startTime,
+			metadata: { reviewStatus: status, isApproved },
+		})
+
 		return NextResponse.json(
 			{
 				success: true,
@@ -173,6 +197,15 @@ export async function POST(req: NextRequest) {
 		console.error('Milestone Review Error:', error)
 
 		if (error instanceof AppError) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.review',
+				resourceType: 'milestone',
+				status: 'failure',
+				errorCode: String(error.statusCode),
+				durationMs: Date.now() - startTime,
+				metadata: { error: error.message },
+			})
 			return NextResponse.json(
 				{ error: error.message, details: error.details },
 				{ status: error.statusCode },
@@ -180,12 +213,30 @@ export async function POST(req: NextRequest) {
 		}
 
 		if (error instanceof SyntaxError && error.message.includes('JSON')) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.review',
+				resourceType: 'milestone',
+				status: 'failure',
+				errorCode: '400',
+				durationMs: Date.now() - startTime,
+				metadata: { error: 'Invalid JSON format' },
+			})
 			return NextResponse.json(
 				{ error: 'Invalid JSON format in request body' },
 				{ status: 400 },
 			)
 		}
 
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.review',
+			resourceType: 'milestone',
+			status: 'failure',
+			errorCode: '400',
+			durationMs: Date.now() - startTime,
+			metadata: { error: error instanceof Error ? error.message : String(error) },
+		})
 		return NextResponse.json(
 			{
 				error: 'An unexpected error occurred',

--- a/apps/web/app/api/escrow/sign-and-submit/route.ts
+++ b/apps/web/app/api/escrow/sign-and-submit/route.ts
@@ -3,7 +3,9 @@ import { TransactionBuilder } from '@stellar/stellar-sdk'
 import { Api, Server } from '@stellar/stellar-sdk/rpc'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
+import { AuditLogger } from '~/lib/services/audit-logger'
 import { signAndSubmitSchema } from '~/lib/schemas/escrow-sign.schemas'
+import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
 
 /**
@@ -13,11 +15,24 @@ import { validateRequest } from '~/lib/utils/validation'
  * and submits it to the network
  */
 export async function POST(req: NextRequest) {
+	const auditLogger = new AuditLogger()
+	const correlationId = generateUniqueId('audit-')
+	const startTime = Date.now()
+
 	try {
 		const appConfig = appEnvConfig('web')
 		const body = await req.json()
 		const validation = validateRequest(signAndSubmitSchema, body)
-		if (!validation.success) return validation.response
+		if (!validation.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.sign_and_submit',
+				resourceType: 'escrow',
+				status: 'validation_error',
+				durationMs: Date.now() - startTime,
+			})
+			return validation.response
+		}
 		const { unsignedTransactionXDR, userDevice } = validation.data
 
 		// Parse the unsigned transaction
@@ -90,6 +105,15 @@ export async function POST(req: NextRequest) {
 
 		const authOptions = await authOptionsResponse.json()
 
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.sign_and_submit',
+			resourceType: 'escrow',
+			actorId: userDevice.address ? AuditLogger.maskAddress(userDevice.address) : undefined,
+			status: 'success',
+			durationMs: Date.now() - startTime,
+		})
+
 		// Return auth options to client for WebAuthn signing
 		return NextResponse.json({
 			authOptions,
@@ -99,6 +123,15 @@ export async function POST(req: NextRequest) {
 		})
 	} catch (error) {
 		console.error('Error in sign-and-submit:', error)
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.sign_and_submit',
+			resourceType: 'escrow',
+			status: 'failure',
+			errorCode: '500',
+			durationMs: Date.now() - startTime,
+			metadata: { error: error instanceof Error ? error.message : String(error) },
+		})
 		return NextResponse.json(
 			{
 				error: 'Failed to prepare transaction for signing',

--- a/apps/web/app/api/nfts/evolve/route.ts
+++ b/apps/web/app/api/nfts/evolve/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { AuditLogger } from '~/lib/services/audit-logger'
 import {
 	buildNFTMetadata,
 	determineTier,
@@ -13,6 +14,7 @@ import {
 	uploadMetadataToIPFS,
 } from '~/lib/services/pinata'
 import { evolveNftSchema } from '~/lib/schemas/nft.schemas'
+import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
 import { IMPACT_SCORE_WEIGHTS } from '~/lib/services/user-stats'
 import { GamificationContractService } from '~/lib/stellar/gamification-contracts'
@@ -41,6 +43,10 @@ function getRedis(): Redis | null {
  * Body: { user_id?: string }
  */
 export async function POST(req: NextRequest) {
+	const auditLogger = new AuditLogger()
+	const correlationId = generateUniqueId('audit-')
+	const startTime = Date.now()
+
 	try {
 		const session = await getServerSession(nextAuthOption)
 		if (!session?.user?.id) {
@@ -49,6 +55,14 @@ export async function POST(req: NextRequest) {
 		const body = await req.json()
 		const validation = validateRequest(evolveNftSchema, body)
 		if (!validation.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'nft.evolve',
+				resourceType: 'nft',
+				actorId: session.user.id,
+				status: 'validation_error',
+				durationMs: Date.now() - startTime,
+			})
 			return validation.response
 		}
 		const sessionUserId = session.user.id
@@ -262,6 +276,22 @@ export async function POST(req: NextRequest) {
 			to: newTier,
 		})
 
+		await auditLogger.log({
+			correlationId,
+			operation: 'nft.evolve',
+			resourceType: 'nft',
+			resourceId: existingNFT.id,
+			actorId: session.user.id,
+			status: 'success',
+			durationMs: Date.now() - startTime,
+			metadata: {
+				tokenId: existingNFT.token_id,
+				previousTier: currentTier,
+				newTier,
+				impactScore: stats.impactScore,
+			},
+		})
+
 		return NextResponse.json({
 			success: true,
 			evolved: true,
@@ -273,6 +303,15 @@ export async function POST(req: NextRequest) {
 		})
 	} catch (error) {
 		console.error('Error in POST /api/nfts/evolve:', error)
+		await auditLogger.log({
+			correlationId,
+			operation: 'nft.evolve',
+			resourceType: 'nft',
+			status: 'failure',
+			errorCode: '500',
+			durationMs: Date.now() - startTime,
+			metadata: { error: error instanceof Error ? error.message : String(error) },
+		})
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/nfts/mint/route.ts
+++ b/apps/web/app/api/nfts/mint/route.ts
@@ -5,6 +5,7 @@ import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { RateLimiter } from '~/lib/auth/rate-limiter'
 import { Logger } from '~/lib/logger'
+import { AuditLogger } from '~/lib/services/audit-logger'
 
 import {
 	buildNFTMetadata,
@@ -15,6 +16,7 @@ import {
 	uploadMetadataToIPFS,
 } from '~/lib/services/pinata'
 import { mintNftSchema } from '~/lib/schemas/nft.schemas'
+import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
 import { getUserStats } from '~/lib/services/user-stats'
 import { GamificationContractService } from '~/lib/stellar/gamification-contracts'
@@ -34,6 +36,10 @@ const logger = new Logger()
  * - If stellar_address is not provided, resolves from devices table
  */
 export async function POST(req: NextRequest) {
+	const auditLogger = new AuditLogger()
+	const correlationId = generateUniqueId('audit-')
+	const startTime = Date.now()
+
 	try {
 		const session = await getServerSession(nextAuthOption)
 		if (!session?.user?.id) {
@@ -60,6 +66,14 @@ export async function POST(req: NextRequest) {
 		const body = await req.json()
 		const validation = validateRequest(mintNftSchema, body)
 		if (!validation.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'nft.mint',
+				resourceType: 'nft',
+				actorId: session.user.id,
+				status: 'validation_error',
+				durationMs: Date.now() - startTime,
+			})
 			return validation.response
 		}
 		const sessionUserId = session.user.id
@@ -101,6 +115,16 @@ export async function POST(req: NextRequest) {
 			.single()
 
 		if (existingNFT) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'nft.mint',
+				resourceType: 'nft',
+				resourceId: existingNFT.id,
+				actorId: session.user.id,
+				status: 'success',
+				durationMs: Date.now() - startTime,
+				metadata: { alreadyExists: true, tier: existingNFT.tier },
+			})
 			return NextResponse.json({
 				success: true,
 				message: 'User already has an NFT',
@@ -244,6 +268,22 @@ export async function POST(req: NextRequest) {
 			stellarAddress,
 		})
 
+		await auditLogger.log({
+			correlationId,
+			operation: 'nft.mint',
+			resourceType: 'nft',
+			resourceId: nftRecord?.id,
+			actorId: session.user.id,
+			status: 'success',
+			durationMs: Date.now() - startTime,
+			metadata: {
+				tokenId,
+				tier,
+				stellarAddress: AuditLogger.maskAddress(stellarAddress),
+				contractAddress: nftContractAddress,
+			},
+		})
+
 		return NextResponse.json({
 			success: true,
 			tokenId,
@@ -253,6 +293,15 @@ export async function POST(req: NextRequest) {
 		})
 	} catch (error) {
 		console.error('Error in POST /api/nfts/mint:', error)
+		await auditLogger.log({
+			correlationId,
+			operation: 'nft.mint',
+			resourceType: 'nft',
+			status: 'failure',
+			errorCode: '500',
+			durationMs: Date.now() - startTime,
+			metadata: { error: error instanceof Error ? error.message : String(error) },
+		})
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/lib/services/audit-logger.ts
+++ b/apps/web/lib/services/audit-logger.ts
@@ -1,0 +1,111 @@
+import { createSupabaseBrowserClient } from '@packages/lib/supabase-client'
+
+// audit_logs table is not in generated Supabase types
+const AUDIT_LOGS_TABLE = 'audit_logs' as const
+
+export type AuditOperation =
+	| 'escrow.initialize'
+	| 'escrow.fund'
+	| 'escrow.fund.update'
+	| 'escrow.review'
+	| 'escrow.sign_and_submit'
+	| 'escrow.dispute.create'
+	| 'escrow.dispute.sign'
+	| 'escrow.dispute.resolve'
+	| 'escrow.dispute.assign_mediator'
+	| 'nft.mint'
+	| 'nft.evolve'
+
+export type AuditResourceType =
+	| 'escrow'
+	| 'transaction'
+	| 'milestone'
+	| 'dispute'
+	| 'nft'
+
+export type AuditStatus =
+	| 'initiated'
+	| 'success'
+	| 'failure'
+	| 'validation_error'
+
+export interface AuditLogEntry {
+	timestamp: string
+	correlationId: string
+	operation: AuditOperation
+	resourceType: AuditResourceType
+	resourceId?: string
+	actorId?: string
+	status: AuditStatus
+	metadata?: Record<string, unknown>
+	errorCode?: string
+	durationMs?: number
+}
+
+export interface AuditLogParams {
+	correlationId: string
+	operation: AuditOperation
+	resourceType: AuditResourceType
+	resourceId?: string
+	actorId?: string
+	status: AuditStatus
+	metadata?: Record<string, unknown>
+	errorCode?: string
+	durationMs?: number
+}
+
+export class AuditLogger {
+	/**
+	 * Masks a wallet/Stellar address for PII safety.
+	 * Shows first 4 and last 4 characters: "GABCD***WXYZ"
+	 */
+	static maskAddress(address: string): string {
+		if (!address || address.length <= 8) return address
+		return `${address.slice(0, 4)}***${address.slice(-4)}`
+	}
+
+	/**
+	 * Logs an audit event to console and persists to the audit_logs table.
+	 * Never throws — catches DB errors to avoid disrupting the main flow.
+	 */
+	async log(params: AuditLogParams): Promise<void> {
+		const entry: AuditLogEntry = {
+			timestamp: new Date().toISOString(),
+			correlationId: params.correlationId,
+			operation: params.operation,
+			resourceType: params.resourceType,
+			resourceId: params.resourceId,
+			actorId: params.actorId,
+			status: params.status,
+			metadata: params.metadata,
+			errorCode: params.errorCode,
+			durationMs: params.durationMs,
+		}
+
+		// Always emit structured JSON to console
+		console.info('[AUDIT]', JSON.stringify(entry))
+
+		try {
+			const supabase = createSupabaseBrowserClient()
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- audit_logs not in generated types
+			const { error } = await (supabase as any)
+				.from(AUDIT_LOGS_TABLE)
+				.insert({
+					correlation_id: params.correlationId,
+					operation: params.operation,
+					resource_type: params.resourceType,
+					resource_id: params.resourceId,
+					actor_id: params.actorId,
+					status: params.status,
+					metadata: params.metadata ?? {},
+					error_code: params.errorCode,
+					duration_ms: params.durationMs,
+				})
+
+			if (error) throw error
+		} catch (dbError) {
+			console.error('[AuditLogger] Failed to persist audit log:', dbError)
+			// Don't throw to avoid disrupting the main flow
+		}
+	}
+}

--- a/apps/web/test/audit-logger.integration.test.ts
+++ b/apps/web/test/audit-logger.integration.test.ts
@@ -1,0 +1,388 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+
+// ===== Environment =====
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key'
+process.env.NEXTAUTH_SECRET = 'test-secret'
+
+// ===== Mutable mock state (configured per test in beforeEach) =====
+let mockDbResults: Record<string, any> = {}
+let mockSession: any = null
+
+// ===== Module mocks =====
+
+// Audit logger's Supabase client — captures audit_logs inserts
+const mockAuditInsert = mock(() => Promise.resolve({ error: null }))
+mock.module('@packages/lib/supabase-client', () => ({
+	createSupabaseBrowserClient: () => ({
+		from: () => ({ insert: mockAuditInsert }),
+	}),
+}))
+
+// Main Supabase client — chainable mock driven by mockDbResults
+function createChain(result: any) {
+	const chain: any = {}
+	for (const m of [
+		'select', 'insert', 'update', 'delete', 'eq', 'neq',
+		'in', 'not', 'order', 'limit', 'range', 'is', 'maybeSingle',
+	]) {
+		chain[m] = () => createChain(result)
+	}
+	chain.single = () => Promise.resolve(result)
+	chain.then = (res: any, rej?: any) => Promise.resolve(result).then(res, rej)
+	chain.catch = (fn: any) => Promise.resolve(result).catch(fn)
+	return chain
+}
+
+mock.module('@packages/lib/supabase', () => ({
+	supabase: {
+		from: (table: string) =>
+			createChain(mockDbResults[table] ?? { data: null, error: null }),
+		auth: {
+			getUser: () =>
+				Promise.resolve({
+					data: { user: { id: 'test-user' } },
+					error: null,
+				}),
+		},
+	},
+}))
+
+// next/server — minimal mock providing NextResponse.json and no-op after()
+mock.module('next/server', () => ({
+	NextResponse: {
+		json: (body: any, init?: any) =>
+			new Response(JSON.stringify(body), {
+				status: init?.status ?? 200,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+	},
+	after: () => {},
+}))
+
+// next-auth
+mock.module('next-auth', () => ({
+	getServerSession: () => Promise.resolve(mockSession),
+}))
+mock.module('~/lib/auth/auth-options', () => ({ nextAuthOption: {} }))
+
+// Stellar utils
+const mockCreateEscrow = mock(() =>
+	Promise.resolve({ unsignedTransaction: 'mock-xdr' }),
+)
+const mockSendTx = mock(() =>
+	Promise.resolve({
+		txHash: 'mock-tx-hash',
+		contract_id: 'CABC123XYZ',
+		escrow: { engagementId: 'eng-1', amount: '100', platformFee: '5' },
+	}),
+)
+mock.module('~/lib/stellar/utils/create-escrow', () => ({
+	createEscrowRequest: mockCreateEscrow,
+}))
+mock.module('~/lib/stellar/utils/send-transaction', () => ({
+	sendTransaction: mockSendTx,
+}))
+
+// Validation
+const mockValidateReq = mock(() => ({ success: true, data: {} }))
+mock.module('~/lib/utils/validation', () => ({
+	validateRequest: mockValidateReq,
+}))
+
+const mockValidateMediatorAssign = mock(() => ({
+	success: true,
+	data: { disputeId: 'disp-1', mediatorId: 'med-1' },
+}))
+mock.module('~/lib/validators/dispute', () => ({
+	validateMediatorAssignment: mockValidateMediatorAssign,
+	validateDispute: mock(() => ({ success: true, data: {} })),
+	validateDisputeSign: mock(() => ({ success: true, data: {} })),
+	validateDisputeResolution: mock(() => ({ success: true, data: {} })),
+}))
+
+// Schemas (objects only, actual validation is mocked via validateRequest)
+mock.module('~/lib/schemas/escrow.schemas', () => ({
+	escrowInitializeSchema: {},
+	escrowFundSchema: {},
+	escrowFundUpdateSchema: {},
+	milestoneReviewSchema: {},
+}))
+mock.module('~/lib/schemas/escrow-sign.schemas', () => ({
+	signAndSubmitSchema: {},
+}))
+mock.module('~/lib/schemas/escrow-dispute.schemas', () => ({
+	listDisputesQuerySchema: {},
+}))
+
+// Type-only modules (ensure module resolution works at runtime)
+mock.module('@services/supabase', () => ({}))
+
+// ===== Helpers =====
+
+function createRequest(body: any) {
+	return new Request('http://localhost/api/test', {
+		method: 'POST',
+		body: JSON.stringify(body),
+		headers: { 'Content-Type': 'application/json' },
+	})
+}
+
+/** Finds the first [AUDIT] call in console.info spy and parses its JSON payload */
+function getAuditEntry(spy: ReturnType<typeof spyOn>): any | null {
+	for (const call of spy.mock.calls) {
+		if (call[0] === '[AUDIT]') {
+			return JSON.parse(call[1] as string)
+		}
+	}
+	return null
+}
+
+/** Returns the first argument passed to the audit_logs Supabase insert */
+function getAuditDbRow(): any | null {
+	if (mockAuditInsert.mock.calls.length > 0) {
+		return mockAuditInsert.mock.calls[0][0]
+	}
+	return null
+}
+
+// =============================================================================
+// POST /api/escrow/initialize
+// =============================================================================
+
+describe('Audit logging integration — POST /api/escrow/initialize', () => {
+	let infoSpy: ReturnType<typeof spyOn>
+	let errorSpy: ReturnType<typeof spyOn>
+
+	beforeEach(() => {
+		infoSpy = spyOn(console, 'info').mockImplementation(() => {})
+		errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+		mockAuditInsert.mockClear()
+		mockCreateEscrow.mockClear()
+		mockSendTx.mockClear()
+		mockValidateReq.mockImplementation(() => ({
+			success: true,
+			data: {},
+		}))
+		mockDbResults = {
+			escrow_contracts: { data: { id: 'esc-123' }, error: null },
+		}
+	})
+
+	afterEach(() => {
+		infoSpy.mockRestore()
+		errorSpy.mockRestore()
+	})
+
+	test('emits validation_error audit log on invalid input', async () => {
+		mockValidateReq.mockReturnValueOnce({
+			success: false,
+			response: new Response(JSON.stringify({ error: 'Invalid' }), {
+				status: 400,
+			}),
+		})
+
+		const { POST } = await import('../app/api/escrow/initialize/route')
+		const res = await POST(createRequest({}) as any)
+
+		expect(res.status).toBe(400)
+
+		const entry = getAuditEntry(infoSpy)
+		expect(entry).not.toBeNull()
+		expect(entry.operation).toBe('escrow.initialize')
+		expect(entry.status).toBe('validation_error')
+		expect(entry.resourceType).toBe('escrow')
+		expect(entry.correlationId).toContain('audit-')
+		expect(typeof entry.durationMs).toBe('number')
+	})
+
+	test('emits success audit log with resourceId on successful initialization', async () => {
+		const { POST } = await import('../app/api/escrow/initialize/route')
+		const res = await POST(createRequest({}) as any)
+
+		expect(res.status).toBe(201)
+
+		// Verify console audit entry
+		const entry = getAuditEntry(infoSpy)
+		expect(entry).not.toBeNull()
+		expect(entry.operation).toBe('escrow.initialize')
+		expect(entry.status).toBe('success')
+		expect(entry.resourceId).toBe('esc-123')
+		expect(entry.metadata.contractAddress).toBe('CABC123XYZ')
+
+		// Verify Supabase persistence
+		const dbRow = getAuditDbRow()
+		expect(dbRow).not.toBeNull()
+		expect(dbRow.correlation_id).toContain('audit-')
+		expect(dbRow.operation).toBe('escrow.initialize')
+		expect(dbRow.status).toBe('success')
+		expect(dbRow.resource_id).toBe('esc-123')
+	})
+
+	test('emits failure audit log when external API throws', async () => {
+		mockCreateEscrow.mockImplementationOnce(() => {
+			throw new Error('Stellar API unreachable')
+		})
+
+		const { POST } = await import('../app/api/escrow/initialize/route')
+		const res = await POST(createRequest({}) as any)
+
+		expect(res.status).toBe(500)
+
+		const entry = getAuditEntry(infoSpy)
+		expect(entry).not.toBeNull()
+		expect(entry.operation).toBe('escrow.initialize')
+		expect(entry.status).toBe('failure')
+		expect(entry.errorCode).toBe('500')
+		expect(entry.metadata.error).toContain('Stellar API unreachable')
+	})
+})
+
+// =============================================================================
+// POST /api/escrow/dispute/assign
+// =============================================================================
+
+describe('Audit logging integration — POST /api/escrow/dispute/assign', () => {
+	let infoSpy: ReturnType<typeof spyOn>
+	let errorSpy: ReturnType<typeof spyOn>
+
+	beforeEach(() => {
+		infoSpy = spyOn(console, 'info').mockImplementation(() => {})
+		errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+		mockAuditInsert.mockClear()
+		mockValidateMediatorAssign.mockImplementation(() => ({
+			success: true,
+			data: { disputeId: 'disp-1', mediatorId: 'med-1' },
+		}))
+		mockSession = { user: { id: 'admin-user-123' } }
+		mockDbResults = {
+			escrow_reviews: {
+				data: {
+					id: 'disp-1',
+					status: 'PENDING',
+					type: 'dispute',
+					escrow_id: 'esc-1',
+					milestone_id: 'mil-1',
+				},
+				error: null,
+			},
+			users: {
+				data: {
+					id: 'admin-user-123',
+					user_roles: [{ role: 'admin' }],
+				},
+				error: null,
+			},
+			notifications: { data: null, error: null },
+		}
+	})
+
+	afterEach(() => {
+		infoSpy.mockRestore()
+		errorSpy.mockRestore()
+	})
+
+	test('emits validation_error audit log with actorId on invalid data', async () => {
+		mockValidateMediatorAssign.mockReturnValueOnce({
+			success: false,
+			error: { format: () => ({ _errors: ['Invalid disputeId'] }) },
+		})
+
+		const { POST } = await import(
+			'../app/api/escrow/dispute/assign/route'
+		)
+		const res = await POST(createRequest({}) as any)
+
+		expect(res.status).toBe(400)
+
+		const entry = getAuditEntry(infoSpy)
+		expect(entry).not.toBeNull()
+		expect(entry.operation).toBe('escrow.dispute.assign_mediator')
+		expect(entry.status).toBe('validation_error')
+		expect(entry.actorId).toBe('admin-user-123')
+		expect(entry.resourceType).toBe('dispute')
+	})
+
+	test('emits success audit log with actorId, resourceId and metadata', async () => {
+		const { POST } = await import(
+			'../app/api/escrow/dispute/assign/route'
+		)
+		const res = await POST(
+			createRequest({ disputeId: 'disp-1', mediatorId: 'med-1' }) as any,
+		)
+
+		expect(res.status).toBe(200)
+
+		// Verify console audit entry
+		const entry = getAuditEntry(infoSpy)
+		expect(entry).not.toBeNull()
+		expect(entry.operation).toBe('escrow.dispute.assign_mediator')
+		expect(entry.status).toBe('success')
+		expect(entry.actorId).toBe('admin-user-123')
+		expect(entry.resourceId).toBe('disp-1')
+		expect(entry.metadata.mediatorId).toBe('med-1')
+
+		// Verify Supabase persistence
+		const dbRow = getAuditDbRow()
+		expect(dbRow).not.toBeNull()
+		expect(dbRow.operation).toBe('escrow.dispute.assign_mediator')
+		expect(dbRow.actor_id).toBe('admin-user-123')
+		expect(dbRow.resource_id).toBe('disp-1')
+	})
+})
+
+// =============================================================================
+// POST /api/escrow/fund/[transactionHash]
+// =============================================================================
+
+describe('Audit logging integration — POST /api/escrow/fund/[transactionHash]', () => {
+	let infoSpy: ReturnType<typeof spyOn>
+	let errorSpy: ReturnType<typeof spyOn>
+
+	beforeEach(() => {
+		infoSpy = spyOn(console, 'info').mockImplementation(() => {})
+		errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+		mockAuditInsert.mockClear()
+		mockValidateReq.mockImplementation(() => ({
+			success: true,
+			data: { escrowId: 'esc-1', status: 'PENDING' },
+		}))
+		mockDbResults = {
+			transactions: { data: null, error: null },
+		}
+	})
+
+	afterEach(() => {
+		infoSpy.mockRestore()
+		errorSpy.mockRestore()
+	})
+
+	test('emits success audit log with transactionHash as resourceId', async () => {
+		const { POST } = await import(
+			'../app/api/escrow/fund/[transactionHash]/route'
+		)
+		const res = await POST(createRequest({ escrowId: 'esc-1', status: 'PENDING' }) as any, {
+			params: Promise.resolve({ transactionHash: 'tx-abc123' }),
+		})
+
+		expect(res.status).toBe(200)
+
+		// Verify console audit entry
+		const entry = getAuditEntry(infoSpy)
+		expect(entry).not.toBeNull()
+		expect(entry.operation).toBe('escrow.fund.update')
+		expect(entry.status).toBe('success')
+		expect(entry.resourceType).toBe('transaction')
+		expect(entry.resourceId).toBe('tx-abc123')
+		expect(entry.metadata.escrowId).toBe('esc-1')
+		expect(entry.metadata.newStatus).toBe('PENDING')
+
+		// Verify Supabase persistence
+		const dbRow = getAuditDbRow()
+		expect(dbRow).not.toBeNull()
+		expect(dbRow.operation).toBe('escrow.fund.update')
+		expect(dbRow.resource_type).toBe('transaction')
+		expect(dbRow.resource_id).toBe('tx-abc123')
+	})
+})

--- a/apps/web/test/audit-logger.test.ts
+++ b/apps/web/test/audit-logger.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+
+const mockInsert = mock(() => Promise.resolve({ error: null }))
+const mockFrom = mock(() => ({ insert: mockInsert }))
+
+mock.module('@packages/lib/supabase-client', () => ({
+	createSupabaseBrowserClient: () => ({ from: mockFrom }),
+}))
+
+describe('AuditLogger', () => {
+	afterEach(() => {
+		mockInsert.mockClear()
+		mockFrom.mockClear()
+	})
+
+	describe('maskAddress', () => {
+		test('masks a standard Stellar address', async () => {
+			const { AuditLogger } = await import(
+				'../lib/services/audit-logger'
+			)
+			const result = AuditLogger.maskAddress(
+				'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV',
+			)
+			expect(result).toBe('GABC***STUV')
+		})
+
+		test('returns short strings unchanged', async () => {
+			const { AuditLogger } = await import(
+				'../lib/services/audit-logger'
+			)
+			expect(AuditLogger.maskAddress('GABCWXYZ')).toBe('GABCWXYZ')
+			expect(AuditLogger.maskAddress('SHORT')).toBe('SHORT')
+		})
+
+		test('returns empty string unchanged', async () => {
+			const { AuditLogger } = await import(
+				'../lib/services/audit-logger'
+			)
+			expect(AuditLogger.maskAddress('')).toBe('')
+		})
+	})
+
+	describe('log', () => {
+		test('emits structured JSON to console.info', async () => {
+			const { AuditLogger } = await import(
+				'../lib/services/audit-logger'
+			)
+			const consoleSpy = spyOn(console, 'info').mockImplementation(
+				() => {},
+			)
+
+			const logger = new AuditLogger()
+			await logger.log({
+				correlationId: 'test-123',
+				operation: 'escrow.initialize',
+				resourceType: 'escrow',
+				status: 'success',
+			})
+
+			expect(consoleSpy).toHaveBeenCalledTimes(1)
+			const args = consoleSpy.mock.calls[0]
+			expect(args[0]).toBe('[AUDIT]')
+			const parsed = JSON.parse(args[1] as string)
+			expect(parsed.correlationId).toBe('test-123')
+			expect(parsed.operation).toBe('escrow.initialize')
+			expect(parsed.resourceType).toBe('escrow')
+			expect(parsed.status).toBe('success')
+			expect(parsed.timestamp).toBeDefined()
+
+			consoleSpy.mockRestore()
+		})
+
+		test('calls Supabase insert with correct fields', async () => {
+			const { AuditLogger } = await import(
+				'../lib/services/audit-logger'
+			)
+			spyOn(console, 'info').mockImplementation(() => {})
+
+			const logger = new AuditLogger()
+			await logger.log({
+				correlationId: 'corr-456',
+				operation: 'nft.mint',
+				resourceType: 'nft',
+				resourceId: 'nft-789',
+				actorId: 'user-abc',
+				status: 'success',
+				metadata: { tier: 'gold' },
+				durationMs: 150,
+			})
+
+			expect(mockFrom).toHaveBeenCalledWith('audit_logs')
+			expect(mockInsert).toHaveBeenCalledTimes(1)
+
+			const insertArg = mockInsert.mock.calls[0][0]
+			expect(insertArg.correlation_id).toBe('corr-456')
+			expect(insertArg.operation).toBe('nft.mint')
+			expect(insertArg.resource_type).toBe('nft')
+			expect(insertArg.resource_id).toBe('nft-789')
+			expect(insertArg.actor_id).toBe('user-abc')
+			expect(insertArg.status).toBe('success')
+			expect(insertArg.metadata).toEqual({ tier: 'gold' })
+			expect(insertArg.duration_ms).toBe(150)
+
+			spyOn(console, 'info').mockRestore()
+		})
+
+		test('does not throw when Supabase insert fails', async () => {
+			const { AuditLogger } = await import(
+				'../lib/services/audit-logger'
+			)
+			spyOn(console, 'info').mockImplementation(() => {})
+			const errorSpy = spyOn(console, 'error').mockImplementation(
+				() => {},
+			)
+
+			mockInsert.mockImplementationOnce(() =>
+				Promise.resolve({ error: new Error('DB down') }),
+			)
+
+			const logger = new AuditLogger()
+			// Should not throw
+			await logger.log({
+				correlationId: 'corr-err',
+				operation: 'escrow.fund',
+				resourceType: 'transaction',
+				status: 'failure',
+			})
+
+			expect(errorSpy).toHaveBeenCalled()
+			const errorArgs = errorSpy.mock.calls[0]
+			expect(errorArgs[0]).toContain('[AuditLogger]')
+
+			spyOn(console, 'info').mockRestore()
+			errorSpy.mockRestore()
+		})
+
+		test('includes all fields in the log entry', async () => {
+			const { AuditLogger } = await import(
+				'../lib/services/audit-logger'
+			)
+			const consoleSpy = spyOn(console, 'info').mockImplementation(
+				() => {},
+			)
+
+			const logger = new AuditLogger()
+			await logger.log({
+				correlationId: 'corr-full',
+				operation: 'escrow.dispute.create',
+				resourceType: 'dispute',
+				resourceId: 'disp-1',
+				actorId: 'user-1',
+				status: 'failure',
+				metadata: { reason: 'timeout' },
+				errorCode: 'TIMEOUT',
+				durationMs: 5000,
+			})
+
+			const parsed = JSON.parse(consoleSpy.mock.calls[0][1] as string)
+			expect(parsed.correlationId).toBe('corr-full')
+			expect(parsed.operation).toBe('escrow.dispute.create')
+			expect(parsed.resourceType).toBe('dispute')
+			expect(parsed.resourceId).toBe('disp-1')
+			expect(parsed.actorId).toBe('user-1')
+			expect(parsed.status).toBe('failure')
+			expect(parsed.metadata).toEqual({ reason: 'timeout' })
+			expect(parsed.errorCode).toBe('TIMEOUT')
+			expect(parsed.durationMs).toBe(5000)
+
+			consoleSpy.mockRestore()
+		})
+	})
+})

--- a/docs/kindfi-architecture/audit-logging.md
+++ b/docs/kindfi-architecture/audit-logging.md
@@ -1,0 +1,112 @@
+# Audit Logging — Escrow and NFT Operations
+
+Structured audit logging for all mutation operations in the KindFi escrow and NFT subsystems. Logs are emitted as structured JSON to `console.info` and persisted to the `audit_logs` Supabase table.
+
+## Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | UUID | Primary key (auto-generated) |
+| `correlation_id` | TEXT | Unique ID linking related log entries |
+| `operation` | TEXT | Operation name (e.g., `escrow.initialize`) |
+| `resource_type` | TEXT | Resource category (`escrow`, `transaction`, `milestone`, `dispute`, `nft`) |
+| `resource_id` | TEXT | ID of the affected resource (nullable) |
+| `actor_id` | TEXT | User or masked address performing the action (nullable) |
+| `status` | TEXT | `initiated`, `success`, `failure`, or `validation_error` |
+| `metadata` | JSONB | Operation-specific data (amounts, hashes, tiers, etc.) |
+| `error_code` | TEXT | HTTP status code or error identifier on failure |
+| `duration_ms` | INTEGER | Wall-clock duration of the operation |
+| `created_at` | TIMESTAMPTZ | Auto-set by database |
+
+## Operations Covered
+
+| Operation | Resource Type | Route |
+|-----------|---------------|-------|
+| `escrow.initialize` | `escrow` | `POST /api/escrow/initialize` |
+| `escrow.fund` | `transaction` | `POST /api/escrow/fund` |
+| `escrow.fund.update` | `transaction` | `POST /api/escrow/fund/[transactionHash]` |
+| `escrow.review` | `milestone` | `POST /api/escrow/review` |
+| `escrow.sign_and_submit` | `escrow` | `POST /api/escrow/sign-and-submit` |
+| `escrow.dispute.create` | `dispute` | `POST /api/escrow/dispute` |
+| `escrow.dispute.sign` | `dispute` | `POST /api/escrow/dispute/sign` |
+| `escrow.dispute.resolve` | `dispute` | `POST /api/escrow/dispute/resolve` |
+| `escrow.dispute.assign_mediator` | `dispute` | `POST /api/escrow/dispute/assign` |
+| `nft.mint` | `nft` | `POST /api/nfts/mint` |
+| `nft.evolve` | `nft` | `POST /api/nfts/evolve` |
+
+## PII Handling
+
+- **Wallet/Stellar addresses** — always masked via `AuditLogger.maskAddress()` → `"GABC***WXYZ"`
+- **User UUIDs** — safe to use as `actorId` (pseudonymous, not PII)
+- **Contract addresses, transaction hashes, amounts** — safe to include in metadata
+- **IP addresses, emails, names** — never included in audit logs
+
+## Usage
+
+```typescript
+import { AuditLogger } from '~/lib/services/audit-logger'
+import { generateUniqueId } from '~/lib/utils/id'
+
+const auditLogger = new AuditLogger()
+const correlationId = generateUniqueId('audit-')
+const startTime = Date.now()
+
+// On success
+await auditLogger.log({
+  correlationId,
+  operation: 'escrow.initialize',
+  resourceType: 'escrow',
+  resourceId: escrowId,
+  actorId: userId,
+  status: 'success',
+  durationMs: Date.now() - startTime,
+  metadata: { contractAddress },
+})
+
+// On failure (in catch block)
+await auditLogger.log({
+  correlationId,
+  operation: 'escrow.initialize',
+  resourceType: 'escrow',
+  status: 'failure',
+  errorCode: '500',
+  durationMs: Date.now() - startTime,
+  metadata: { error: error.message },
+})
+```
+
+## Querying Examples
+
+```sql
+-- All failed operations in the last 24 hours
+SELECT * FROM audit_logs
+WHERE status = 'failure'
+  AND created_at > now() - interval '24 hours'
+ORDER BY created_at DESC;
+
+-- Trace all events for a specific correlation ID
+SELECT * FROM audit_logs
+WHERE correlation_id = 'audit-1711324800-a1b2c3d4'
+ORDER BY created_at;
+
+-- Escrow operations by a specific actor
+SELECT operation, status, duration_ms, created_at
+FROM audit_logs
+WHERE actor_id = 'user-uuid-here'
+  AND resource_type = 'escrow'
+ORDER BY created_at DESC;
+
+-- Average duration per operation type
+SELECT operation, AVG(duration_ms) AS avg_ms, COUNT(*) AS total
+FROM audit_logs
+WHERE status = 'success'
+GROUP BY operation
+ORDER BY avg_ms DESC;
+```
+
+## Design Decisions
+
+- **Never throws** — the `AuditLogger.log()` method catches all DB errors to avoid disrupting the main request flow
+- **Console + DB** — always emits to `console.info` (observable in logs) even if DB write fails
+- **No middleware** — each route instruments audit logging inline because metadata varies per operation
+- **Correlation IDs** — generated per-request using `generateUniqueId('audit-')`, not propagated via AsyncLocalStorage

--- a/services/supabase/migrations/20260325000000_create_audit_logs_table.sql
+++ b/services/supabase/migrations/20260325000000_create_audit_logs_table.sql
@@ -1,0 +1,36 @@
+-- Create audit_logs table for structured audit logging of escrow and NFT operations
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    correlation_id TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    resource_type TEXT NOT NULL,
+    resource_id TEXT,
+    actor_id TEXT,
+    status TEXT NOT NULL,
+    metadata JSONB DEFAULT '{}'::jsonb,
+    error_code TEXT,
+    duration_ms INTEGER,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Create indexes for common query patterns
+CREATE INDEX IF NOT EXISTS audit_logs_correlation_id_idx ON audit_logs(correlation_id);
+CREATE INDEX IF NOT EXISTS audit_logs_operation_idx ON audit_logs(operation);
+CREATE INDEX IF NOT EXISTS audit_logs_resource_type_idx ON audit_logs(resource_type);
+CREATE INDEX IF NOT EXISTS audit_logs_resource_id_idx ON audit_logs(resource_id);
+CREATE INDEX IF NOT EXISTS audit_logs_actor_id_idx ON audit_logs(actor_id);
+CREATE INDEX IF NOT EXISTS audit_logs_created_at_idx ON audit_logs(created_at);
+CREATE INDEX IF NOT EXISTS audit_logs_status_idx ON audit_logs(status);
+
+-- Enable Row Level Security
+ALTER TABLE audit_logs ENABLE ROW LEVEL SECURITY;
+
+-- Service role has full access (for server-side inserts)
+CREATE POLICY "Service role has full access to audit_logs"
+    ON audit_logs FOR ALL
+    USING (auth.role() = 'service_role');
+
+-- Authenticated users can read audit logs
+CREATE POLICY "Authenticated users can read audit_logs"
+    ON audit_logs FOR SELECT
+    USING (auth.role() = 'authenticated');


### PR DESCRIPTION
# feat(audit): add structured audit logging for escrow and NFT operations

closes: #810 

## Summary                                                                    
  - Add `AuditLogger` service with structured JSON logging to console + Supabase
   `audit_logs` table                                                           
  - Instrument all 11 escrow and NFT mutation API routes with correlation IDs,  
  PII-safe metadata, and success/failure tracking                               
  - Add DB migration with indexes and RLS policies                              

  ## Test plan                       
  - [ ] Unit tests pass: `bun test test/audit-logger.test.ts` (5 tests)
  - [ ] Integration tests pass: `bun test test/audit-logger.integration.test.ts`
   (6 tests)
  - [ ] Apply migration and verify `audit_logs` table is created
  - [ ] Trigger an escrow/NFT operation and confirm row appears in `audit_logs`
  - [ ] Verify `[AUDIT]` JSON entries appear in server console output
  - [ ] Confirm no PII (emails, IPs) leaks into logs — only masked addresses and
   UUIDs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added audit logging across escrow operations (fund, initialize, dispute management, signing) and NFT mutations (mint, evolve). Tracks operation status, correlation IDs, resource identifiers, and performance metrics.

* **Documentation**
  * Added architecture documentation covering audit logging schema, PII handling, and SQL query examples.

* **Tests**
  * Added unit and integration tests validating audit logging behavior and data persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->