### PR TITLE
Feat/api helpers standardization

### DIFF
--- a/apps/web/lib/api-helpers.ts
+++ b/apps/web/lib/api-helpers.ts
@@ -1,0 +1,162 @@
+import { createSupabaseServerClient } from '@packages/lib/supabase-server'
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { nextAuthOption } from '~/lib/auth/auth-options'
+import { Logger } from '~/lib/logger'
+
+const logger = new Logger()
+
+// ────────────────────────────────────────────────────────────────────────────
+// Shared types
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface Pagination {
+	limit: number
+	offset: number
+	total: number
+}
+
+export interface ApiSuccessResponse<T> {
+	success: true
+	data: T
+	pagination?: Pagination
+}
+
+export interface ApiErrorBody {
+	success: false
+	error: {
+		code: string
+		message: string
+		details?: unknown
+	}
+}
+
+/**
+ * Minimal authenticated user shape compatible with both Supabase and NextAuth.
+ * Route handlers can cast to the provider-specific type when additional fields
+ * are needed.
+ */
+export interface AuthUser {
+	id: string
+	email?: string | null
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// requireSession
+// ────────────────────────────────────────────────────────────────────────────
+
+type SessionSuccess = { user: AuthUser; error: null }
+type SessionFailure = { user: null; error: NextResponse<ApiErrorBody> }
+export type SessionResult = SessionSuccess | SessionFailure
+
+/**
+ * Validates the current user session and returns either the authenticated user
+ * or a pre-built 401 `NextResponse` ready to be returned from the route.
+ *
+ * Defaults to Supabase auth. Pass `provider: 'nextauth'` for NextAuth sessions.
+ *
+ * @example
+ * export async function POST(req: Request) {
+ *   const { user, error } = await requireSession()
+ *   if (error) return error
+ *   // user.id is guaranteed here
+ * }
+ */
+export async function requireSession(options?: {
+	provider?: 'supabase' | 'nextauth'
+}): Promise<SessionResult> {
+	if (options?.provider === 'nextauth') {
+		const session = await getServerSession(nextAuthOption)
+		if (!session?.user?.id) {
+			return {
+				user: null,
+				error: error('Unauthorized', { status: 401, code: 'UNAUTHORIZED' }),
+			}
+		}
+		return {
+			user: { id: session.user.id, email: session.user.email },
+			error: null,
+		}
+	}
+
+	const supabase = await createSupabaseServerClient()
+	const { data: authData } = await supabase.auth.getUser()
+	if (!authData?.user) {
+		return {
+			user: null,
+			error: error('Unauthorized', { status: 401, code: 'UNAUTHORIZED' }),
+		}
+	}
+	return { user: authData.user, error: null }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// respond
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a standardized success response.
+ *
+ * @example
+ * return respond(newComment, { status: 201 })
+ * return respond(comments, { pagination: { limit: 50, offset: 0, total: 150 } })
+ */
+export function respond<T>(
+	data: T,
+	options?: { status?: number; pagination?: Pagination },
+): NextResponse<ApiSuccessResponse<T>> {
+	const body: ApiSuccessResponse<T> = { success: true, data }
+	if (options?.pagination) body.pagination = options.pagination
+	return NextResponse.json(body, { status: options?.status ?? 200 })
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// error
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a standardized error response with optional structured logging.
+ *
+ * - `log: true` — logs the message using the shared logger
+ * - `log: someError` — logs the message along with error details / stack
+ *
+ * @example
+ * return error('Invalid payload', { status: 400, code: 'VALIDATION_ERROR' })
+ * return error('Insert failed', { status: 500, code: 'INSERT_FAILED', log: dbError })
+ */
+export function error(
+	message: string,
+	options?: {
+		status?: number
+		code?: string
+		details?: unknown
+		log?: boolean | Error | unknown
+	},
+): NextResponse<ApiErrorBody> {
+	if (options?.log) {
+		const logData: Record<string, unknown> = {
+			eventType: options.code ?? 'API_ERROR',
+			message,
+		}
+		if (options.details !== undefined) logData.details = options.details
+		if (options.log instanceof Error) {
+			logData.errorMessage = options.log.message
+			logData.stack = options.log.stack
+		} else if (typeof options.log !== 'boolean') {
+			logData.errorDetail = options.log
+		}
+		logger.error(logData as Parameters<Logger['error']>[0])
+	}
+
+	return NextResponse.json(
+		{
+			success: false as const,
+			error: {
+				code: options?.code ?? 'INTERNAL_ERROR',
+				message,
+				...(options?.details !== undefined && { details: options.details }),
+			},
+		},
+		{ status: options?.status ?? 500 },
+	)
+}

--- a/apps/web/test/api-helpers.test.ts
+++ b/apps/web/test/api-helpers.test.ts
@@ -1,0 +1,345 @@
+import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+
+// ────────────────────────────────────────────────────────────────────────────
+// Mutable mock handles — defined before mock.module so factories can close
+// over them, and resettable in beforeEach
+// ────────────────────────────────────────────────────────────────────────────
+
+const mockGetUser = mock(async () => ({
+	data: { user: { id: 'user-123', email: 'test@example.com' } },
+	error: null,
+}))
+
+const mockSupabase = { auth: { getUser: mockGetUser } }
+const mockCreateSupabaseServerClient = mock(async () => mockSupabase)
+
+const mockGetServerSession = mock(async () => null as unknown)
+
+// ────────────────────────────────────────────────────────────────────────────
+// Module mocks — must be registered before the module under test is loaded.
+// We use await import() below so these registrations are in place first.
+// ────────────────────────────────────────────────────────────────────────────
+
+mock.module('next/server', () => ({
+	NextResponse: {
+		json: (body: unknown, init?: ResponseInit) => ({
+			status: init?.status ?? 200,
+			json: async () => JSON.parse(JSON.stringify(body)),
+		}),
+	},
+}))
+
+mock.module('@packages/lib/supabase-server', () => ({
+	createSupabaseServerClient: mockCreateSupabaseServerClient,
+}))
+
+mock.module('next-auth', () => ({
+	getServerSession: mockGetServerSession,
+}))
+
+mock.module('~/lib/auth/auth-options', () => ({
+	nextAuthOption: {},
+}))
+
+// Dynamic import ensures mocks are fully registered before the module loads
+const { requireSession, respond, error } = await import('../lib/api-helpers')
+
+// ────────────────────────────────────────────────────────────────────────────
+// requireSession
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('requireSession', () => {
+	describe('supabase provider (default)', () => {
+		beforeEach(() => {
+			mockGetUser.mockReset()
+			mockGetUser.mockResolvedValue({
+				data: { user: { id: 'user-123', email: 'test@example.com' } },
+				error: null,
+			})
+		})
+
+		test('returns user when authenticated', async () => {
+			const result = await requireSession()
+
+			expect(result.error).toBeNull()
+			expect(result.user).toMatchObject({
+				id: 'user-123',
+				email: 'test@example.com',
+			})
+		})
+
+		test('returns 401 NextResponse when user is null', async () => {
+			mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null })
+
+			const result = await requireSession()
+
+			expect(result.user).toBeNull()
+			expect(result.error).not.toBeNull()
+
+			const json = await result.error!.json()
+			expect(result.error!.status).toBe(401)
+			expect(json.success).toBe(false)
+			expect(json.error.code).toBe('UNAUTHORIZED')
+			expect(json.error.message).toBe('Unauthorized')
+		})
+
+		test('returns 401 when getUser returns an auth error', async () => {
+			mockGetUser.mockResolvedValueOnce({
+				data: { user: null },
+				error: { message: 'JWT expired' },
+			})
+
+			const result = await requireSession()
+
+			expect(result.user).toBeNull()
+			const json = await result.error!.json()
+			expect(result.error!.status).toBe(401)
+			expect(json.error.code).toBe('UNAUTHORIZED')
+		})
+
+		test('explicit provider: "supabase" behaves identically to default', async () => {
+			const result = await requireSession({ provider: 'supabase' })
+
+			expect(result.error).toBeNull()
+			expect(result.user?.id).toBe('user-123')
+		})
+	})
+
+	describe('nextauth provider', () => {
+		beforeEach(() => {
+			mockGetServerSession.mockReset()
+			mockGetServerSession.mockResolvedValue(null)
+		})
+
+		test('returns user when session exists', async () => {
+			mockGetServerSession.mockResolvedValueOnce({
+				user: { id: 'nextauth-user-456', email: 'nextauth@example.com' },
+			})
+
+			const result = await requireSession({ provider: 'nextauth' })
+
+			expect(result.error).toBeNull()
+			expect(result.user).toMatchObject({
+				id: 'nextauth-user-456',
+				email: 'nextauth@example.com',
+			})
+		})
+
+		test('returns 401 when session is null', async () => {
+			mockGetServerSession.mockResolvedValueOnce(null)
+
+			const result = await requireSession({ provider: 'nextauth' })
+
+			expect(result.user).toBeNull()
+			const json = await result.error!.json()
+			expect(result.error!.status).toBe(401)
+			expect(json.success).toBe(false)
+			expect(json.error.code).toBe('UNAUTHORIZED')
+		})
+
+		test('returns 401 when session has no user id', async () => {
+			mockGetServerSession.mockResolvedValueOnce({
+				user: { email: 'no-id@example.com' },
+			})
+
+			const result = await requireSession({ provider: 'nextauth' })
+
+			expect(result.user).toBeNull()
+			expect(result.error!.status).toBe(401)
+		})
+	})
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// respond
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('respond', () => {
+	test('returns 200 with success shape by default', async () => {
+		const res = respond({ id: 'abc' })
+		const json = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(json.success).toBe(true)
+		expect(json.data).toEqual({ id: 'abc' })
+		expect(json.pagination).toBeUndefined()
+	})
+
+	test('respects custom status code', async () => {
+		const res = respond({ id: 'new' }, { status: 201 })
+
+		expect(res.status).toBe(201)
+		const json = await res.json()
+		expect(json.success).toBe(true)
+	})
+
+	test('includes pagination when provided', async () => {
+		const pagination = { limit: 10, offset: 20, total: 100 }
+		const res = respond(['item1', 'item2'], { pagination })
+		const json = await res.json()
+
+		expect(json.pagination).toEqual(pagination)
+		expect(json.data).toEqual(['item1', 'item2'])
+	})
+
+	test('handles null data', async () => {
+		const res = respond(null)
+		const json = await res.json()
+
+		expect(json.success).toBe(true)
+		expect(json.data).toBeNull()
+	})
+
+	test('handles array data', async () => {
+		const items = [{ id: 1 }, { id: 2 }]
+		const res = respond(items)
+		const json = await res.json()
+
+		expect(json.data).toEqual(items)
+	})
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// error
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('error', () => {
+	test('returns 500 with INTERNAL_ERROR code by default', async () => {
+		const res = error('Something went wrong')
+		const json = await res.json()
+
+		expect(res.status).toBe(500)
+		expect(json.success).toBe(false)
+		expect(json.error.code).toBe('INTERNAL_ERROR')
+		expect(json.error.message).toBe('Something went wrong')
+	})
+
+	test('respects custom status and code', async () => {
+		const res = error('Bad input', { status: 400, code: 'VALIDATION_ERROR' })
+		const json = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(json.error.code).toBe('VALIDATION_ERROR')
+		expect(json.error.message).toBe('Bad input')
+	})
+
+	test('includes details when provided', async () => {
+		const details = { field: 'email', issue: 'required' }
+		const res = error('Validation failed', { status: 400, details })
+		const json = await res.json()
+
+		expect(json.error.details).toEqual(details)
+	})
+
+	test('omits details key when not provided', async () => {
+		const res = error('Oops', { status: 500 })
+		const json = await res.json()
+
+		expect(Object.hasOwn(json.error, 'details')).toBe(false)
+	})
+
+	test('logs when log: true', async () => {
+		const { Logger } = await import('../lib/logger')
+		const errorSpy = spyOn(Logger.prototype, 'error').mockImplementation(
+			() => {},
+		)
+
+		error('DB failed', { status: 500, code: 'DB_ERROR', log: true })
+
+		expect(errorSpy).toHaveBeenCalledTimes(1)
+		const [logData] = errorSpy.mock.calls[0]
+		expect(logData.eventType).toBe('DB_ERROR')
+		expect(logData.message).toBe('DB failed')
+
+		errorSpy.mockRestore()
+	})
+
+	test('logs Error instance with message and stack', async () => {
+		const { Logger } = await import('../lib/logger')
+		const errorSpy = spyOn(Logger.prototype, 'error').mockImplementation(
+			() => {},
+		)
+
+		const err = new Error('Connection refused')
+		error('DB failed', { status: 500, code: 'DB_ERROR', log: err })
+
+		expect(errorSpy).toHaveBeenCalledTimes(1)
+		const [logData] = errorSpy.mock.calls[0]
+		expect(logData.errorMessage).toBe('Connection refused')
+		expect(logData.stack).toBeDefined()
+
+		errorSpy.mockRestore()
+	})
+
+	test('logs arbitrary objects (e.g. Supabase errors)', async () => {
+		const { Logger } = await import('../lib/logger')
+		const errorSpy = spyOn(Logger.prototype, 'error').mockImplementation(
+			() => {},
+		)
+
+		const supabaseError = { message: 'duplicate key', code: '23505' }
+		error('Insert failed', {
+			status: 500,
+			code: 'INSERT_FAILED',
+			log: supabaseError,
+		})
+
+		expect(errorSpy).toHaveBeenCalledTimes(1)
+		const [logData] = errorSpy.mock.calls[0]
+		expect(logData.errorDetail).toEqual(supabaseError)
+
+		errorSpy.mockRestore()
+	})
+
+	test('does not log when log is not set', async () => {
+		const { Logger } = await import('../lib/logger')
+		const errorSpy = spyOn(Logger.prototype, 'error').mockImplementation(
+			() => {},
+		)
+
+		error('Silent error', { status: 400 })
+
+		expect(errorSpy).not.toHaveBeenCalled()
+		errorSpy.mockRestore()
+	})
+
+	test('does not log when log: false', async () => {
+		const { Logger } = await import('../lib/logger')
+		const errorSpy = spyOn(Logger.prototype, 'error').mockImplementation(
+			() => {},
+		)
+
+		error('Silent error', { status: 400, log: false })
+
+		expect(errorSpy).not.toHaveBeenCalled()
+		errorSpy.mockRestore()
+	})
+
+	test('uses code as log eventType', async () => {
+		const { Logger } = await import('../lib/logger')
+		const errorSpy = spyOn(Logger.prototype, 'error').mockImplementation(
+			() => {},
+		)
+
+		error('Not found', { status: 404, code: 'NOT_FOUND', log: true })
+
+		const [logData] = errorSpy.mock.calls[0]
+		expect(logData.eventType).toBe('NOT_FOUND')
+
+		errorSpy.mockRestore()
+	})
+
+	test('falls back to API_ERROR eventType when no code given', async () => {
+		const { Logger } = await import('../lib/logger')
+		const errorSpy = spyOn(Logger.prototype, 'error').mockImplementation(
+			() => {},
+		)
+
+		error('Unknown', { log: true })
+
+		const [logData] = errorSpy.mock.calls[0]
+		expect(logData.eventType).toBe('API_ERROR')
+
+		errorSpy.mockRestore()
+	})
+})


### PR DESCRIPTION

## feat(web): standardize API route helpers — requireSession, respond, error

### Problem
60+ API routes in `apps/web/app/api` implement auth checking, success responses, and error handling with inconsistent patterns. Three distinct auth patterns (Supabase, NextAuth, simplified Supabase), three different success response shapes, and at least three error formats coexist in the codebase, increasing cognitive load and maintenance burden.

---

### Solution
Adds `apps/web/lib/api-helpers.ts` with three helper functions that serve as a single source of truth for these cross-cutting concerns.

#### `requireSession(options?)`
Validates the current session and returns a discriminated union — either the authenticated user or a pre-built `401 NextResponse` ready to return. Supports both Supabase (default) and NextAuth providers.

```ts
const { user, error: authError } = await requireSession()
if (authError) return authError
// user.id guaranteed below
````

---

#### `respond(data, options?)`

Builds a consistent `{ success: true, data, pagination? }` response.

```ts
return respond(newComment, { status: 201 })
return respond(comments, {
  pagination: { limit: 50, offset: 0, total: 150 }
})
```

---

#### `error(message, options?)`

Builds a consistent `{ success: false, error: { code, message, details? } }` response with optional structured logging via the shared Logger.

```ts
return error('Invalid payload', { status: 400, code: 'VALIDATION_ERROR' })
return error('Insert failed', {
  status: 500,
  code: 'INSERT_FAILED',
  log: dbError
})
```

---

### Before / After

#### Before

```ts
const supabase = await createSupabaseServerClient()
const { data: authData } = await supabase.auth.getUser()

if (!authData?.user) {
  return NextResponse.json(
    {
      success: false,
      error: { code: 'UNAUTHORIZED', message: 'Unauthorized' }
    },
    { status: 401 }
  )
}

// ...

if (insertError) {
  console.error('Error:', insertError)
  return NextResponse.json({ error: 'Failed to create' }, { status: 500 })
}

return NextResponse.json({ success: true, data: result }, { status: 201 })
```

#### After

```ts
const { user, error: authError } = await requireSession()
if (authError) return authError

// ...

if (insertError) {
  return error('Failed to create', {
    status: 500,
    code: 'INSERT_FAILED',
    log: insertError
  })
}

return respond(result, { status: 201 })
```

---

### Testing

23 unit tests covering all three helpers, including:

* Edge cases for both auth providers
* Pagination handling
* Details omission
* All log variants (`true`, `Error`, arbitrary objects, `false`)

---

### Notes

* Existing routes are **not migrated in this PR** — adoption can be incremental per the issue guidelines.
* The `error` export name matches the issue spec; route handlers that destructure Supabase results should rename the local variable:

```ts
const { data, error: dbError } = ...
```


## Closes #804 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced standardized API response and error handling formats for consistency across endpoints
  * Added session authentication validation with flexible provider support for route handlers
  * Implemented structured error responses with detailed error codes, messages, and optional logging capabilities

* **Tests**
  * Added comprehensive test coverage for API response and authentication utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->