### PR TITLE
refactor(escrow): migrate initialize route to use API helpers

### DIFF
--- a/apps/web/app/api/escrow/initialize/route.ts
+++ b/apps/web/app/api/escrow/initialize/route.ts
@@ -1,15 +1,18 @@
 import { supabase } from '@packages/lib/supabase'
 import type { NextRequest } from 'next/server'
-import { NextResponse } from 'next/server'
+import { error, requireSession, respond } from '~/lib/api-helpers'
 import { AppError } from '~/lib/error'
+import { escrowInitializeSchema } from '~/lib/schemas/escrow.schemas'
 import { AuditLogger } from '~/lib/services/audit-logger'
 import { createEscrowRequest } from '~/lib/stellar/utils/create-escrow'
 import { sendTransaction } from '~/lib/stellar/utils/send-transaction'
-import { escrowInitializeSchema } from '~/lib/schemas/escrow.schemas'
 import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
 
 export async function POST(req: NextRequest) {
+	const { user, error: authError } = await requireSession()
+	if (authError) return authError
+
 	const auditLogger = new AuditLogger()
 	const correlationId = generateUniqueId('audit-')
 	const startTime = Date.now()
@@ -63,13 +66,12 @@ export async function POST(req: NextRequest) {
 				.single()
 
 			if (dbError) {
-				return NextResponse.json(
-					{
-						error: 'Failed to track escrow contract',
-						details: dbError,
-					},
-					{ status: 500 },
-				)
+				return error('Failed to track escrow contract', {
+					status: 500,
+					code: 'DB_INSERT_FAILED',
+					details: dbError,
+					log: dbError,
+				})
 			}
 
 			// If successful, update the state to INITIALIZED
@@ -83,12 +85,13 @@ export async function POST(req: NextRequest) {
 				operation: 'escrow.initialize',
 				resourceType: 'escrow',
 				resourceId: dbResult.id,
+				actorId: user.id,
 				status: 'success',
 				durationMs: Date.now() - startTime,
 				metadata: { contractAddress: response.contract_id },
 			})
 
-			return NextResponse.json(
+			return respond(
 				{
 					escrowId: dbResult.id,
 					contractAddress: response.contract_id,
@@ -97,28 +100,25 @@ export async function POST(req: NextRequest) {
 				{ status: 201 },
 			)
 		}
-	} catch (error) {
-		if (error instanceof AppError) {
-			console.error('Escrow initialization error:', error)
+	} catch (err) {
+		if (err instanceof AppError) {
 			await auditLogger.log({
 				correlationId,
 				operation: 'escrow.initialize',
 				resourceType: 'escrow',
 				status: 'failure',
-				errorCode: String(error.statusCode),
+				errorCode: String(err.statusCode),
 				durationMs: Date.now() - startTime,
-				metadata: { error: error.message },
+				metadata: { error: err.message },
 			})
-			return NextResponse.json(
-				{
-					error: (error as AppError).message,
-					details: (error as AppError).details,
-				},
-				{ status: (error as AppError).statusCode },
-			)
+			return error(err.message, {
+				status: err.statusCode,
+				code: 'ESCROW_INIT_ERROR',
+				details: err.details,
+				log: err,
+			})
 		}
 
-		console.error('Internal server error during escrow initialization:', error)
 		await auditLogger.log({
 			correlationId,
 			operation: 'escrow.initialize',
@@ -126,13 +126,12 @@ export async function POST(req: NextRequest) {
 			status: 'failure',
 			errorCode: '500',
 			durationMs: Date.now() - startTime,
-			metadata: { error: error instanceof Error ? error.message : String(error) },
+			metadata: { error: err instanceof Error ? err.message : String(err) },
 		})
-		return NextResponse.json(
-			{
-				error: 'Internal server error during escrow initialization',
-			},
-			{ status: 500 },
-		)
+		return error('Internal server error during escrow initialization', {
+			status: 500,
+			code: 'INTERNAL_ERROR',
+			log: err instanceof Error ? err : true,
+		})
 	}
 }

--- a/apps/web/app/api/escrow/initialize/route.ts
+++ b/apps/web/app/api/escrow/initialize/route.ts
@@ -25,6 +25,7 @@ export async function POST(req: NextRequest) {
 				correlationId,
 				operation: 'escrow.initialize',
 				resourceType: 'escrow',
+				actorId: user.id,
 				status: 'validation_error',
 				durationMs: Date.now() - startTime,
 			})
@@ -52,62 +53,87 @@ export async function POST(req: NextRequest) {
 		// 4. Send the signed transaction to the Stellar network through the send transaction - Trustless Work API
 		const response = await sendTransaction(signedTxXdr || '')
 
-		if (response) {
-			const { data: dbResult, error: dbError } = await supabase
-				.from('escrow_contracts')
-				.insert({
-					engagement_id: response.escrow.engagementId,
-					contract_id: response.contract_id,
-					amount: response.escrow.amount,
-					platform_fee: response.escrow.platformFee,
-					current_state: 'PENDING',
-				})
-				.select('id')
-				.single()
-
-			if (dbError) {
-				return error('Failed to track escrow contract', {
-					status: 500,
-					code: 'DB_INSERT_FAILED',
-					details: dbError,
-					log: dbError,
-				})
-			}
-
-			// If successful, update the state to INITIALIZED
-			await supabase
-				.from('escrow_contracts')
-				.update({ current_state: 'INITIALIZED' })
-				.eq('id', dbResult.id)
-
+		if (!response) {
 			await auditLogger.log({
 				correlationId,
 				operation: 'escrow.initialize',
 				resourceType: 'escrow',
-				resourceId: dbResult.id,
 				actorId: user.id,
-				status: 'success',
+				status: 'failure',
+				errorCode: 'TX_SEND_FAILED',
 				durationMs: Date.now() - startTime,
-				metadata: { contractAddress: response.contract_id },
 			})
-
-			return respond(
-				{
-					escrowId: dbResult.id,
-					contractAddress: response.contract_id,
-					status: 'INITIALIZED',
-				},
-				{ status: 201 },
-			)
+			return error('Failed to send escrow transaction', {
+				status: 502,
+				code: 'TX_SEND_FAILED',
+			})
 		}
+
+		const { data: dbResult, error: dbError } = await supabase
+			.from('escrow_contracts')
+			.insert({
+				engagement_id: response.escrow.engagementId,
+				contract_id: response.contract_id,
+				amount: response.escrow.amount,
+				platform_fee: response.escrow.platformFee,
+				current_state: 'PENDING',
+			})
+			.select('id')
+			.single()
+
+		if (dbError) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'escrow.initialize',
+				resourceType: 'escrow',
+				actorId: user.id,
+				status: 'failure',
+				errorCode: 'DB_INSERT_FAILED',
+				durationMs: Date.now() - startTime,
+				metadata: { error: dbError.message },
+			})
+			return error('Failed to track escrow contract', {
+				status: 500,
+				code: 'DB_INSERT_FAILED',
+				details: dbError,
+				log: dbError,
+			})
+		}
+
+		// If successful, update the state to INITIALIZED
+		await supabase
+			.from('escrow_contracts')
+			.update({ current_state: 'INITIALIZED' })
+			.eq('id', dbResult.id)
+
+		await auditLogger.log({
+			correlationId,
+			operation: 'escrow.initialize',
+			resourceType: 'escrow',
+			resourceId: dbResult.id,
+			actorId: user.id,
+			status: 'success',
+			durationMs: Date.now() - startTime,
+			metadata: { contractAddress: response.contract_id },
+		})
+
+		return respond(
+			{
+				escrowId: dbResult.id,
+				contractAddress: response.contract_id,
+				status: 'INITIALIZED',
+			},
+			{ status: 201 },
+		)
 	} catch (err) {
 		if (err instanceof AppError) {
 			await auditLogger.log({
 				correlationId,
 				operation: 'escrow.initialize',
 				resourceType: 'escrow',
+				actorId: user.id,
 				status: 'failure',
-				errorCode: String(err.statusCode),
+				errorCode: 'ESCROW_INIT_ERROR',
 				durationMs: Date.now() - startTime,
 				metadata: { error: err.message },
 			})
@@ -123,8 +149,9 @@ export async function POST(req: NextRequest) {
 			correlationId,
 			operation: 'escrow.initialize',
 			resourceType: 'escrow',
+			actorId: user.id,
 			status: 'failure',
-			errorCode: '500',
+			errorCode: 'INTERNAL_ERROR',
 			durationMs: Date.now() - startTime,
 			metadata: { error: err instanceof Error ? err.message : String(err) },
 		})


### PR DESCRIPTION
## Description

Migrates `apps/web/app/api/escrow/initialize/route.ts` to use the standardized API helpers introduced in PR #828, replacing raw `NextResponse.json()` calls and `console.error` usage with the shared utilities.

## Changes

- Added `requireSession()` call at the start of the handler to enforce authentication before any processing
- Replaced raw `NextResponse.json()` success response with `respond()` helper (consistent `{ success: true, data }` shape, HTTP 201)
- Replaced raw `NextResponse.json()` error responses with `error()` helper (consistent `{ success: false, error: { code, message, details } }` shape)
- Removed both `console.error` calls — error logging is now handled via the `log` option of the `error()` helper, which internally uses the shared `Logger` class
- Removed unused `NextResponse` import (no longer needed after migrating to helpers)
- Populated `actorId` in the success audit log entry using the authenticated `user.id` from `requireSession`

## Closes

Closes #835

## Notes

The `validateRequest` validation path still returns `validation.response` directly, which is the existing pattern used across other escrow routes and is consistent with how the validation utility works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Escrow initialization endpoint now requires user authentication

* **Bug Fixes**
  * Standardized error handling and response consistency for escrow operations
  * Enhanced audit logging to properly track user actions during escrow initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->