### PR TITLE
fix(security): prevent privilege escalation via user_id in NFT routes (#799)

### DIFF
--- a/apps/web/app/api/nfts/evolve/route.ts
+++ b/apps/web/app/api/nfts/evolve/route.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
+import { authorizeUserOverride } from '~/lib/auth/authorize-user-override'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { withRateLimit } from '~/lib/middleware/rate-limit'
 import { AuditLogger } from '~/lib/services/audit-logger'
@@ -50,30 +51,28 @@ async function evolveHandler(req: NextRequest): Promise<NextResponse> {
 			})
 			return validation.response
 		}
-		const sessionUserId = session.user.id
-		const requestedUserId = validation.data.user_id
-
-		let userId: string
-
-		if (requestedUserId && requestedUserId !== sessionUserId) {
-			const isAdmin = session.user.role === 'admin'
-
-			if (!isAdmin) {
-				return new Response(
-					JSON.stringify({
-						error:
-							'Forbidden: Only administrators can evolve NFTs for other users.',
-					}),
-					{
-						status: 403,
-						headers: { 'Content-Type': 'application/json' },
-					},
-				)
-			}
-			userId = requestedUserId
-		} else {
-			userId = sessionUserId
+		const authorization = authorizeUserOverride({
+			session,
+			requestedUserId: validation.data.user_id,
+			resource: 'evolve NFTs',
+		})
+		if (!authorization.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'nft.evolve',
+				resourceType: 'nft',
+				actorId: session.user.id,
+				status: 'failure',
+				errorCode: '403',
+				durationMs: Date.now() - startTime,
+				metadata: {
+					reason: 'forbidden_user_override',
+					requestedUserId: validation.data.user_id,
+				},
+			})
+			return authorization.response
 		}
+		const { userId } = authorization
 
 
 		// Use service role client to bypass RLS

--- a/apps/web/app/api/nfts/mint/route.ts
+++ b/apps/web/app/api/nfts/mint/route.ts
@@ -2,6 +2,7 @@ import { headers } from 'next/headers'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
+import { authorizeUserOverride } from '~/lib/auth/authorize-user-override'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { RateLimiter } from '~/lib/auth/rate-limiter'
 import { Logger } from '~/lib/logger'
@@ -76,30 +77,28 @@ export async function POST(req: NextRequest) {
 			})
 			return validation.response
 		}
-		const sessionUserId = session.user.id
-		const requestedUserId = validation.data.user_id
-
-		let userId: string
-
-		if (requestedUserId && requestedUserId !== sessionUserId) {
-			const isAdmin = session.user.role === 'admin'
-
-			if (!isAdmin) {
-				return new Response(
-					JSON.stringify({
-						error:
-							'Forbidden: You do not have permission to mint NFTs for other users.',
-					}),
-					{
-						status: 403,
-						headers: { 'Content-Type': 'application/json' },
-					},
-				)
-			}
-			userId = requestedUserId
-		} else {
-			userId = sessionUserId
+		const authorization = authorizeUserOverride({
+			session,
+			requestedUserId: validation.data.user_id,
+			resource: 'mint NFTs',
+		})
+		if (!authorization.success) {
+			await auditLogger.log({
+				correlationId,
+				operation: 'nft.mint',
+				resourceType: 'nft',
+				actorId: session.user.id,
+				status: 'failure',
+				errorCode: '403',
+				durationMs: Date.now() - startTime,
+				metadata: {
+					reason: 'forbidden_user_override',
+					requestedUserId: validation.data.user_id,
+				},
+			})
+			return authorization.response
 		}
+		const { userId } = authorization
 
 		let stellarAddress: string | null =
 			validation.data.stellar_address || null

--- a/apps/web/lib/auth/authorize-user-override.ts
+++ b/apps/web/lib/auth/authorize-user-override.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server'
+import type { Session } from 'next-auth'
+
+export type AuthorizeUserOverrideSuccess = {
+	success: true
+	userId: string
+	overridden: boolean
+}
+
+export type AuthorizeUserOverrideFailure = {
+	success: false
+	response: NextResponse
+}
+
+export type AuthorizeUserOverrideResult =
+	| AuthorizeUserOverrideSuccess
+	| AuthorizeUserOverrideFailure
+
+interface AuthorizeUserOverrideParams {
+	session: Session
+	requestedUserId?: string | null
+	resource: string
+}
+
+/**
+ * Resolves which userId an authenticated request may operate on.
+ *
+ * Defaults to the session user. A different `requestedUserId` is only honored
+ * when the session user has the `admin` role; otherwise a 403 response is
+ * returned so callers can short-circuit. This prevents privilege escalation
+ * via attacker-controlled body fields.
+ */
+export function authorizeUserOverride({
+	session,
+	requestedUserId,
+	resource,
+}: AuthorizeUserOverrideParams): AuthorizeUserOverrideResult {
+	const sessionUserId = session.user?.id
+	if (!sessionUserId) {
+		return {
+			success: false,
+			response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+		}
+	}
+
+	if (!requestedUserId || requestedUserId === sessionUserId) {
+		return { success: true, userId: sessionUserId, overridden: false }
+	}
+
+	if (session.user?.role !== 'admin') {
+		return {
+			success: false,
+			response: NextResponse.json(
+				{
+					error: `Forbidden: Only administrators can ${resource} for other users.`,
+				},
+				{ status: 403 },
+			),
+		}
+	}
+
+	return { success: true, userId: requestedUserId, overridden: true }
+}


### PR DESCRIPTION
## Summary
- Centralizes the `user_id` override authorization in a new `authorizeUserOverride` helper at `apps/web/lib/auth/authorize-user-override.ts`, used by both `/api/nfts/evolve` and `/api/nfts/mint`.
- Non-admin sessions can no longer use a body-supplied `user_id` to operate on another user's NFT — the request defaults to `session.user.id` and admin overrides are the only path to a different `userId`.
- Forbidden override attempts now return a consistent `NextResponse.json` 403 (replacing the inline `new Response(JSON.stringify(...))`) and are recorded via `AuditLogger` so privilege escalation attempts are observable.

## Closes
Closes #799

## Changes
- `apps/web/lib/auth/authorize-user-override.ts` (new): typed helper that resolves the effective `userId` from the session vs. an optional override, returning either `{ success: true, userId, overridden }` or `{ success: false, response }`.
- `apps/web/app/api/nfts/evolve/route.ts`: replaces the inline RBAC check with `authorizeUserOverride`, audit-logs forbidden attempts (`reason: 'forbidden_user_override'`).
- `apps/web/app/api/nfts/mint/route.ts`: same refactor + audit log.

## Security rationale
Before: each route duplicated `if (requestedUserId !== sessionUserId) { isAdmin ? allow : 403 }`. The pattern was correct after PR #814 but had two issues:
1. The 403 used `new Response(JSON.stringify(...))` which is inconsistent with the rest of the route and bypasses `NextResponse.json` typing.
2. Forbidden attempts weren't audit-logged, so privilege escalation attempts were invisible to operators.

Now: a single helper enforces the rule in one place and emits an audit entry on denial — easier to reuse on future NFT routes (the issue notes the same pattern may exist elsewhere).

## Test plan
- [ ] Authenticated non-admin POSTs `/api/nfts/evolve` with another user's `user_id` in body → 403 + audit entry with `reason: forbidden_user_override`.
- [ ] Authenticated non-admin POSTs `/api/nfts/evolve` without `user_id` (or with own id) → request proceeds against `session.user.id`.
- [ ] Authenticated admin POSTs `/api/nfts/evolve` with another user's `user_id` → request proceeds against the requested id.
- [ ] Same three scenarios for `/api/nfts/mint`.
- [ ] Unauthenticated POSTs to either route → 401.
- [ ] `bunx biome check apps/web/app/api/nfts/evolve/route.ts apps/web/app/api/nfts/mint/route.ts apps/web/lib/auth/authorize-user-override.ts` passes (verified locally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refactored authorization system for NFT operations (mint and evolve) to centralize admin override checks, ensuring consistent security enforcement across endpoints.
  * Enhanced audit logging now captures comprehensive details of failed authorization attempts, including specific error codes and denial reasons, improving security oversight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->