### PR TITLE
fix: remove formdata from useeffect deps

### DIFF
--- a/apps/web/components/sections/projects/manage/escrow/hooks/use-wallet-sync.ts
+++ b/apps/web/components/sections/projects/manage/escrow/hooks/use-wallet-sync.ts
@@ -55,6 +55,10 @@ export function useWalletSync({
   ]);
 
   // Sync wallet address into empty multi-release milestone receivers
+  const milestoneReceiversKey = formData.milestones
+    .map((m) => ("receiver" in m ? m.receiver : ""))
+    .join("|");
+
   useEffect(() => {
     if (!address || formData.selectedEscrowType !== "multi-release") return;
     const updated = formData.milestones.map((m) => {
@@ -65,5 +69,5 @@ export function useWalletSync({
     // Only update if something changed
     const changed = updated.some((m, i) => m !== formData.milestones[i]);
     if (changed) setField("milestones", updated);
-  }, [address, formData.selectedEscrowType, formData.milestones, setField]);
+  }, [address, formData.selectedEscrowType, milestoneReceiversKey, setField]);
 }

--- a/apps/web/components/sections/projects/manage/escrow/hooks/use-wallet-sync.ts
+++ b/apps/web/components/sections/projects/manage/escrow/hooks/use-wallet-sync.ts
@@ -1,59 +1,69 @@
-import { useEffect } from 'react'
-import { useWallet } from '~/hooks/contexts/use-stellar-wallet.context'
-import { useEscrowForm } from '../context/escrow-form-context'
+import { useEffect } from "react";
+import { useWallet } from "~/hooks/contexts/use-stellar-wallet.context";
+import { useEscrowForm } from "../context/escrow-form-context";
 
 /**
  * Syncs connected wallet address into empty role fields and milestone receivers.
  * Also syncs suggested project defaults into empty text fields.
  */
 export function useWalletSync({
-	suggestedTitle,
-	suggestedEngagementId,
-	suggestedDescription,
+  suggestedTitle,
+  suggestedEngagementId,
+  suggestedDescription,
 }: {
-	suggestedTitle: string
-	suggestedEngagementId: string
-	suggestedDescription: string
+  suggestedTitle: string;
+  suggestedEngagementId: string;
+  suggestedDescription: string;
 }) {
-	const { address } = useWallet()
-	const { formData, setField } = useEscrowForm()
+  const { address } = useWallet();
+  const { formData, setField } = useEscrowForm();
 
-	// Sync suggested values when they arrive (only if field is still empty)
-	useEffect(() => {
-		if (!formData.title.trim() && suggestedTitle)
-			setField('title', suggestedTitle)
-	}, [suggestedTitle, formData.title, setField])
+  // Sync suggested values when they arrive (only if field is still empty)
+  useEffect(() => {
+    if (!formData.title.trim() && suggestedTitle)
+      setField("title", suggestedTitle);
+  }, [suggestedTitle, formData.title, setField]);
 
-	useEffect(() => {
-		if (!formData.engagementId.trim() && suggestedEngagementId)
-			setField('engagementId', suggestedEngagementId)
-	}, [suggestedEngagementId, formData.engagementId, setField])
+  useEffect(() => {
+    if (!formData.engagementId.trim() && suggestedEngagementId)
+      setField("engagementId", suggestedEngagementId);
+  }, [suggestedEngagementId, formData.engagementId, setField]);
 
-	useEffect(() => {
-		if (!formData.description.trim() && suggestedDescription)
-			setField('description', suggestedDescription)
-	}, [suggestedDescription, formData.description, setField])
+  useEffect(() => {
+    if (!formData.description.trim() && suggestedDescription)
+      setField("description", suggestedDescription);
+  }, [suggestedDescription, formData.description, setField]);
 
-	// Sync wallet address into empty role fields
-	useEffect(() => {
-		if (!address) return
-		if (!formData.approver.trim()) setField('approver', address)
-		if (!formData.serviceProvider.trim()) setField('serviceProvider', address)
-		if (!formData.releaseSigner.trim()) setField('releaseSigner', address)
-		if (!formData.disputeResolver.trim()) setField('disputeResolver', address)
-		if (!formData.platformAddress.trim()) setField('platformAddress', address)
-		if (!formData.receiver.trim()) setField('receiver', address)
-	}, [address, formData, setField])
+  // Sync wallet address into empty role fields
+  useEffect(() => {
+    if (!address) return;
+    if (!formData.approver.trim()) setField("approver", address);
+    if (!formData.serviceProvider.trim()) setField("serviceProvider", address);
+    if (!formData.releaseSigner.trim()) setField("releaseSigner", address);
+    if (!formData.disputeResolver.trim()) setField("disputeResolver", address);
+    if (!formData.platformAddress.trim()) setField("platformAddress", address);
+    if (!formData.receiver.trim()) setField("receiver", address);
+  }, [
+    address,
+    formData.approver,
+    formData.serviceProvider,
+    formData.releaseSigner,
+    formData.disputeResolver,
+    formData.platformAddress,
+    formData.receiver,
+    setField,
+  ]);
 
-	// Sync wallet address into empty multi-release milestone receivers
-	useEffect(() => {
-		if (!address || formData.selectedEscrowType !== 'multi-release') return
-		const updated = formData.milestones.map((m) => {
-			if ('receiver' in m && !m.receiver.trim()) return { ...m, receiver: address }
-			return m
-		})
-		// Only update if something changed
-		const changed = updated.some((m, i) => m !== formData.milestones[i])
-		if (changed) setField('milestones', updated)
-	}, [address, formData.selectedEscrowType, formData.milestones, setField])
+  // Sync wallet address into empty multi-release milestone receivers
+  useEffect(() => {
+    if (!address || formData.selectedEscrowType !== "multi-release") return;
+    const updated = formData.milestones.map((m) => {
+      if ("receiver" in m && !m.receiver.trim())
+        return { ...m, receiver: address };
+      return m;
+    });
+    // Only update if something changed
+    const changed = updated.some((m, i) => m !== formData.milestones[i]);
+    if (changed) setField("milestones", updated);
+  }, [address, formData.selectedEscrowType, formData.milestones, setField]);
 }


### PR DESCRIPTION
# PR: Remove formdata from useeffect deps

## Summary

The wallet-address sync `useEffect` in `use-wallet-sync.ts` was depending on the entire
`formData` object. Because `formData` is recreated as a new object reference on every
field update, the effect re-ran on every single keystroke anywhere in the form not just
when the six wallet-related fields changed. This Pr replaces the broad `formData`
dependency with the six specific fields the effect actually reads.

## Problem

```ts
// Before — re-runs on ANY form field change
}, [address, formData, setField])
```

Every time the user typed in `title`, `description`, `engagementId`, or any other unrelated
field, React saw a new `formData` reference and fired this effect again. This caused
unnecessary re-renders and, more importantly, could silently overwrite user edits to the
wallet fields if the address was still set.

## Fix

```ts
// After — only re-runs when a wallet-related field actually changes
}, [
  address,
  formData.approver,
  formData.serviceProvider,
  formData.releaseSigner,
  formData.disputeResolver,
  formData.platformAddress,
  formData.receiver,
  setField,
])
```

The effect now triggers only when `address` or one of the six fields it reads changes.

## Files Modified

| File | Change |
|------|--------|
| `apps/web/components/sections/projects/manage/escrow/hooks/use-wallet-sync.ts` | Replace `formData` with `formData.approver`, `formData.serviceProvider`, `formData.releaseSigner`, `formData.disputeResolver`, `formData.platformAddress`, `formData.receiver` in the wallet-sync `useEffect` dependency array |


Closes #837 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized wallet-role synchronization to reduce unnecessary updates by tightening effect dependencies and only updating empty fields when appropriate.
  * Improved multi-milestone receiver sync to detect and apply only actual receiver changes, avoiding redundant writes.
  * Applied consistent code style and formatting updates for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->