### PR TITLE
fix(rate-limit): use preset.block instead of preset.window for Retry-After header

### DIFF
--- a/apps/web/lib/middleware/rate-limit.ts
+++ b/apps/web/lib/middleware/rate-limit.ts
@@ -32,7 +32,7 @@ export function withRateLimit(
 					{ error: 'Too many requests. Please try again later.' },
 					{
 						status: 429,
-						headers: { 'Retry-After': preset.window.toString() },
+						headers: { 'Retry-After': preset.block.toString() },
 					},
 				)
 			}

--- a/apps/web/test/rate-limit-middleware.test.ts
+++ b/apps/web/test/rate-limit-middleware.test.ts
@@ -148,9 +148,9 @@ describe('withRateLimit', () => {
 
 				const res = await wrapped(makeRequest())
 
-				expect((res.headers as Record<string, string>)['Retry-After']).toBe(
-					RATE_LIMIT_PRESETS[preset].block.toString(),
-				)
+				const actual = (res.headers as Record<string, string>)['Retry-After']
+				const expected = RATE_LIMIT_PRESETS[preset].block.toString()
+				expect(actual).toBe(expected, `preset "${preset}"`)
 			}
 		})
 

--- a/apps/web/test/rate-limit-middleware.test.ts
+++ b/apps/web/test/rate-limit-middleware.test.ts
@@ -136,18 +136,22 @@ describe('withRateLimit', () => {
 			expect(handler).not.toHaveBeenCalled()
 		})
 
-		test('includes Retry-After header matching the preset window', async () => {
-			const handler = makeHandler()
-			const wrapped = withRateLimit(
-				{ preset: 'strict', identifier: async () => 'user-1' },
-				handler,
-			)
+		test('includes Retry-After header matching preset.block for all presets', async () => {
+			const presets = ['strict', 'moderate', 'lenient'] as const
 
-			const res = await wrapped(makeRequest())
+			for (const preset of presets) {
+				const handler = makeHandler()
+				const wrapped = withRateLimit(
+					{ preset, identifier: async () => 'user-1' },
+					handler,
+				)
 
-			expect((res.headers as Record<string, string>)['Retry-After']).toBe(
-				RATE_LIMIT_PRESETS.strict.window.toString(),
-			)
+				const res = await wrapped(makeRequest())
+
+				expect((res.headers as Record<string, string>)['Retry-After']).toBe(
+					RATE_LIMIT_PRESETS[preset].block.toString(),
+				)
+			}
 		})
 
 		test('response body contains error message', async () => {


### PR DESCRIPTION
## Summary
- Changed Retry-After header to reflect actual block duration (`preset.block`) instead of window (`preset.window`)
- Updated test to verify Retry-After matches `preset.block` for all presets (strict, moderate, lenient)

Closes #831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved rate-limit response accuracy: The `Retry-After` header now returns the correct duration for when clients can retry requests after being rate-limited.

* **Tests**
  * Enhanced test coverage for rate-limit responses across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->