### PR TITLE
  fix: replace direct console calls with Logger to comply with no-con…

### DIFF
--- a/apps/web/app/api/nfts/mint/route.ts
+++ b/apps/web/app/api/nfts/mint/route.ts
@@ -35,6 +35,7 @@ import { validateRequest } from '~/lib/utils/validation'
  */
 async function mintHandler(req: NextRequest) {
 	const auditLogger = new AuditLogger()
+	const logger = new Logger()
 	const correlationId = generateUniqueId('audit-')
 	const startTime = Date.now()
 
@@ -166,10 +167,10 @@ async function mintHandler(req: NextRequest) {
 			imageUri = uploadResult.ipfsUrl
 			imageIpfsHash = uploadResult.ipfsHash
 		} catch (err) {
-			console.warn(
-				'[NFT Mint] Failed to upload image to Pinata, using placeholder:',
-				err,
-			)
+			logger.warn({
+				eventType: 'nft.mint.image_upload_failed',
+				error: err instanceof Error ? err.message : String(err),
+			})
 			imageUri = `https://kindfi.org/images/nft-${tier}.svg`
 		}
 
@@ -183,7 +184,10 @@ async function mintHandler(req: NextRequest) {
 			)
 			metadataIpfsHash = metaResult.ipfsHash
 		} catch (err) {
-			console.warn('[NFT Mint] Failed to upload metadata to Pinata:', err)
+			logger.warn({
+				eventType: 'nft.mint.metadata_upload_failed',
+				error: err instanceof Error ? err.message : String(err),
+			})
 		}
 
 		// Mint on-chain
@@ -200,7 +204,10 @@ async function mintHandler(req: NextRequest) {
 		})
 
 		if (!mintResult.success) {
-			console.error('[NFT Mint] On-chain mint failed:', mintResult.error)
+			logger.error({
+				eventType: 'nft.mint.onchain_failed',
+				error: mintResult.error,
+			})
 			return NextResponse.json(
 				{ error: `Failed to mint NFT on-chain: ${mintResult.error}` },
 				{ status: 500 },
@@ -225,7 +232,10 @@ async function mintHandler(req: NextRequest) {
 			.single()
 
 		if (dbError) {
-			console.error('[NFT Mint] Database insert failed:', dbError)
+			logger.error({
+				eventType: 'nft.mint.db_insert_failed',
+				error: dbError.message,
+			})
 			// The on-chain mint succeeded, so we still return success
 			return NextResponse.json({
 				success: true,
@@ -261,7 +271,10 @@ async function mintHandler(req: NextRequest) {
 			imageUri,
 		})
 	} catch (error) {
-		console.error('Error in POST /api/nfts/mint:', error)
+		logger.error({
+			eventType: 'nft.mint.unhandled_error',
+			error: error instanceof Error ? error.message : String(error),
+		})
 		await auditLogger.log({
 			correlationId,
 			operation: 'nft.mint',

--- a/apps/web/components/sections/projects/manage/escrow/hooks/use-escrow-transaction.ts
+++ b/apps/web/components/sections/projects/manage/escrow/hooks/use-escrow-transaction.ts
@@ -7,11 +7,14 @@ import type {
 } from '@trustless-work/escrow'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import { Logger } from '~/lib/logger'
 import { toast } from 'sonner'
 import { saveEscrowContractAction } from '~/app/actions/escrow/save-escrow-contract'
 import { useEscrow } from '~/hooks/contexts/use-escrow.context'
 import { useWallet } from '~/hooks/contexts/use-stellar-wallet.context'
 import type { EscrowFormData } from '../types'
+
+const logger = new Logger()
 
 interface UseEscrowTransactionParams {
 	projectId: string
@@ -73,7 +76,7 @@ export function useEscrowTransaction({
 				})
 			}
 		} catch (e) {
-			console.error(e)
+			logger.error({ eventType: 'escrow.create.error', error: e instanceof Error ? e.message : String(e) })
 			toast.error(e instanceof Error ? e.message : 'Failed to create escrow')
 		} finally {
 			setIsSubmitting(false)

--- a/apps/web/lib/services/audit-logger.ts
+++ b/apps/web/lib/services/audit-logger.ts
@@ -99,6 +99,7 @@ export class AuditLogger {
 
 			if (error) throw error
 		} catch (dbError) {
+			// eslint-disable-next-line no-console -- last-resort fallback: AuditLogger itself failed, no other logging mechanism available
 			console.error('[AuditLogger] Failed to persist audit log:', dbError)
 			// Don't throw to avoid disrupting the main flow
 		}


### PR DESCRIPTION
 ## Summary
  - `use-escrow-transaction.ts`: imported `Logger` and replaced `console.error(e)` in catch block with `logger.error({
  eventType: 'escrow.create.error', ... })`
  - `audit-logger.ts`: added `// eslint-disable-next-line no-console` with inline justification — intentional
  last-resort fallback when the AuditLogger itself fails to persist
  - `nfts/mint/route.ts`: replaced 5 direct `console.warn` / `console.error` calls with `logger.warn` / `logger.error`
  using structured `LogData` format
  - `escrow/initialize/route.ts`: no changes needed — already clean

  ## Context
  PR #826 (bundled in #828) introduced the `no-console` ESLint rule. These files were part of the same bundle but still
  used direct console calls, violating the newly added rule.

  Closes #832 