### PR TITLE
refactor: standardize logging infrastructure and unify backend 

### DIFF
--- a/apps/web/app/(auth-pages)/reset-password/page.tsx
+++ b/apps/web/app/(auth-pages)/reset-password/page.tsx
@@ -10,6 +10,7 @@ import { AuthLayout } from '~/components/shared/layout/auth/auth-layout'
 import { FormFieldGroup } from '~/components/shared/form/form-field-group'
 import { FormShell } from '~/components/shared/form/form-shell'
 import { formLayoutClasses } from '~/lib/form/form-styles'
+import { logger } from '@/lib/logger'
 
 export default function ResetPassword(props: {
 	searchParams: Promise<Message>
@@ -22,7 +23,7 @@ export default function ResetPassword(props: {
 				const result = await props.searchParams
 				setMessage(result)
 			} catch (error) {
-				console.error('Error fetching message:', error)
+				logger.error('Error fetching message:', error)
 			}
 		}
 

--- a/apps/web/app/(routes)/create-foundation/page.tsx
+++ b/apps/web/app/(routes)/create-foundation/page.tsx
@@ -5,6 +5,7 @@ import { CreateFoundationForm } from '~/components/sections/foundations/create/c
 import { UnauthorizedAccess } from '~/components/shared/unauthorized-access'
 import { CreateFoundationProvider } from '~/hooks/contexts/use-create-foundation.context'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { logger } from '@/lib/logger'
 
 export default async function CreateFoundationPage() {
 	const session = await getServerSession(nextAuthOption)
@@ -22,7 +23,7 @@ export default async function CreateFoundationPage() {
 		.single()
 
 	if (error || !profileData) {
-		console.error('Error fetching user profile:', error)
+		logger.error('Error fetching user profile:', error)
 		redirect('/sign-in')
 	}
 

--- a/apps/web/app/(routes)/create-project/page.tsx
+++ b/apps/web/app/(routes)/create-project/page.tsx
@@ -5,6 +5,7 @@ import { CreateProjectForm } from '~/components/sections/projects/create/create-
 import { UnauthorizedAccess } from '~/components/shared/unauthorized-access'
 import { CreateProjectProvider } from '~/hooks/contexts/use-create-project.context'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { logger } from '@/lib/logger'
 
 export default async function CreateProjectPage() {
 	const session = await getServerSession(nextAuthOption)
@@ -22,7 +23,7 @@ export default async function CreateProjectPage() {
 		.single()
 
 	if (error || !profileData) {
-		console.error('Error fetching user profile:', error)
+		logger.error('Error fetching user profile:', error)
 		redirect('/sign-in')
 	}
 

--- a/apps/web/app/(routes)/profile/page.tsx
+++ b/apps/web/app/(routes)/profile/page.tsx
@@ -5,6 +5,7 @@ import { getServerSession } from 'next-auth'
 import { ProfileDashboard } from '~/components/sections/profile/profile-dashboard'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { mapDiditStatusToKYC } from '~/lib/services/didit'
+import { logger } from '@/lib/logger'
 
 interface ProfilePageProps {
 	searchParams: Promise<{
@@ -79,7 +80,7 @@ export default async function ProfilePage({ searchParams }: ProfilePageProps) {
 				.select()
 
 			if (updateResult.error) {
-				console.error(' Failed to update KYC record:', updateResult.error)
+				logger.error(' Failed to update KYC record:', updateResult.error)
 			} else {
 			}
 		} else {
@@ -106,7 +107,7 @@ export default async function ProfilePage({ searchParams }: ProfilePageProps) {
 		.single()
 
 	if (error || !profileData) {
-		console.error('⚠️ ProfilePage profile fetch error:', error)
+		logger.error('⚠️ ProfilePage profile fetch error:', error)
 		redirect('/sign-in')
 	}
 

--- a/apps/web/app/(routes)/projects/[slug]/manage/highlights/page.tsx
+++ b/apps/web/app/(routes)/projects/[slug]/manage/highlights/page.tsx
@@ -25,6 +25,7 @@ import { WritingTips } from '~/components/sections/project/highlights/writing-ti
 import { useHighlightsMutation } from '~/hooks/projects/use-highlights-mutation'
 import { getProjectHighlights } from '~/lib/queries/projects/get-project-highlights'
 import { generateUniqueId } from '~/lib/utils/id'
+import { logger } from '@/lib/logger'
 
 interface Highlight {
 	id: string
@@ -113,7 +114,7 @@ export default function ProjectHighlights() {
 			})
 		} catch (error) {
 			// Error is handled by the mutation hook (toast notification)
-			console.error('Failed to save highlights:', error)
+			logger.error('Failed to save highlights:', error)
 		}
 	}
 

--- a/apps/web/app/api/auth/user/route.ts
+++ b/apps/web/app/api/auth/user/route.ts
@@ -1,5 +1,6 @@
 import { createSupabaseServerClient } from '@packages/lib/supabase-server'
 import { NextResponse } from 'next/server'
+import { logger } from '@/lib/logger'
 
 export async function GET() {
 	try {
@@ -24,7 +25,7 @@ export async function GET() {
 			.single()
 
 		if (profileError) {
-			console.error('Error fetching user profile:', profileError)
+			logger.error('Error fetching user profile:', profileError)
 			return NextResponse.json(
 				{ error: 'Error fetching user profile' },
 				{ status: 500 },
@@ -49,7 +50,7 @@ export async function GET() {
 			},
 		})
 	} catch (error) {
-		console.error('Error getting user:', error)
+		logger.error('Error getting user:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/comments/[id]/like/route.ts
+++ b/apps/web/app/api/comments/[id]/like/route.ts
@@ -1,5 +1,6 @@
 import { createSupabaseServerClient } from '@packages/lib/supabase-server'
 import { NextResponse } from 'next/server'
+import { logger } from '@/lib/logger'
 
 // POST /api/comments/[id]/like
 export async function POST(
@@ -51,13 +52,13 @@ export async function POST(
                         .single()
 
                 if (error) {
-                        console.error('Failed to update likes:', error)
+                        logger.error('Failed to update likes:', error)
                         return NextResponse.json({ error: 'Failed to update like' }, { status: 500 })
                 }
 
                 return NextResponse.json({ success: true, data })
         } catch (error) {
-                console.error('Error in like route:', error)
+                logger.error('Error in like route:', error)
                 return NextResponse.json({ error: 'Internal error' }, { status: 500 })
         }
 }

--- a/apps/web/app/api/comments/route.ts
+++ b/apps/web/app/api/comments/route.ts
@@ -7,6 +7,7 @@ import {
 	validateParentComment,
 } from './validation'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
 	try {
@@ -52,7 +53,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
 		const { data, error, count } = await query.range(offset, offset + limit - 1)
 		if (error) {
-			console.error('GET /api/comments fetch failed:', error)
+			logger.error('GET /api/comments fetch failed:', error)
 			return NextResponse.json(
 				{
 					success: false,
@@ -69,7 +70,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 		})
 	} catch (error) {
 		// Keep parity with POST logging
-		console.error('Unexpected error in GET /api/comments:', error)
+		logger.error('Unexpected error in GET /api/comments:', error)
 		return NextResponse.json(
 			{
 				success: false,
@@ -202,7 +203,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 			.single()
 
 		if (insertError) {
-			console.error('Error inserting comment:', insertError)
+			logger.error('Error inserting comment:', insertError)
 			return NextResponse.json(
 				{
 					success: false,
@@ -224,7 +225,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 			{ status: 201 },
 		)
 	} catch (error) {
-		console.error('Unexpected error in POST /api/comments:', error)
+		logger.error('Unexpected error in POST /api/comments:', error)
 		return NextResponse.json(
 			{
 				success: false,

--- a/apps/web/app/api/contributions/create/route.ts
+++ b/apps/web/app/api/contributions/create/route.ts
@@ -6,6 +6,7 @@ import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { createContributionSchema } from '~/lib/schemas/contribution.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function POST(req: NextRequest) {
 	try {
@@ -119,7 +120,7 @@ export async function POST(req: NextRequest) {
 			.single()
 
 		if (contributionError) {
-			console.error('Error creating contribution:', contributionError)
+			logger.error('Error creating contribution:', contributionError)
 			return NextResponse.json(
 				{
 					error: 'Failed to create contribution',
@@ -196,12 +197,12 @@ export async function POST(req: NextRequest) {
 					})
 				}
 			} catch (err) {
-				console.error('[Contributions] Notification error:', err)
+				logger.error('[Contributions] Notification error:', err)
 			}
 		}
 
 		notifyContribution().catch((err) => {
-			console.error('[Contributions] Unhandled notification error:', err)
+			logger.error('[Contributions] Unhandled notification error:', err)
 		})
 
 		// Trigger gamification updates (fire and forget - don't block response)
@@ -281,7 +282,7 @@ export async function POST(req: NextRequest) {
 							return response
 						})
 						.catch((error) => {
-							console.error(
+							logger.error(
 								'[Gamification] Error updating weekly streak:',
 								error,
 							)
@@ -299,7 +300,7 @@ export async function POST(req: NextRequest) {
 							return response
 						})
 						.catch((error) => {
-							console.error(
+							logger.error(
 								'[Gamification] Error updating monthly streak:',
 								error,
 							)
@@ -335,7 +336,7 @@ export async function POST(req: NextRequest) {
 						])
 
 				if (questsError) {
-					console.error('[Gamification] Error fetching quests:', questsError)
+					logger.error('[Gamification] Error fetching quests:', questsError)
 				}
 
 				if (donationQuests && donationQuests.length > 0) {
@@ -405,7 +406,7 @@ export async function POST(req: NextRequest) {
 								return response
 							})
 							.catch((error) => {
-								console.error(
+								logger.error(
 									`[Gamification] Error updating quest ${quest.quest_id}:`,
 									error,
 								)
@@ -445,11 +446,11 @@ export async function POST(req: NextRequest) {
 						)
 					}
 				} catch (nftError) {
-					console.error('[Gamification] NFT mint/evolve error:', nftError)
+					logger.error('[Gamification] NFT mint/evolve error:', nftError)
 				}
 			} catch (error) {
 				// Log but don't throw - gamification updates shouldn't block donations
-				console.error(
+				logger.error(
 					'[Gamification] Fatal error in gamification updates:',
 					error,
 				)
@@ -459,7 +460,7 @@ export async function POST(req: NextRequest) {
 
 		// Trigger gamification updates asynchronously
 		gamificationUpdates().catch((error) => {
-			console.error(
+			logger.error(
 				'[Gamification] Unhandled error in gamification updates:',
 				error,
 			)
@@ -473,7 +474,7 @@ export async function POST(req: NextRequest) {
 			{ status: 201 },
 		)
 	} catch (error) {
-		console.error('Create contribution error:', error)
+		logger.error('Create contribution error:', error)
 		return NextResponse.json(
 			{
 				error: error instanceof Error ? error.message : 'Internal server error',

--- a/apps/web/app/api/contributions/sync/route.ts
+++ b/apps/web/app/api/contributions/sync/route.ts
@@ -5,6 +5,7 @@ import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { syncContributionSchema } from '~/lib/schemas/contribution.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * Sync an existing on-chain donation to the contributions table
@@ -92,7 +93,7 @@ export async function POST(req: NextRequest) {
 			.single()
 
 		if (contributionError) {
-			console.error('Error creating contribution:', contributionError)
+			logger.error('Error creating contribution:', contributionError)
 			return NextResponse.json(
 				{
 					error: 'Failed to create contribution',
@@ -138,7 +139,7 @@ export async function POST(req: NextRequest) {
 			{ status: 201 },
 		)
 	} catch (error) {
-		console.error('Sync contribution error:', error)
+		logger.error('Sync contribution error:', error)
 		return NextResponse.json(
 			{
 				error: error instanceof Error ? error.message : 'Internal server error',

--- a/apps/web/app/api/escrow/dispute/assign/route.ts
+++ b/apps/web/app/api/escrow/dispute/assign/route.ts
@@ -9,6 +9,7 @@ import { AuditLogger } from '~/lib/services/audit-logger'
 import type { MediatorAssignmentPayload } from '~/lib/types/escrow/escrow-payload.types'
 import { generateUniqueId } from '~/lib/utils/id'
 import { validateMediatorAssignment } from '~/lib/validators/dispute'
+import { logger } from '@/lib/logger'
 
 export async function POST(req: NextRequest) {
 	const auditLogger = new AuditLogger()
@@ -106,7 +107,7 @@ export async function POST(req: NextRequest) {
 				})
 
 			if (notificationError) {
-				console.error('Failed to send notification:', notificationError)
+				logger.error('Failed to send notification:', notificationError)
 			}
 		})
 
@@ -134,7 +135,7 @@ export async function POST(req: NextRequest) {
 			{ status: 200 },
 		)
 	} catch (error) {
-		console.error('Mediator Assignment Error:', error)
+		logger.error('Mediator Assignment Error:', error)
 
 		await auditLogger.log({
 			correlationId,

--- a/apps/web/app/api/escrow/dispute/resolve/route.ts
+++ b/apps/web/app/api/escrow/dispute/resolve/route.ts
@@ -7,6 +7,7 @@ import { createEscrowRequest } from '~/lib/stellar/utils/create-escrow'
 import type { DisputeResolutionPayload } from '~/lib/types/escrow/escrow-payload.types'
 import { generateUniqueId } from '~/lib/utils/id'
 import { validateDisputeResolution } from '~/lib/validators/dispute'
+import { logger } from '@/lib/logger'
 
 export async function POST(req: NextRequest) {
 	const auditLogger = new AuditLogger()
@@ -129,7 +130,7 @@ export async function POST(req: NextRequest) {
 		// Note: Notifications will be handled by the /escrow/dispute/sign endpoint
 		// after the transaction is signed and submitted
 	} catch (error) {
-		console.error('Dispute Resolution Error:', error)
+		logger.error('Dispute Resolution Error:', error)
 
 		if (error instanceof AppError) {
 			await auditLogger.log({

--- a/apps/web/app/api/escrow/dispute/route.ts
+++ b/apps/web/app/api/escrow/dispute/route.ts
@@ -9,6 +9,7 @@ import { listDisputesQuerySchema } from '~/lib/schemas/escrow-dispute.schemas'
 import { generateUniqueId } from '~/lib/utils/id'
 import { validateDispute } from '~/lib/validators/dispute'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function POST(req: NextRequest) {
 	const auditLogger = new AuditLogger()
@@ -141,7 +142,7 @@ export async function POST(req: NextRequest) {
 		// Note: The database updates and notifications will be handled by the /escrow/dispute/sign endpoint
 		// after the transaction is signed and submitted
 	} catch (error) {
-		console.error('Dispute Filing Error:', error)
+		logger.error('Dispute Filing Error:', error)
 
 		if (error instanceof AppError) {
 			await auditLogger.log({
@@ -221,7 +222,7 @@ export async function GET(req: NextRequest) {
 			{ status: 200 },
 		)
 	} catch (error) {
-		console.error('Fetch Disputes Error:', error)
+		logger.error('Fetch Disputes Error:', error)
 
 		if (error instanceof AppError) {
 			return NextResponse.json(

--- a/apps/web/app/api/escrow/dispute/sign/route.ts
+++ b/apps/web/app/api/escrow/dispute/sign/route.ts
@@ -7,6 +7,7 @@ import { sendTransaction } from '~/lib/stellar/utils/send-transaction'
 import type { DisputeSignPayload } from '~/lib/types/escrow/escrow-payload.types'
 import { generateUniqueId } from '~/lib/utils/id'
 import { validateDisputeSign } from '~/lib/validators/dispute'
+import { logger } from '@/lib/logger'
 
 export async function POST(req: NextRequest) {
 	const auditLogger = new AuditLogger()
@@ -123,10 +124,10 @@ export async function POST(req: NextRequest) {
 			const { data: milestone, error: milestoneError } = milestoneResult
 
 			if (escrowError) {
-				console.error('Error fetching escrow contract:', escrowError)
+				logger.error('Error fetching escrow contract:', escrowError)
 			}
 			if (milestoneError) {
-				console.error('Error fetching milestone:', milestoneError)
+				logger.error('Error fetching milestone:', milestoneError)
 			}
 
 			// Create notifications for all parties involved
@@ -149,7 +150,7 @@ export async function POST(req: NextRequest) {
 					])
 
 				if (notificationError) {
-					console.error(
+					logger.error(
 						'Error creating dispute filed notifications:',
 						notificationError,
 					)
@@ -234,7 +235,7 @@ export async function POST(req: NextRequest) {
 					.eq('id', dispute.escrow_milestones.id)
 
 				if (milestoneUpdateError) {
-					console.error(
+					logger.error(
 						'Error updating milestone status:',
 						milestoneUpdateError,
 					)
@@ -251,7 +252,7 @@ export async function POST(req: NextRequest) {
 					.single()
 
 				if (escrowError) {
-					console.error('Error fetching escrow contract:', escrowError)
+					logger.error('Error fetching escrow contract:', escrowError)
 					throw new Error(
 						`Failed to fetch escrow contract: ${escrowError.message}`,
 					)
@@ -277,7 +278,7 @@ export async function POST(req: NextRequest) {
 						])
 
 					if (notificationError) {
-						console.error('Error creating notifications:', notificationError)
+						logger.error('Error creating notifications:', notificationError)
 						throw new Error(
 							`Failed to create notifications: ${notificationError.message}`,
 						)
@@ -321,7 +322,7 @@ export async function POST(req: NextRequest) {
 			{ status: 400 },
 		)
 	} catch (error) {
-		console.error('Dispute Sign Error:', error)
+		logger.error('Dispute Sign Error:', error)
 
 		await auditLogger.log({
 			correlationId,

--- a/apps/web/app/api/escrow/fund/[transactionHash]/route.ts
+++ b/apps/web/app/api/escrow/fund/[transactionHash]/route.ts
@@ -6,6 +6,7 @@ import { AuditLogger } from '~/lib/services/audit-logger'
 import { escrowFundUpdateSchema } from '~/lib/schemas/escrow.schemas'
 import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function POST(
 	req: NextRequest,
@@ -74,7 +75,7 @@ export async function POST(
 						}),
 					)
 					.catch((err) =>
-						console.error('[Escrow fund] Notification error:', err),
+						logger.error('[Escrow fund] Notification error:', err),
 					)
 			}
 		}
@@ -95,7 +96,7 @@ export async function POST(
 		)
 	} catch (error) {
 		if (error instanceof AppError) {
-			console.error('Escrow Fund error:', error)
+			logger.error('Escrow Fund error:', error)
 			await auditLogger.log({
 				correlationId,
 				operation: 'escrow.fund.update',
@@ -114,7 +115,7 @@ export async function POST(
 			)
 		}
 
-		console.error('Internal server error during escrow fund:', error)
+		logger.error('Internal server error during escrow fund:', error)
 		await auditLogger.log({
 			correlationId,
 			operation: 'escrow.fund.update',

--- a/apps/web/app/api/escrow/fund/route.ts
+++ b/apps/web/app/api/escrow/fund/route.ts
@@ -10,6 +10,7 @@ import { signTransaction } from '~/lib/stellar/utils/sign-transaction'
 import { escrowFundSchema } from '~/lib/schemas/escrow.schemas'
 import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function POST(req: NextRequest) {
 	const auditLogger = new AuditLogger()
@@ -102,7 +103,7 @@ export async function POST(req: NextRequest) {
 			{ status: 201 },
 		)
 	} catch (error) {
-		console.error('Escrow Fund Error:', error)
+		logger.error('Escrow Fund Error:', error)
 
 		if (error instanceof AppError) {
 			await auditLogger.log({
@@ -120,7 +121,7 @@ export async function POST(req: NextRequest) {
 			)
 		}
 
-		console.error('Internal server error during escrow initialization:', error)
+		logger.error('Internal server error during escrow initialization:', error)
 
 		await auditLogger.log({
 			correlationId,

--- a/apps/web/app/api/escrow/review/route.ts
+++ b/apps/web/app/api/escrow/review/route.ts
@@ -7,6 +7,7 @@ import { createEscrowRequest } from '~/lib/stellar/utils/create-escrow'
 import { milestoneReviewSchema } from '~/lib/schemas/escrow.schemas'
 import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function POST(req: NextRequest) {
 	const auditLogger = new AuditLogger()
@@ -161,7 +162,7 @@ export async function POST(req: NextRequest) {
 						}),
 					)
 					.catch((err) =>
-						console.error('[Escrow review] Notification error:', err),
+						logger.error('[Escrow review] Notification error:', err),
 					)
 			}
 		}
@@ -189,7 +190,7 @@ export async function POST(req: NextRequest) {
 			{ status: 200 },
 		)
 	} catch (error) {
-		console.error('Milestone Review Error:', error)
+		logger.error('Milestone Review Error:', error)
 
 		if (error instanceof AppError) {
 			await auditLogger.log({

--- a/apps/web/app/api/escrow/sign-and-submit/route.ts
+++ b/apps/web/app/api/escrow/sign-and-submit/route.ts
@@ -8,6 +8,7 @@ import { signAndSubmitSchema } from '~/lib/schemas/escrow-sign.schemas'
 import { isSmartAccountAddress } from '~/lib/utils/escrow/trustless-signer'
 import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/escrow/sign-and-submit
@@ -143,7 +144,7 @@ export async function POST(req: NextRequest) {
 			authEntry: authEntry.toXDR('base64'),
 		})
 	} catch (error) {
-		console.error('Error in sign-and-submit:', error)
+		logger.error('Error in sign-and-submit:', error)
 		await auditLogger.log({
 			correlationId,
 			operation: 'escrow.sign_and_submit',

--- a/apps/web/app/api/foundations/[slug]/campaigns/route.ts
+++ b/apps/web/app/api/foundations/[slug]/campaigns/route.ts
@@ -6,6 +6,7 @@ import { nextAuthOption } from '~/lib/auth/auth-options'
 import { getFoundationBySlug } from '~/lib/queries/foundations/get-foundation-by-slug'
 import { foundationCampaignsSchema } from '~/lib/schemas/foundation.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * PATCH /api/foundations/[slug]/campaigns
@@ -70,7 +71,7 @@ export async function PATCH(
 			.eq('id', projectId)
 
 		if (updateError) {
-			console.error('Error updating project:', updateError)
+			logger.error('Error updating project:', updateError)
 			return NextResponse.json(
 				{ error: 'Failed to update campaign' },
 				{ status: 500 },
@@ -79,7 +80,7 @@ export async function PATCH(
 
 		return NextResponse.json({ success: true })
 	} catch (error) {
-		console.error('Error in PATCH /api/foundations/[slug]/campaigns:', error)
+		logger.error('Error in PATCH /api/foundations/[slug]/campaigns:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/foundations/[slug]/milestones/route.ts
+++ b/apps/web/app/api/foundations/[slug]/milestones/route.ts
@@ -7,6 +7,7 @@ import {
 	foundationSlugParamSchema,
 } from '~/lib/schemas/foundation.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function POST(
 	req: Request,
@@ -64,7 +65,7 @@ export async function POST(
 			})
 
 		if (insertError) {
-			console.error('Insert milestone error:', insertError)
+			logger.error('Insert milestone error:', insertError)
 			return NextResponse.json(
 				{ error: insertError.message ?? 'Failed to add milestone' },
 				{ status: 500 },
@@ -73,7 +74,7 @@ export async function POST(
 
 		return NextResponse.json({ success: true }, { status: 201 })
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },

--- a/apps/web/app/api/foundations/[slug]/route.ts
+++ b/apps/web/app/api/foundations/[slug]/route.ts
@@ -5,6 +5,7 @@ import { nextAuthOption } from '~/lib/auth/auth-options'
 import { foundationSlugParamSchema, foundationUpdateFormSchema } from '~/lib/schemas/foundation.schemas'
 import { uploadFoundationLogo } from '~/lib/utils/project-utils'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function PATCH(
 	req: Request,
@@ -32,7 +33,7 @@ export async function PATCH(
 			.maybeSingle()
 
 		if (fetchError) {
-			console.error('Foundation fetch error:', fetchError)
+			logger.error('Foundation fetch error:', fetchError)
 			return NextResponse.json(
 				{ error: fetchError.message ?? 'Failed to load foundation' },
 				{ status: 500 },
@@ -93,7 +94,7 @@ export async function PATCH(
 			.eq('id', foundation.id)
 
 		if (updateError) {
-			console.error('Foundation update error:', updateError)
+			logger.error('Foundation update error:', updateError)
 			return NextResponse.json(
 				{ error: updateError.message ?? 'Failed to update foundation' },
 				{ status: 500 },
@@ -112,7 +113,7 @@ export async function PATCH(
 					.eq('id', foundation.id)
 
 				if (logoUpdateError) {
-					console.error('Logo update error:', logoUpdateError)
+					logger.error('Logo update error:', logoUpdateError)
 					// Do not fail the whole request; main update succeeded
 				}
 			}
@@ -120,7 +121,7 @@ export async function PATCH(
 
 		return NextResponse.json({ slug: validatedSlug }, { status: 200 })
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },

--- a/apps/web/app/api/foundations/check-slug/route.ts
+++ b/apps/web/app/api/foundations/check-slug/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { checkSlugQuerySchema } from '~/lib/schemas/foundation.schemas'
 import { validateRequest } from '~/lib/utils/validation'
 import { validateSlug } from '~/lib/validation/foundation-api'
+import { logger } from '@/lib/logger'
 
 export async function GET(req: Request) {
 	try {
@@ -31,7 +32,7 @@ export async function GET(req: Request) {
 			.maybeSingle()
 
 		if (error) {
-			console.error('Error checking slug:', error)
+			logger.error('Error checking slug:', error)
 			return NextResponse.json(
 				{ error: 'Failed to check slug' },
 				{ status: 500 },
@@ -40,7 +41,7 @@ export async function GET(req: Request) {
 
 		return NextResponse.json({ data: data || null })
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },

--- a/apps/web/app/api/foundations/create/route.ts
+++ b/apps/web/app/api/foundations/create/route.ts
@@ -6,6 +6,7 @@ import { nextAuthOption } from '~/lib/auth/auth-options'
 import { createFoundationFormSchema } from '~/lib/schemas/foundation-create.schemas'
 import { uploadFoundationLogo } from '~/lib/utils/project-utils'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function POST(req: Request) {
 	try {
@@ -24,7 +25,7 @@ export async function POST(req: Request) {
 			.single()
 
 		if (profileError || !profileData) {
-			console.error('Profile lookup error:', {
+			logger.error('Profile lookup error:', {
 				error: profileError,
 				userId,
 			})
@@ -122,7 +123,7 @@ export async function POST(req: Request) {
 			.single()
 
 		if (insertError || !foundation) {
-			console.error(insertError)
+			logger.error(insertError)
 			return NextResponse.json(
 				{ error: insertError?.message || 'Failed to create foundation' },
 				{ status: 500 },
@@ -147,7 +148,7 @@ export async function POST(req: Request) {
 					.eq('id', foundation.id)
 
 				if (updateLogoError) {
-					console.error(updateLogoError)
+					logger.error(updateLogoError)
 					return NextResponse.json(
 						{ error: updateLogoError.message },
 						{ status: 500 },
@@ -158,7 +159,7 @@ export async function POST(req: Request) {
 
 		return NextResponse.json({ slug: foundation.slug }, { status: 201 })
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },

--- a/apps/web/app/api/governance/balance/route.ts
+++ b/apps/web/app/api/governance/balance/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { logger } from '@/lib/logger'
 
 const TW_API_KEY = process.env.NEXT_PUBLIC_TRUSTLESS_WORK_API_KEY ?? ''
 const APP_ENV = process.env.NEXT_PUBLIC_APP_ENV ?? 'development'
@@ -48,7 +49,7 @@ export async function GET() {
 
 		if (!res.ok) {
 			const body = await res.text()
-			console.error('TW balance API error:', res.status, body)
+			logger.error('TW balance API error:', res.status, body)
 			throw new Error(`Trustless Work API returned ${res.status}`)
 		}
 
@@ -64,7 +65,7 @@ export async function GET() {
 			},
 		})
 	} catch (error) {
-		console.error('Error fetching community fund balance:', error)
+		logger.error('Error fetching community fund balance:', error)
 		return NextResponse.json(
 			{ error: 'Failed to fetch balance' },
 			{ status: 500 },

--- a/apps/web/app/api/governance/eligibility/route.ts
+++ b/apps/web/app/api/governance/eligibility/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import type { NftTier } from '~/lib/governance/types'
 import { getVoteWeight } from '~/lib/governance/vote-weight'
+import { logger } from '@/lib/logger'
 
 /**
  * GET /api/governance/eligibility
@@ -32,7 +33,7 @@ export async function GET() {
 			.single()
 
 		if (error && error.code !== 'PGRST116') {
-			console.error('Error fetching user NFT for eligibility:', error)
+			logger.error('Error fetching user NFT for eligibility:', error)
 		}
 
 		if (!nft) {
@@ -52,7 +53,7 @@ export async function GET() {
 			voteWeight: getVoteWeight(tier),
 		})
 	} catch (error) {
-		console.error('Error in GET /api/governance/eligibility:', error)
+		logger.error('Error in GET /api/governance/eligibility:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/governance/rounds/[id]/route.ts
+++ b/apps/web/app/api/governance/rounds/[id]/route.ts
@@ -4,6 +4,7 @@ import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { governanceRoundIdParamSchema } from '~/lib/schemas/governance.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * GET /api/governance/rounds/[id]
@@ -91,7 +92,7 @@ export async function GET(
 			},
 		})
 	} catch (error) {
-		console.error('Error in GET /api/governance/rounds/[id]:', error)
+		logger.error('Error in GET /api/governance/rounds/[id]:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/governance/rounds/route.ts
+++ b/apps/web/app/api/governance/rounds/route.ts
@@ -8,6 +8,7 @@ import {
 } from '~/lib/schemas/governance.schemas'
 import { GovernanceContractService } from '~/lib/stellar/governance-contract'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * GET /api/governance/rounds
@@ -47,7 +48,7 @@ export async function GET(req: NextRequest) {
 		const { data: rounds, error } = await query
 
 		if (error) {
-			console.error('Error fetching governance rounds:', error)
+			logger.error('Error fetching governance rounds:', error)
 			return NextResponse.json(
 				{ error: 'Failed to fetch rounds' },
 				{ status: 500 },
@@ -88,7 +89,7 @@ export async function GET(req: NextRequest) {
 
 		return NextResponse.json({ success: true, data: enrichedRounds })
 	} catch (error) {
-		console.error('Error in GET /api/governance/rounds:', error)
+		logger.error('Error in GET /api/governance/rounds:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },
@@ -151,7 +152,7 @@ export async function POST(req: NextRequest) {
 			.single()
 
 		if (roundError || !round) {
-			console.error('Error creating governance round:', roundError)
+			logger.error('Error creating governance round:', roundError)
 			return NextResponse.json(
 				{ error: 'Failed to create round' },
 				{ status: 500 },
@@ -174,7 +175,7 @@ export async function POST(req: NextRequest) {
 				)
 				.select('id, title')
 			if (optError) {
-				console.error('Error inserting options:', optError)
+				logger.error('Error inserting options:', optError)
 			} else {
 				insertedOptions.push(...(opts ?? []))
 			}
@@ -195,7 +196,7 @@ export async function POST(req: NextRequest) {
 			})
 
 			if (!roundResult.success || roundResult.roundId === undefined) {
-				console.warn('[Governance] create_round failed:', roundResult.error)
+				logger.warn('[Governance] create_round failed:', roundResult.error)
 			} else {
 				contractRoundId = roundResult.roundId
 
@@ -215,12 +216,12 @@ export async function POST(req: NextRequest) {
 							.update({ contract_option_id: optResult.optionId })
 							.eq('id', opt.id)
 					} else {
-						console.warn('[Governance] add_option failed:', optResult.error)
+						logger.warn('[Governance] add_option failed:', optResult.error)
 					}
 				}
 			}
 		} catch (err) {
-			console.error('[Governance] on-chain recording error:', err)
+			logger.error('[Governance] on-chain recording error:', err)
 		}
 
 		return NextResponse.json(
@@ -232,7 +233,7 @@ export async function POST(req: NextRequest) {
 			{ status: 201 },
 		)
 	} catch (error) {
-		console.error('Error in POST /api/governance/rounds:', error)
+		logger.error('Error in POST /api/governance/rounds:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/governance/vote/route.ts
+++ b/apps/web/app/api/governance/vote/route.ts
@@ -6,6 +6,7 @@ import type { NftTier } from '~/lib/governance/types'
 import { castVoteSchema } from '~/lib/schemas/governance.schemas'
 import { validateRequest } from '~/lib/utils/validation'
 import { getVoteWeight } from '~/lib/governance/vote-weight'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/governance/vote
@@ -125,7 +126,7 @@ export async function POST(req: NextRequest) {
 					{ status: 409 },
 				)
 			}
-			console.error('Error inserting vote:', insertError)
+			logger.error('Error inserting vote:', insertError)
 			return NextResponse.json(
 				{ error: 'Failed to record vote' },
 				{ status: 500 },
@@ -182,11 +183,11 @@ export async function POST(req: NextRequest) {
 					})
 					onChain = result.success
 					if (!result.success) {
-						console.warn('[governance/vote] on-chain record_vote failed:', result.error)
+						logger.warn('[governance/vote] on-chain record_vote failed:', result.error)
 					}
 				}
 			} catch (err) {
-				console.warn('[governance/vote] on-chain record error:', err)
+				logger.warn('[governance/vote] on-chain record error:', err)
 			}
 		}
 
@@ -201,7 +202,7 @@ export async function POST(req: NextRequest) {
 			},
 		})
 	} catch (error) {
-		console.error('Error in POST /api/governance/vote:', error)
+		logger.error('Error in POST /api/governance/vote:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/kyc/didit/callback/route.ts
+++ b/apps/web/app/api/kyc/didit/callback/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { mapDiditStatusToKYC } from '~/lib/services/didit'
+import { logger } from '@/lib/logger'
 
 interface DiditCallbackBody {
 	verificationSessionId: string
@@ -74,7 +75,7 @@ export async function POST(req: NextRequest) {
 			.limit(1)
 
 		if (findError) {
-			console.error('Error finding KYC record:', findError)
+			logger.error('Error finding KYC record:', findError)
 			return NextResponse.json(
 				{ error: 'Failed to find KYC record', details: findError.message },
 				{ status: 500 },
@@ -97,7 +98,7 @@ export async function POST(req: NextRequest) {
 				})
 
 			if (insertError) {
-				console.error('Failed to create KYC record:', insertError)
+				logger.error('Failed to create KYC record:', insertError)
 				return NextResponse.json(
 					{ error: 'Failed to create KYC record' },
 					{ status: 500 },
@@ -133,7 +134,7 @@ export async function POST(req: NextRequest) {
 			.eq('id', kycRecord.id)
 
 		if (updateError) {
-			console.error('Failed to update KYC record:', updateError)
+			logger.error('Failed to update KYC record:', updateError)
 			return NextResponse.json(
 				{ error: 'Failed to update KYC record' },
 				{ status: 500 },
@@ -146,7 +147,7 @@ export async function POST(req: NextRequest) {
 			diditStatus: status,
 		})
 	} catch (error) {
-		console.error('Error processing Didit callback:', error)
+		logger.error('Error processing Didit callback:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to process callback',

--- a/apps/web/app/api/kyc/didit/check-status/route.ts
+++ b/apps/web/app/api/kyc/didit/check-status/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import {
+import { logger } from '@/lib/logger'
 	getDiditSessionStatus,
 	mapDiditStatusToKYC,
 } from '~/lib/services/didit'
@@ -33,7 +34,7 @@ export async function POST(_req: NextRequest) {
 			.maybeSingle()
 
 		if (findError) {
-			console.error('Error finding KYC record:', findError)
+			logger.error('Error finding KYC record:', findError)
 			return NextResponse.json(
 				{ error: 'Failed to find KYC record', details: findError.message },
 				{ status: 500 },
@@ -88,7 +89,7 @@ export async function POST(_req: NextRequest) {
 			.eq('user_id', session.user.id)
 
 		if (updateError) {
-			console.error('Failed to update KYC record:', updateError)
+			logger.error('Failed to update KYC record:', updateError)
 			// Still return the status even if update fails
 		}
 
@@ -98,7 +99,7 @@ export async function POST(_req: NextRequest) {
 			diditStatus: diditStatus.status,
 		})
 	} catch (error) {
-		console.error('Error checking KYC status:', error)
+		logger.error('Error checking KYC status:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to check KYC status',

--- a/apps/web/app/api/kyc/didit/create-session/route.ts
+++ b/apps/web/app/api/kyc/didit/create-session/route.ts
@@ -8,6 +8,7 @@ import { nextAuthOption } from '~/lib/auth/auth-options'
 import { createDiditSession } from '~/lib/services/didit'
 import { createDiditSessionSchema } from '~/lib/schemas/kyc.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/kyc/didit/create-session
@@ -57,7 +58,7 @@ export async function POST(req: NextRequest) {
 			})
 
 		if (dbError) {
-			console.error('Failed to store KYC session:', dbError)
+			logger.error('Failed to store KYC session:', dbError)
 			// Don't fail the request if DB write fails, session is still created
 		}
 
@@ -67,7 +68,7 @@ export async function POST(req: NextRequest) {
 			verificationUrl: diditSession.url,
 		})
 	} catch (error) {
-		console.error('Error creating Didit session:', error)
+		logger.error('Error creating Didit session:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to create verification session',

--- a/apps/web/app/api/kyc/didit/webhook/route.ts
+++ b/apps/web/app/api/kyc/didit/webhook/route.ts
@@ -4,6 +4,7 @@ import { createSupabaseServerClient } from '@packages/lib/supabase-server'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import {
+import { logger } from '@/lib/logger'
 	mapDiditStatusToKYC,
 	verifyDiditWebhookSignatureSimple,
 	verifyDiditWebhookSignatureV2,
@@ -37,7 +38,7 @@ export async function POST(req: NextRequest) {
 		const webhookSecret = process.env.DIDIT_WEBHOOK_SECRET_KEY
 
 		if (!webhookSecret) {
-			console.error('DIDIT_WEBHOOK_SECRET_KEY is not configured')
+			logger.error('DIDIT_WEBHOOK_SECRET_KEY is not configured')
 			return NextResponse.json(
 				{ error: 'Webhook secret not configured' },
 				{ status: 500 },
@@ -97,7 +98,7 @@ export async function POST(req: NextRequest) {
 			.like('notes', `%${jsonBody.session_id}%`)
 
 		if (findError || !kycRecords || kycRecords.length === 0) {
-			console.error('KYC record not found for session:', jsonBody.session_id)
+			logger.error('KYC record not found for session:', jsonBody.session_id)
 			// Return 200 to prevent retries for sessions we don't have
 			return NextResponse.json({ received: true })
 		}
@@ -127,7 +128,7 @@ export async function POST(req: NextRequest) {
 			.eq('user_id', kycRecord.user_id)
 
 		if (updateError) {
-			console.error('Failed to update KYC record:', updateError)
+			logger.error('Failed to update KYC record:', updateError)
 			// Return 500 to trigger retry
 			return NextResponse.json(
 				{ error: 'Failed to update KYC record' },
@@ -137,7 +138,7 @@ export async function POST(req: NextRequest) {
 
 		return NextResponse.json({ received: true })
 	} catch (error) {
-		console.error('Error processing Didit webhook:', error)
+		logger.error('Error processing Didit webhook:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to process webhook',

--- a/apps/web/app/api/kyc/status/route.ts
+++ b/apps/web/app/api/kyc/status/route.ts
@@ -2,6 +2,7 @@ import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { logger } from '@/lib/logger'
 
 /**
  * GET /api/kyc/status
@@ -26,7 +27,7 @@ export async function GET() {
 			.maybeSingle()
 
 		if (error) {
-			console.error('Error fetching KYC status:', error)
+			logger.error('Error fetching KYC status:', error)
 			return NextResponse.json(
 				{ error: 'Failed to fetch KYC status', details: error.message },
 				{ status: 500 },
@@ -38,7 +39,7 @@ export async function GET() {
 			updatedAt: kycRecord?.updated_at || null,
 		})
 	} catch (error) {
-		console.error('Error in KYC status API:', error)
+		logger.error('Error in KYC status API:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to fetch KYC status',

--- a/apps/web/app/api/nfts/[address]/route.ts
+++ b/apps/web/app/api/nfts/[address]/route.ts
@@ -13,6 +13,7 @@ import { NextResponse } from 'next/server'
 import { addressParamSchema } from '~/lib/schemas/stellar.schemas'
 import { SmartWalletTransactionService } from '~/lib/stellar/smart-wallet-transactions'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * GET /api/nfts/[address]
@@ -205,7 +206,7 @@ export async function GET(
 			},
 		})
 	} catch (error) {
-		console.error('Error fetching NFTs:', error)
+		logger.error('Error fetching NFTs:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to fetch NFTs',

--- a/apps/web/app/api/nfts/evolve/route.ts
+++ b/apps/web/app/api/nfts/evolve/route.ts
@@ -19,6 +19,7 @@ import { IMPACT_SCORE_WEIGHTS } from '~/lib/services/user-stats'
 import { GamificationContractService } from '~/lib/stellar/gamification-contracts'
 import { generateUniqueId } from '~/lib/utils/id'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/nfts/evolve
@@ -139,7 +140,7 @@ async function evolveHandler(req: NextRequest): Promise<NextResponse> {
 			imageUri = uploadResult.ipfsUrl
 			imageIpfsHash = uploadResult.ipfsHash
 		} catch (err) {
-			console.warn(
+			logger.warn(
 				'[NFT Evolve] Failed to upload image, using placeholder:',
 				err,
 			)
@@ -163,7 +164,7 @@ async function evolveHandler(req: NextRequest): Promise<NextResponse> {
 			)
 			metadataIpfsHash = metaResult.ipfsHash
 		} catch (err) {
-			console.warn('[NFT Evolve] Failed to upload metadata to Pinata:', err)
+			logger.warn('[NFT Evolve] Failed to upload metadata to Pinata:', err)
 		}
 
 		// Update on-chain metadata
@@ -183,7 +184,7 @@ async function evolveHandler(req: NextRequest): Promise<NextResponse> {
 		)
 
 		if (!updateResult.success) {
-			console.error('[NFT Evolve] On-chain update failed:', updateResult.error)
+			logger.error('[NFT Evolve] On-chain update failed:', updateResult.error)
 			return NextResponse.json(
 				{ error: `Failed to update NFT on-chain: ${updateResult.error}` },
 				{ status: 500 },
@@ -205,7 +206,7 @@ async function evolveHandler(req: NextRequest): Promise<NextResponse> {
 			.single()
 
 		if (dbError) {
-			console.error('[NFT Evolve] Database update failed:', dbError)
+			logger.error('[NFT Evolve] Database update failed:', dbError)
 		}
 
 		await auditLogger.log({
@@ -234,7 +235,7 @@ async function evolveHandler(req: NextRequest): Promise<NextResponse> {
 			nft: updatedNFT || existingNFT,
 		})
 	} catch (error) {
-		console.error('Error in POST /api/nfts/evolve:', error)
+		logger.error('Error in POST /api/nfts/evolve:', error)
 		await auditLogger.log({
 			correlationId,
 			operation: 'nft.evolve',

--- a/apps/web/app/api/nfts/user/route.ts
+++ b/apps/web/app/api/nfts/user/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { getUserStats } from '~/lib/services/user-stats'
+import { logger } from '@/lib/logger'
 
 /**
  * GET /api/nfts/user
@@ -30,7 +31,7 @@ export async function GET() {
 		const { data: nft, error } = nftResult
 
 		if (error && error.code !== 'PGRST116') {
-			console.error('Error fetching user NFT:', error)
+			logger.error('Error fetching user NFT:', error)
 		}
 
 		return NextResponse.json({
@@ -38,7 +39,7 @@ export async function GET() {
 			stats,
 		})
 	} catch (error) {
-		console.error('Error in GET /api/nfts/user:', error)
+		logger.error('Error in GET /api/nfts/user:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/passkey/generate-auth-options/route.ts
+++ b/apps/web/app/api/passkey/generate-auth-options/route.ts
@@ -6,6 +6,7 @@ import { NextResponse } from 'next/server'
 import { getRpIdFromOrigin } from '@/lib/passkey/rp-id-helper'
 import { generateAuthOptionsSchema } from '~/lib/schemas/passkey.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/passkey/generate-auth-options
@@ -67,7 +68,7 @@ export async function POST(req: NextRequest) {
 
 		return NextResponse.json(options)
 	} catch (error) {
-		console.error('❌ Error generating authentication options:', error)
+		logger.error('❌ Error generating authentication options:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to generate authentication options',

--- a/apps/web/app/api/passkey/generate-registration-options/route.ts
+++ b/apps/web/app/api/passkey/generate-registration-options/route.ts
@@ -9,6 +9,7 @@ import {
 } from '@/lib/passkey/rp-id-helper'
 import { generateRegistrationOptionsSchema } from '~/lib/schemas/passkey.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/passkey/generate-registration-options
@@ -68,7 +69,7 @@ export async function POST(req: NextRequest) {
 
 		return NextResponse.json(options)
 	} catch (error) {
-		console.error('❌ Error generating registration options:', error)
+		logger.error('❌ Error generating registration options:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to generate registration options',

--- a/apps/web/app/api/passkey/verify-auth/route.ts
+++ b/apps/web/app/api/passkey/verify-auth/route.ts
@@ -13,6 +13,7 @@ import { NextResponse } from 'next/server'
 import { getRpIdFromOrigin } from '@/lib/passkey/rp-id-helper'
 import { verifyAuthSchema } from '~/lib/schemas/passkey.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/passkey/verify-auth
@@ -107,7 +108,7 @@ export async function POST(req: NextRequest) {
 			publicKey: publicKeyBase64, // Base64 encoded public key for session creation
 		})
 	} catch (error) {
-		console.error('❌ Error verifying authentication:', error)
+		logger.error('❌ Error verifying authentication:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to verify authentication',

--- a/apps/web/app/api/passkey/verify-registration/route.ts
+++ b/apps/web/app/api/passkey/verify-registration/route.ts
@@ -15,6 +15,7 @@ import { NextResponse } from 'next/server'
 import { getRpIdFromOrigin } from '@/lib/passkey/rp-id-helper'
 import { verifyRegistrationSchema } from '~/lib/schemas/passkey.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/passkey/verify-registration
@@ -85,14 +86,14 @@ export async function POST(req: NextRequest) {
 					) {
 						const errorMsg =
 							'Funding account not configured. Set STELLAR_FUNDING_SECRET_KEY environment variable.'
-						console.error('❌', errorMsg)
+						logger.error('❌', errorMsg)
 						throw new Error(errorMsg)
 					}
 
 					if (!config.stellar.factoryContractId) {
 						const errorMsg =
 							'Factory contract not configured. Set FACTORY_CONTRACT_ID environment variable.'
-						console.error('❌', errorMsg)
+						logger.error('❌', errorMsg)
 						throw new Error(errorMsg)
 					}
 
@@ -122,17 +123,17 @@ export async function POST(req: NextRequest) {
 							? deploymentError.message
 							: String(deploymentError)
 
-					console.error('❌ Smart Account deployment failed:', { error: errorMessage })
+					logger.error('❌ Smart Account deployment failed:', { error: errorMessage })
 
 					// Log detailed error for debugging
-					console.error('Smart Account deployment error details:', {
+					logger.error('Smart Account deployment error details:', {
 						fundingAccount: config.stellar.fundingAccount ? 'set' : 'missing',
 						factoryContractId: config.stellar.factoryContractId ? 'set' : 'missing',
 					})
 
 					// For now, we'll continue without Smart Account creation
 					// In production, you may want to fail the registration
-					console.warn(
+					logger.warn(
 						'⚠️ Continuing registration without Smart Account creation. ' +
 							'Check server logs for deployment errors. ' +
 							'The passkey can still be used for authentication.',
@@ -185,8 +186,8 @@ export async function POST(req: NextRequest) {
 				'Passkey registered successfully, but Smart Account creation failed. ' +
 				'Check server logs for details. The passkey can still be used for authentication.'
 			response.warning = warningMessage
-			console.warn('⚠️', warningMessage)
-			console.warn('⚠️ Configuration check:', {
+			logger.warn('⚠️', warningMessage)
+			logger.warn('⚠️ Configuration check:', {
 				hasAccountWasmHash: !!process.env.NEXT_PUBLIC_ACCOUNT_WASM_HASH,
 				hasWebAuthnVerifier:
 					!!process.env.NEXT_PUBLIC_WEBAUTHN_VERIFIER_ADDRESS,
@@ -199,7 +200,7 @@ export async function POST(req: NextRequest) {
 
 		return NextResponse.json(response)
 	} catch (error) {
-		console.error('❌ Error verifying registration:', error instanceof Error ? error.message : String(error))
+		logger.error('❌ Error verifying registration:', error instanceof Error ? error.message : String(error))
 		return NextResponse.json(
 			{
 				error: 'Failed to verify registration',

--- a/apps/web/app/api/projects/[slug]/highlights/route.ts
+++ b/apps/web/app/api/projects/[slug]/highlights/route.ts
@@ -5,6 +5,7 @@ import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { highlightsUpdateSchema } from '~/lib/schemas/project.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function POST(
 	req: Request,
@@ -87,7 +88,7 @@ export async function POST(
 			.eq('id', projectId)
 
 		if (updateError) {
-			console.error(updateError)
+			logger.error(updateError)
 			return NextResponse.json({ error: updateError.message }, { status: 500 })
 		}
 
@@ -95,7 +96,7 @@ export async function POST(
 			message: 'Highlights saved successfully',
 		})
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },

--- a/apps/web/app/api/projects/[slug]/members/route.ts
+++ b/apps/web/app/api/projects/[slug]/members/route.ts
@@ -8,6 +8,7 @@ import {
 	projectMemberDeleteFormSchema,
 } from '~/lib/schemas/project.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function PATCH(
 	req: Request,
@@ -112,7 +113,7 @@ export async function PATCH(
 			.single()
 
 		if (error) {
-			console.error(error)
+			logger.error(error)
 			return NextResponse.json({ error: error.message }, { status: 500 })
 		}
 
@@ -122,7 +123,7 @@ export async function PATCH(
 			slug,
 		})
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },
@@ -213,7 +214,7 @@ export async function DELETE(
 			.eq('project_id', projectId)
 
 		if (error) {
-			console.error(error)
+			logger.error(error)
 			return NextResponse.json({ error: error.message }, { status: 500 })
 		}
 
@@ -222,7 +223,7 @@ export async function DELETE(
 			slug,
 		})
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },

--- a/apps/web/app/api/projects/[slug]/pitch/route.ts
+++ b/apps/web/app/api/projects/[slug]/pitch/route.ts
@@ -10,6 +10,7 @@ import {
 	uploadPitchDeck,
 } from '~/lib/utils/project-utils'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function POST(
 	req: Request,
@@ -102,7 +103,7 @@ export async function POST(
 					validatedSlug,
 				)
 			} catch (e) {
-				console.warn(
+				logger.warn(
 					'Failed to cleanup pitch deck folder:',
 					(e as Error).message,
 				)
@@ -114,7 +115,7 @@ export async function POST(
 			.upsert(projectPitchData, { onConflict: 'project_id' })
 
 		if (error) {
-			console.error(error)
+			logger.error(error)
 			return NextResponse.json({ error: error.message }, { status: 500 })
 		}
 
@@ -122,7 +123,7 @@ export async function POST(
 			message: 'Project pitch upserted successfully',
 		})
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },

--- a/apps/web/app/api/projects/[slug]/team/route.ts
+++ b/apps/web/app/api/projects/[slug]/team/route.ts
@@ -9,6 +9,7 @@ import {
 	teamMemberDeleteQuerySchema,
 } from '~/lib/schemas/project.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function POST(
 	req: Request,
@@ -96,7 +97,7 @@ export async function POST(
 			.single()
 
 		if (insertError) {
-			console.error(insertError)
+			logger.error(insertError)
 			return NextResponse.json({ error: insertError.message }, { status: 500 })
 		}
 
@@ -116,7 +117,7 @@ export async function POST(
 			},
 		})
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },
@@ -174,7 +175,7 @@ export async function PATCH(
 		}
 
 		if (memberError && memberError.code !== 'PGRST116') {
-			console.error('Error checking user permissions:', memberError)
+			logger.error('Error checking user permissions:', memberError)
 		}
 
 		const isOwner = project.kindler_id === userId
@@ -210,7 +211,7 @@ export async function PATCH(
 				.single()
 
 		if (updateError) {
-			console.error(updateError)
+			logger.error(updateError)
 			return NextResponse.json({ error: updateError.message }, { status: 500 })
 		}
 
@@ -230,7 +231,7 @@ export async function PATCH(
 			},
 		})
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },
@@ -283,7 +284,7 @@ export async function DELETE(
 		}
 
 		if (memberError && memberError.code !== 'PGRST116') {
-			console.error('Error checking user permissions:', memberError)
+			logger.error('Error checking user permissions:', memberError)
 		}
 
 		const isOwner = project.kindler_id === userId
@@ -306,7 +307,7 @@ export async function DELETE(
 			.eq('project_id', projectId)
 
 		if (deleteError) {
-			console.error(deleteError)
+			logger.error(deleteError)
 			return NextResponse.json({ error: deleteError.message }, { status: 500 })
 		}
 
@@ -314,7 +315,7 @@ export async function DELETE(
 			message: 'Team member removed successfully',
 		})
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },

--- a/apps/web/app/api/projects/create/route.ts
+++ b/apps/web/app/api/projects/create/route.ts
@@ -11,6 +11,7 @@ import {
 	upsertTags,
 } from '~/lib/utils/project-utils'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function POST(req: Request) {
 	try {
@@ -30,7 +31,7 @@ export async function POST(req: Request) {
 			.single()
 
 		if (profileError || !profileData) {
-			console.error('Profile lookup error:', {
+			logger.error('Profile lookup error:', {
 				error: profileError,
 				userId,
 			})
@@ -97,7 +98,7 @@ export async function POST(req: Request) {
 			.single()
 
 		if (insertError || !project) {
-			console.error(insertError)
+			logger.error(insertError)
 			return NextResponse.json({ error: insertError?.message }, { status: 500 })
 		}
 
@@ -114,7 +115,7 @@ export async function POST(req: Request) {
 					.eq('id', project.id)
 
 				if (updateImageError) {
-					console.error(updateImageError)
+					logger.error(updateImageError)
 					return NextResponse.json(
 						{ error: updateImageError.message },
 						{ status: 500 },
@@ -135,11 +136,11 @@ export async function POST(req: Request) {
 					creatorId: userId,
 				}),
 			)
-			.catch((err) => console.error('[Project create] Notification error:', err))
+			.catch((err) => logger.error('[Project create] Notification error:', err))
 
 		return NextResponse.json({ slug: project.slug }, { status: 201 })
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },

--- a/apps/web/app/api/projects/pitch/analyze/route.ts
+++ b/apps/web/app/api/projects/pitch/analyze/route.ts
@@ -2,6 +2,7 @@ import { gateway, streamText } from 'ai'
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { logger } from '@/lib/logger'
 
 export const maxDuration = 30
 
@@ -72,7 +73,7 @@ Provide specific, actionable recommendations to help improve this pitch for pote
 
 		return result.toTextStreamResponse()
 	} catch (err) {
-		console.error('[pitch/analyze] Error:', err)
+		logger.error('[pitch/analyze] Error:', err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },

--- a/apps/web/app/api/projects/route.ts
+++ b/apps/web/app/api/projects/route.ts
@@ -1,5 +1,6 @@
 import { supabase } from '@packages/lib/supabase'
 import { NextResponse } from 'next/server'
+import { logger } from '@/lib/logger'
 
 /**
  * GET /api/projects
@@ -20,7 +21,7 @@ export async function GET() {
 
 		return NextResponse.json({ success: true, data: data ?? [] })
 	} catch (error) {
-		console.error('Error fetching projects list:', error)
+		logger.error('Error fetching projects list:', error)
 		return NextResponse.json(
 			{ error: 'Failed to fetch projects' },
 			{ status: 500 },

--- a/apps/web/app/api/projects/update/route.ts
+++ b/apps/web/app/api/projects/update/route.ts
@@ -12,6 +12,7 @@ import {
 	upsertTags,
 } from '~/lib/utils/project-utils'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 export async function PATCH(req: Request) {
 	try {
@@ -112,7 +113,7 @@ export async function PATCH(req: Request) {
 					// Delete all files in the project's thumbnail folder
 					await deleteFolderFromBucket(supabase, 'project_thumbnails', slug)
 				} catch (e) {
-					console.warn('Failed to cleanup thumbnails:', (e as Error).message)
+					logger.warn('Failed to cleanup thumbnails:', (e as Error).message)
 				}
 			}
 		}
@@ -124,7 +125,7 @@ export async function PATCH(req: Request) {
 			.eq('id', projectId)
 
 		if (updateError) {
-			console.error(updateError)
+			logger.error(updateError)
 			return NextResponse.json({ error: updateError.message }, { status: 500 })
 		}
 
@@ -142,7 +143,7 @@ export async function PATCH(req: Request) {
 			{ status: 200 },
 		)
 	} catch (err) {
-		console.error(err)
+		logger.error(err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },

--- a/apps/web/app/api/quests/progress/route.ts
+++ b/apps/web/app/api/quests/progress/route.ts
@@ -6,6 +6,7 @@ import { RateLimiter } from '~/lib/auth/rate-limiter'
 import { GamificationContractService } from '~/lib/stellar/gamification-contracts'
 import { questProgressSchema } from '~/lib/schemas/quest.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 const rateLimiter = new RateLimiter()
 
@@ -108,7 +109,7 @@ export async function POST(req: NextRequest) {
 
 
 					if (!contractResult.success) {
-						console.error(
+						logger.error(
 							'[Quest API] Failed to update quest progress on-chain:',
 							contractResult.error,
 						)
@@ -116,10 +117,10 @@ export async function POST(req: NextRequest) {
 					} else {
 					}
 				} else {
-					console.warn('[Quest API] Quest contract address not configured')
+					logger.warn('[Quest API] Quest contract address not configured')
 				}
 			} catch (error) {
-				console.error('[Quest API] Error calling quest contract:', error)
+				logger.error('[Quest API] Error calling quest contract:', error)
 				// Continue with database update even if contract call fails
 			}
 		} else {
@@ -147,7 +148,7 @@ export async function POST(req: NextRequest) {
 
 		// If there's an error other than "not found", return it
 		if (fetchError && fetchError.code !== 'PGRST116') {
-			console.error('Error fetching quest progress:', fetchError)
+			logger.error('Error fetching quest progress:', fetchError)
 			return NextResponse.json(
 				{ error: 'Failed to fetch quest progress' },
 				{ status: 500 },
@@ -173,7 +174,7 @@ export async function POST(req: NextRequest) {
 				.single()
 
 			if (error) {
-				console.error('Error updating quest progress:', error)
+				logger.error('Error updating quest progress:', error)
 				return NextResponse.json(
 					{ error: 'Failed to update quest progress' },
 					{ status: 500 },
@@ -201,7 +202,7 @@ export async function POST(req: NextRequest) {
 			.single()
 
 		if (error) {
-			console.error('Error creating quest progress:', error)
+			logger.error('Error creating quest progress:', error)
 			return NextResponse.json(
 				{ error: 'Failed to create quest progress' },
 				{ status: 500 },
@@ -214,7 +215,7 @@ export async function POST(req: NextRequest) {
 			reward_points: is_completed ? quest.reward_points : 0,
 		})
 	} catch (error) {
-		console.error('Error in POST /api/quests/progress:', error)
+		logger.error('Error in POST /api/quests/progress:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/quests/route.ts
+++ b/apps/web/app/api/quests/route.ts
@@ -6,6 +6,7 @@ import { nextAuthOption } from '~/lib/auth/auth-options'
 import { createQuestSchema } from '~/lib/schemas/quest.schemas'
 import { GamificationContractService } from '~/lib/stellar/gamification-contracts'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * GET /api/quests
@@ -46,7 +47,7 @@ export async function GET(_req: NextRequest) {
 		const hasContributions = (contributionsCountResult.count ?? 0) > 0
 
 		if (error) {
-			console.error('Error fetching quests:', error)
+			logger.error('Error fetching quests:', error)
 			return NextResponse.json(
 				{ error: 'Failed to fetch quests' },
 				{ status: 500 },
@@ -54,7 +55,7 @@ export async function GET(_req: NextRequest) {
 		}
 
 		if (progressError) {
-			console.error('Error fetching quest progress:', progressError)
+			logger.error('Error fetching quest progress:', progressError)
 		}
 
 		// Build a Map for O(1) lookup instead of O(n) Array.find
@@ -82,7 +83,7 @@ export async function GET(_req: NextRequest) {
 					progressMap,
 				)
 			} catch (syncErr) {
-				console.error('[Quests] Error syncing quest progress:', syncErr)
+				logger.error('[Quests] Error syncing quest progress:', syncErr)
 			}
 		}
 
@@ -108,7 +109,7 @@ export async function GET(_req: NextRequest) {
 
 		return NextResponse.json({ quests: questsWithProgress || [] })
 	} catch (error) {
-		console.error('Error in GET /api/quests:', error)
+		logger.error('Error in GET /api/quests:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },
@@ -183,7 +184,7 @@ export async function POST(req: NextRequest) {
 			.single()
 
 		if (error) {
-			console.error('Error creating quest:', error)
+			logger.error('Error creating quest:', error)
 			return NextResponse.json(
 				{ error: 'Failed to create quest' },
 				{ status: 500 },
@@ -225,7 +226,7 @@ export async function POST(req: NextRequest) {
 					process.env.ADMIN_PRIVATE_KEY || process.env.SOROBAN_PRIVATE_KEY
 
 				if (!adminPrivateKey) {
-					console.warn(
+					logger.warn(
 						'[Quest API] No admin private key found. Quest created in database but not synced to chain.',
 					)
 				} else {
@@ -247,18 +248,18 @@ export async function POST(req: NextRequest) {
 
 					if (onChainResult.success) {
 					} else {
-						console.error(
+						logger.error(
 							'[Quest API] Failed to sync quest to on-chain:',
 							onChainResult.error,
 						)
 					}
 				}
 			} catch (error) {
-				console.error('[Quest API] Error syncing quest to on-chain:', error)
+				logger.error('[Quest API] Error syncing quest to on-chain:', error)
 				// Don't fail the request if on-chain sync fails - quest is still in database
 			}
 		} else {
-			console.warn(
+			logger.warn(
 				'[Quest API] No quest contract address configured. Quest created in database only.',
 			)
 		}
@@ -277,7 +278,7 @@ export async function POST(req: NextRequest) {
 			{ status: 201 },
 		)
 	} catch (error) {
-		console.error('Error in POST /api/quests:', error)
+		logger.error('Error in POST /api/quests:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },
@@ -358,7 +359,7 @@ async function syncQuestProgress(
 			.single()
 
 		if (error) {
-			console.error(
+			logger.error(
 				`[Quests] Failed to backfill progress for quest ${quest.quest_id}:`,
 				error,
 			)

--- a/apps/web/app/api/referrals/donation/route.ts
+++ b/apps/web/app/api/referrals/donation/route.ts
@@ -5,6 +5,7 @@ import { nextAuthOption } from '~/lib/auth/auth-options'
 import { GamificationContractService } from '~/lib/stellar/gamification-contracts'
 import { referralDonationSchema } from '~/lib/schemas/referral.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/referrals/donation
@@ -94,7 +95,7 @@ export async function POST(req: NextRequest) {
 
 
 					if (!contractResult.success) {
-						console.error(
+						logger.error(
 							'[Referral API] Failed to record referral donation on-chain:',
 							contractResult.error,
 						)
@@ -102,12 +103,12 @@ export async function POST(req: NextRequest) {
 					} else {
 					}
 				} else {
-					console.warn(
+					logger.warn(
 						'[Referral API] Referral contract address not configured',
 					)
 				}
 			} catch (error) {
-				console.error('[Referral API] Error calling referral contract:', error)
+				logger.error('[Referral API] Error calling referral contract:', error)
 				// Continue with database update even if contract call fails
 			}
 		} else {
@@ -148,7 +149,7 @@ export async function POST(req: NextRequest) {
 			.single()
 
 		if (updateError) {
-			console.error('Error updating referral:', updateError)
+			logger.error('Error updating referral:', updateError)
 			return NextResponse.json(
 				{ error: 'Failed to update referral' },
 				{ status: 500 },
@@ -186,7 +187,7 @@ export async function POST(req: NextRequest) {
 			status_changed: new_status !== old_status,
 		})
 	} catch (error) {
-		console.error('Error in POST /api/referrals/donation:', error)
+		logger.error('Error in POST /api/referrals/donation:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/referrals/onboard/route.ts
+++ b/apps/web/app/api/referrals/onboard/route.ts
@@ -5,6 +5,7 @@ import { nextAuthOption } from '~/lib/auth/auth-options'
 import { GamificationContractService } from '~/lib/stellar/gamification-contracts'
 import { referralOnboardSchema } from '~/lib/schemas/referral.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 const ONBOARDING_REWARD_POINTS = 50
 
@@ -74,14 +75,14 @@ export async function POST(req: NextRequest) {
 		const { data: stats, error: statsError } = statsResult
 
 		if (statsError && statsError.code !== 'PGRST116') {
-			console.error(
+			logger.error(
 				'[Referral Onboard API] Error fetching referrer statistics:',
 				statsError,
 			)
 		}
 
 		if (updateError) {
-			console.error('Error updating referral:', updateError)
+			logger.error('Error updating referral:', updateError)
 			return NextResponse.json(
 				{ error: 'Failed to update referral' },
 				{ status: 500 },
@@ -129,20 +130,20 @@ export async function POST(req: NextRequest) {
 					)
 
 					if (!contractResult.success) {
-						console.error(
+						logger.error(
 							'[Referral Onboard API] On-chain mark_onboarded failed:',
 							contractResult.error,
 						)
 					} else {
 					}
 				} catch (err) {
-					console.error(
+					logger.error(
 						'[Referral Onboard API] Error calling mark_onboarded on-chain:',
 						err,
 					)
 				}
 			} else {
-				console.warn(
+				logger.warn(
 					'[Referral Onboard API] Skipping on-chain mark_onboarded — no Stellar address for referred user',
 				)
 			}
@@ -154,7 +155,7 @@ export async function POST(req: NextRequest) {
 			onChain: contractResult?.success ?? false,
 		})
 	} catch (error) {
-		console.error('Error in POST /api/referrals/onboard:', error)
+		logger.error('Error in POST /api/referrals/onboard:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/referrals/route.ts
+++ b/apps/web/app/api/referrals/route.ts
@@ -5,6 +5,7 @@ import { nextAuthOption } from '~/lib/auth/auth-options'
 import { GamificationContractService } from '~/lib/stellar/gamification-contracts'
 import { createReferralSchema } from '~/lib/schemas/referral.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * Resolve a user ID to a Stellar address (G... or C...) via devices table.
@@ -67,11 +68,11 @@ export async function GET(_req: NextRequest) {
 		const { data: referredRecord } = referredResult
 
 		if (referralsError) {
-			console.error('Error fetching referrals:', referralsError)
+			logger.error('Error fetching referrals:', referralsError)
 		}
 
 		if (statsError && statsError.code !== 'PGRST116') {
-			console.error('Error fetching referrer stats:', statsError)
+			logger.error('Error fetching referrer stats:', statsError)
 		}
 
 		return NextResponse.json({
@@ -84,7 +85,7 @@ export async function GET(_req: NextRequest) {
 			referred_by: referredRecord?.referrer_id || null,
 		})
 	} catch (error) {
-		console.error('Error in GET /api/referrals:', error)
+		logger.error('Error in GET /api/referrals:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },
@@ -142,7 +143,7 @@ export async function POST(req: NextRequest) {
 			.single()
 
 		if (error) {
-			console.error('Error creating referral:', error)
+			logger.error('Error creating referral:', error)
 			return NextResponse.json(
 				{ error: 'Failed to create referral' },
 				{ status: 500 },
@@ -196,20 +197,20 @@ export async function POST(req: NextRequest) {
 					)
 
 					if (!contractResult.success) {
-						console.error(
+						logger.error(
 							'[Referral API] On-chain create_referral failed:',
 							contractResult.error,
 						)
 					} else {
 					}
 				} catch (err) {
-					console.error(
+					logger.error(
 						'[Referral API] Error calling create_referral on-chain:',
 						err,
 					)
 				}
 			} else {
-				console.warn(
+				logger.warn(
 					'[Referral API] Skipping on-chain create_referral — missing Stellar addresses',
 				)
 			}
@@ -220,7 +221,7 @@ export async function POST(req: NextRequest) {
 			{ status: 201 },
 		)
 	} catch (error) {
-		console.error('Error in POST /api/referrals:', error)
+		logger.error('Error in POST /api/referrals:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/stellar/account-info/route.ts
+++ b/apps/web/app/api/stellar/account-info/route.ts
@@ -4,6 +4,7 @@ import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { accountInfoQuerySchema } from '~/lib/schemas/stellar.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * GET /api/stellar/account-info
@@ -35,7 +36,7 @@ export async function GET(req: NextRequest) {
 			data: accountInfo,
 		})
 	} catch (error) {
-		console.error('❌ Error getting account info:', error)
+		logger.error('❌ Error getting account info:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to get account information',

--- a/apps/web/app/api/stellar/account/approve/route.ts
+++ b/apps/web/app/api/stellar/account/approve/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { accountApproveSchema } from '~/lib/schemas/stellar.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/stellar/account/approve
@@ -42,7 +43,7 @@ export async function POST(req: NextRequest) {
 
 		if (!response.ok) {
 			const errorData = await response.json()
-			console.error('❌ KYC server error:', errorData)
+			logger.error('❌ KYC server error:', errorData)
 			throw new Error(errorData.error || 'Failed to register account')
 		}
 
@@ -58,7 +59,7 @@ export async function POST(req: NextRequest) {
 			},
 		})
 	} catch (error) {
-		console.error('❌ Error approving account:', error)
+		logger.error('❌ Error approving account:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to approve account',

--- a/apps/web/app/api/stellar/account/check-approval/[address]/route.ts
+++ b/apps/web/app/api/stellar/account/check-approval/[address]/route.ts
@@ -5,6 +5,7 @@ import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { addressParamSchema } from '~/lib/schemas/stellar.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * GET /api/stellar/account/check-approval/[address]
@@ -67,7 +68,7 @@ export async function GET(
 			},
 		})
 	} catch (error) {
-		console.error('❌ Error checking account approval:', error)
+		logger.error('❌ Error checking account approval:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to check account approval',

--- a/apps/web/app/api/stellar/balances/[address]/route.ts
+++ b/apps/web/app/api/stellar/balances/[address]/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server'
 import { addressParamSchema } from '~/lib/schemas/stellar.schemas'
 import { SmartWalletTransactionService } from '~/lib/stellar/smart-wallet-transactions'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * GET /api/stellar/balances/[address]
@@ -47,7 +48,7 @@ export async function GET(
 			},
 		})
 	} catch (error) {
-		console.error('Error fetching balances:', error)
+		logger.error('Error fetching balances:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to fetch balances',

--- a/apps/web/app/api/stellar/contract/invoke/route.ts
+++ b/apps/web/app/api/stellar/contract/invoke/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { contractInvokeSchema } from '~/lib/schemas/stellar.schemas'
 import { SmartWalletTransactionService } from '~/lib/stellar/smart-wallet-transactions'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/stellar/contract/invoke
@@ -41,7 +42,7 @@ export async function POST(req: NextRequest) {
 			},
 		})
 	} catch (error) {
-		console.error('Error preparing contract invocation:', error)
+		logger.error('Error preparing contract invocation:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to prepare contract invocation',

--- a/apps/web/app/api/stellar/devices/route.ts
+++ b/apps/web/app/api/stellar/devices/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { devicesSchema } from '~/lib/schemas/stellar.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/stellar/devices
@@ -47,7 +48,7 @@ export async function POST(req: NextRequest) {
 			transactionHash: data.transactionHash,
 		})
 	} catch (error) {
-		console.error('Error executing device operation:', error)
+		logger.error('Error executing device operation:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to execute device operation',

--- a/apps/web/app/api/stellar/faucet/route.ts
+++ b/apps/web/app/api/stellar/faucet/route.ts
@@ -13,6 +13,7 @@ import {
 import { Api, assembleTransaction, Server } from '@stellar/stellar-sdk/rpc'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/stellar/faucet
@@ -95,7 +96,7 @@ export async function POST(req: NextRequest) {
 			},
 		})
 	} catch (error) {
-		console.error('❌ Error funding smart wallet:', error)
+		logger.error('❌ Error funding smart wallet:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to fund smart wallet',
@@ -158,7 +159,7 @@ async function fundContractViaSAC(
 
 
 	if (Api.isSimulationError(simulation)) {
-		console.error('❌ Simulation error:', JSON.stringify(simulation, null, 2))
+		logger.error('❌ Simulation error:', JSON.stringify(simulation, null, 2))
 		throw new Error(
 			`SAC transfer simulation failed: ${JSON.stringify(simulation)}`,
 		)
@@ -174,7 +175,7 @@ async function fundContractViaSAC(
 
 
 	if (submitResult.status === 'ERROR') {
-		console.error('❌ Submit error:', submitResult)
+		logger.error('❌ Submit error:', submitResult)
 		throw new Error(`SAC transfer submission failed: ${submitResult.status}`)
 	}
 
@@ -235,7 +236,7 @@ async function fundAccountViaHorizon(
 
 	if (!submitResponse.ok) {
 		const errorData = await submitResponse.json()
-		console.error('❌ Horizon submission error:', errorData)
+		logger.error('❌ Horizon submission error:', errorData)
 		throw new Error(
 			errorData.extras?.result_codes?.operations?.[0] ||
 				errorData.title ||

--- a/apps/web/app/api/stellar/transfer/prepare/route.ts
+++ b/apps/web/app/api/stellar/transfer/prepare/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server'
 import { transferPrepareSchema } from '~/lib/schemas/stellar.schemas'
 import { validateRequest } from '~/lib/utils/validation'
 import {
+import { logger } from '@/lib/logger'
 	SmartWalletTransactionService,
 	type TransactionChallenge,
 } from '~/lib/stellar/smart-wallet-transactions'
@@ -62,7 +63,7 @@ export async function POST(req: NextRequest) {
 			},
 		})
 	} catch (error) {
-		console.error('Error preparing transfer:', error)
+		logger.error('Error preparing transfer:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to prepare transfer',

--- a/apps/web/app/api/stellar/transfer/submit/route.ts
+++ b/apps/web/app/api/stellar/transfer/submit/route.ts
@@ -17,6 +17,7 @@ import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { transferSubmitSchema } from '~/lib/schemas/stellar.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 // Don't initialize services at module level - do it inside the route handler
 // This prevents build-time errors when environment variables are not available
@@ -60,7 +61,7 @@ export async function POST(req: NextRequest) {
 		try {
 			fundingKeypair = Keypair.fromSecret(appConfig.stellar.fundingAccount)
 		} catch (error) {
-			console.error('❌ Invalid funding account secret:', error)
+			logger.error('❌ Invalid funding account secret:', error)
 			return NextResponse.json(
 				{
 					error: 'Invalid funding account configuration',
@@ -82,7 +83,7 @@ export async function POST(req: NextRequest) {
 				appConfig.stellar.networkPassphrase,
 			) as Transaction
 		} catch (error) {
-			console.error('❌ Invalid transactionXDR:', error)
+			logger.error('❌ Invalid transactionXDR:', error)
 			return NextResponse.json(
 				{
 					error: 'Invalid transactionXDR format',
@@ -129,23 +130,23 @@ export async function POST(req: NextRequest) {
 
 			// ! Keeping logs commented out for now. Deactivating signature verification on-chain, verifying device existence on contract only
 			// Logging WebAuthn Signature Details
-			// console.log('🔏 WebAuthn Signature Details:')
-			// console.log('   Signature (base64):', signature.toString('base64'))
-			// console.log(
+
+
+
 			// 	'   Authenticator Data (base64):',
 			// 	authenticatorData.toString('base64'),
 			// )
-			// console.log('   Client Data (object):', clientData)
-			// console.log(
+
+
 			// 	'   WebAuthn Payload (base64):',
 			// 	webauthnPayload.toString('base64'),
 			// )
-			// console.log(
+
 			// 	'   WebAuthn Payload Hash (hex):',
 			// 	webauthnPayloadHash.toString('hex'),
 			// )
-			// console.log('   Challenge (utf8):', challenge)
-			// console.log('   Challenge Bytes (hex):', challengeBytes?.toString('hex'))
+
+
 
 			// ! Strategy still not the same... simplify. A verification already happening, but is not "preparing" the signature to on-chain verification
 			// const verificationResults = await stellarService.verifyPasskeySignature(
@@ -154,7 +155,6 @@ export async function POST(req: NextRequest) {
 			// 	hash,
 			// )
 
-			// console.log('🔐 Contract will verify signature', { verificationResults })
 
 			// Find and update the auth entry for the smart wallet
 			const signatureScVal = xdr.ScVal.fromXDR(signatureScValRaw.toXDR())
@@ -200,7 +200,7 @@ export async function POST(req: NextRequest) {
 		const submitResult = await server.sendTransaction(transaction)
 
 		if (submitResult.status === 'ERROR') {
-			console.error('❌ Submit error:', submitResult)
+			logger.error('❌ Submit error:', submitResult)
 			throw new Error(
 				`Transaction submission failed: ${JSON.stringify(submitResult.errorResult, null, 2) || 'Unknown error'}`,
 			)
@@ -209,7 +209,7 @@ export async function POST(req: NextRequest) {
 		const txHash = submitResult.hash
 
 		if (submitResult?.errorResult) {
-			console.error('❌ Submit error (false positive):', submitResult)
+			logger.error('❌ Submit error (false positive):', submitResult)
 			throw new Error(
 				`Transaction submission failed: ${submitResult.errorResult || 'Unknown error'}`,
 			)
@@ -223,7 +223,7 @@ export async function POST(req: NextRequest) {
 			},
 		})
 	} catch (error) {
-		console.error('❌ Error submitting transfer:', error)
+		logger.error('❌ Error submitting transfer:', error)
 		return NextResponse.json(
 			{
 				error: 'Failed to submit transfer',

--- a/apps/web/app/api/streaks/route.ts
+++ b/apps/web/app/api/streaks/route.ts
@@ -5,6 +5,7 @@ import { nextAuthOption } from '~/lib/auth/auth-options'
 import { GamificationContractService } from '~/lib/stellar/gamification-contracts'
 import { recordStreakSchema } from '~/lib/schemas/streak.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * GET /api/streaks
@@ -31,7 +32,7 @@ export async function GET(_req: NextRequest) {
 			.order('period', { ascending: true })
 
 		if (error) {
-			console.error('Error fetching streaks:', error)
+			logger.error('Error fetching streaks:', error)
 			return NextResponse.json(
 				{ error: 'Failed to fetch streaks' },
 				{ status: 500 },
@@ -40,7 +41,7 @@ export async function GET(_req: NextRequest) {
 
 		return NextResponse.json({ streaks: streaks || [] })
 	} catch (error) {
-		console.error('Error in GET /api/streaks:', error)
+		logger.error('Error in GET /api/streaks:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },
@@ -126,7 +127,7 @@ export async function POST(req: NextRequest) {
 
 
 					if (!contractResult.success) {
-						console.error(
+						logger.error(
 							'[Streak API] Failed to record streak on-chain:',
 							contractResult.error,
 						)
@@ -134,10 +135,10 @@ export async function POST(req: NextRequest) {
 					} else {
 					}
 				} else {
-					console.warn('[Streak API] Streak contract address not configured')
+					logger.warn('[Streak API] Streak contract address not configured')
 				}
 			} catch (error) {
-				console.error('[Streak API] Error calling streak contract:', error)
+				logger.error('[Streak API] Error calling streak contract:', error)
 				// Continue with database update even if contract call fails
 			}
 		} else {
@@ -153,7 +154,7 @@ export async function POST(req: NextRequest) {
 
 		// If there's an error other than "not found", return it
 		if (fetchError && fetchError.code !== 'PGRST116') {
-			console.error('Error fetching streak:', fetchError)
+			logger.error('Error fetching streak:', fetchError)
 			return NextResponse.json(
 				{ error: 'Failed to fetch streak' },
 				{ status: 500 },
@@ -204,7 +205,7 @@ export async function POST(req: NextRequest) {
 				.single()
 
 			if (error) {
-				console.error('Error updating streak:', error)
+				logger.error('Error updating streak:', error)
 				return NextResponse.json(
 					{ error: 'Failed to update streak' },
 					{ status: 500 },
@@ -224,7 +225,7 @@ export async function POST(req: NextRequest) {
 			.single()
 
 		if (error) {
-			console.error('Error creating streak:', error)
+			logger.error('Error creating streak:', error)
 			return NextResponse.json(
 				{ error: 'Failed to create streak' },
 				{ status: 500 },
@@ -236,7 +237,7 @@ export async function POST(req: NextRequest) {
 			bonus_points: 0,
 		})
 	} catch (error) {
-		console.error('Error in POST /api/streaks:', error)
+		logger.error('Error in POST /api/streaks:', error)
 		return NextResponse.json(
 			{ error: 'Internal server error' },
 			{ status: 500 },

--- a/apps/web/app/api/waitlist/route.ts
+++ b/apps/web/app/api/waitlist/route.ts
@@ -2,6 +2,7 @@ import { supabase } from '@packages/lib/supabase'
 import { NextResponse } from 'next/server'
 import { waitlistSchema } from '~/lib/schemas/waitlist.schemas'
 import { validateRequest } from '~/lib/utils/validation'
+import { logger } from '@/lib/logger'
 
 /**
  * POST /api/waitlist
@@ -49,7 +50,7 @@ export async function POST(req: Request) {
 			.single()
 
 		if (error) {
-			console.error('Waitlist insert failed:', error)
+			logger.error('Waitlist insert failed:', error)
 			return NextResponse.json(
 				{
 					error: error.message || 'Insert failed',
@@ -63,7 +64,7 @@ export async function POST(req: Request) {
 
 		return NextResponse.json({ success: true, id: data.id }, { status: 201 })
 	} catch (err) {
-		console.error('Waitlist submit error:', err)
+		logger.error('Waitlist submit error:', err)
 		return NextResponse.json(
 			{ error: err instanceof Error ? err.message : 'Unknown error' },
 			{ status: 500 },

--- a/apps/web/auth/kindfi-supabase-adapter.ts
+++ b/apps/web/auth/kindfi-supabase-adapter.ts
@@ -3,6 +3,7 @@ import { SupabaseAdapter } from '@auth/supabase-adapter'
 import { appEnvConfig } from '@packages/lib/config'
 import { createSupabaseBrowserClient } from '@packages/lib/supabase-client'
 import type { Adapter, AdapterSession, AdapterUser } from 'next-auth/adapters'
+import { logger } from '@/lib/logger'
 
 interface DeviceData {
 	credential_id: string
@@ -91,7 +92,7 @@ export function KindfiSupabaseAdapter(): Adapter {
 					}),
 				)
 				.catch((err) => {
-					console.error('[Auth] Welcome email error:', err)
+					logger.error('[Auth] Welcome email error:', err)
 				})
 
 			return createdUser

--- a/apps/web/components/base/button.tsx
+++ b/apps/web/components/base/button.tsx
@@ -5,6 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import * as React from 'react'
 
 import { cn } from '~/lib/utils'
+import { logger } from '@/lib/logger'
 
 /**
  * ShadCN/UI Reference: https://ui.shadcn.com/docs/components/button
@@ -135,7 +136,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
 		// Warning for icon-only buttons without aria-label in development
 		// if (appConfig.env.nodeEnv !== 'production' && isIconOnly && !ariaLabel) {
-		// 	console.error(
+
 		// 		`Accessibility error: Icon-only Button must have an aria-label to describe its purpose. Component: ${Button.displayName}`,
 		// 	)
 		// }
@@ -151,7 +152,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 				isLink &&
 				!('href' in props) && {
 					onClick: (e) => {
-						console.warn(
+						logger.warn(
 							'Accessibility warning: Buttons with role="link" should have an href attribute.',
 						)
 						props.onClick?.(e)

--- a/apps/web/components/base/calendar.tsx
+++ b/apps/web/components/base/calendar.tsx
@@ -3,6 +3,7 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import * as React from 'react'
 import { cn } from '~/lib/utils'
+import { logger } from '@/lib/logger'
 
 interface CalendarProps {
 	selected?: Date
@@ -25,7 +26,7 @@ interface CalendarProps {
  * @example
  * <Calendar
  *  selected={new Date()}
- *  onSelect={(date) => console.log(date)}
+ *  onSelect={(date) => logger.info(date)}
  *  disabled={(date) => date.getDay() === 0}
  * />
  */

--- a/apps/web/components/base/form.tsx
+++ b/apps/web/components/base/form.tsx
@@ -15,6 +15,7 @@ import { getCsrfTokenFromCookie } from '~/app/actions/csrf'
 import { Label } from '~/components/base/label'
 import { cn } from '~/lib/utils'
 import { formFieldClasses } from '~/lib/form/form-styles'
+import { logger } from '@/lib/logger'
 
 /**
  * ShadCN/UI Reference:https://ui.shadcn.com/docs/components/form
@@ -224,7 +225,7 @@ export function CSRFTokenField(): React.ReactElement {
 		getCsrfTokenFromCookie().then((fetchedToken) => {
 			if (!active) return
 			if (!fetchedToken) {
-				console.warn(
+				logger.warn(
 					'CSRF token not found in cookies. Ensure you have set it correctly.',
 				)
 				return

--- a/apps/web/components/pages/auth/otp-validation.tsx
+++ b/apps/web/components/pages/auth/otp-validation.tsx
@@ -25,6 +25,7 @@ import {
 	InputOTPSlot,
 } from '~/components/base/input-otp'
 import { OTPTips } from '~/components/shared/otp-tips'
+import { logger } from '@/lib/logger'
 
 export function VerifyOTPComponent() {
 	const router = useRouter()
@@ -107,10 +108,10 @@ export function VerifyOTPComponent() {
 						})
 					// Ignore conflict or RLS (duplicate) errors silently
 					if (profileInsertError) {
-						console.warn('Profile insert warning:', profileInsertError.message)
+						logger.warn('Profile insert warning:', profileInsertError.message)
 					}
 				} catch (profileErr) {
-					console.warn('Profile insert (non-fatal) error:', profileErr)
+					logger.warn('Profile insert (non-fatal) error:', profileErr)
 				}
 
 				setIsVerified(true)
@@ -120,7 +121,7 @@ export function VerifyOTPComponent() {
 				}, 1200)
 			}
 		} catch (err) {
-			console.error('OTP verification error:', err)
+			logger.error('OTP verification error:', err)
 			if (err instanceof Error) {
 				setError(err.message)
 			} else {
@@ -153,7 +154,7 @@ export function VerifyOTPComponent() {
 			setTimeLeft(120)
 			setSuccess('Verification code resent! Please check your inbox.')
 		} catch (err) {
-			console.error('Resend OTP error:', err)
+			logger.error('Resend OTP error:', err)
 			if (err instanceof Error) {
 				setError(err.message)
 			} else {

--- a/apps/web/components/pages/auth/passkey-registration.tsx
+++ b/apps/web/components/pages/auth/passkey-registration.tsx
@@ -22,6 +22,7 @@ import { AuthLayout } from '~/components/shared/layout/auth/auth-layout'
 import { PasskeyInfoDialog } from '~/components/shared/passkey-info-dialog'
 import { useSmartAccountRegistration } from '~/hooks/passkey/use-smart-account-registration'
 import { useWebAuthnSupport } from '~/hooks/passkey/use-web-authn-support'
+import { logger } from '@/lib/logger'
 
 export function PasskeyRegistrationComponent() {
 	const router = useRouter()
@@ -57,7 +58,7 @@ export function PasskeyRegistrationComponent() {
 		try {
 			await signOutAction()
 		} catch (error) {
-			console.error('Error signing out:', error)
+			logger.error('Error signing out:', error)
 			// Even if sign out fails, redirect to home
 			router.push('/')
 		}
@@ -87,7 +88,7 @@ export function PasskeyRegistrationComponent() {
 			sessionStorage.setItem('kindfi_new_session', 'true')
 			router.push('/profile')
 		} catch (e) {
-			console.error('Finalize passkey registration error', e)
+			logger.error('Finalize passkey registration error', e)
 			router.push('/sign-in')
 		}
 	}, [regSuccess, userEmail, userId, smartAccountAddress, router])
@@ -97,7 +98,7 @@ export function PasskeyRegistrationComponent() {
 		// If registration succeeded but no Smart Account address, redirect to sign-in
 		// The passkey is still registered and can be used for authentication
 		if (regSuccess && !smartAccountAddress) {
-			console.warn(
+			logger.warn(
 				'⚠️ Passkey registered but Smart Account creation failed. Redirecting to sign-in.',
 			)
 			toast.warning(

--- a/apps/web/components/sections/foundations/create/hooks/use-foundation-form-submission.ts
+++ b/apps/web/components/sections/foundations/create/hooks/use-foundation-form-submission.ts
@@ -2,6 +2,7 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import type { CreateFoundationFormData } from '../types'
+import { logger } from '@/lib/logger'
 
 export function useFoundationFormSubmission() {
 	const router = useRouter()
@@ -47,7 +48,7 @@ export function useFoundationFormSubmission() {
 			toast.success('Foundation created successfully!')
 			router.push(`/foundations/${result.slug}`)
 		} catch (error) {
-			console.error('Error creating foundation:', error)
+			logger.error('Error creating foundation:', error)
 			toast.error(
 				error instanceof Error
 					? error.message

--- a/apps/web/components/sections/foundations/create/hooks/use-slug-validation.ts
+++ b/apps/web/components/sections/foundations/create/hooks/use-slug-validation.ts
@@ -1,6 +1,7 @@
 import { createSupabaseBrowserClient } from '@packages/lib/supabase-client'
 import { startTransition, useEffect, useState } from 'react'
 import { useDebounce } from 'react-use'
+import { logger } from '@/lib/logger'
 
 interface UseSlugValidationResult {
 	isChecking: boolean
@@ -46,7 +47,7 @@ export function useSlugValidation(slug: string): UseSlugValidationResult {
 		void Promise.resolve(promise)
 			.then(({ data, error: queryError }) => {
 				if (queryError) {
-					console.error('Error checking slug:', queryError)
+					logger.error('Error checking slug:', queryError)
 					setIsAvailable(null)
 					setError(null)
 					return
@@ -61,7 +62,7 @@ export function useSlugValidation(slug: string): UseSlugValidationResult {
 				)
 			})
 			.catch((err) => {
-				console.error('Error checking slug:', err)
+				logger.error('Error checking slug:', err)
 				setIsAvailable(null)
 				setError(null)
 			})

--- a/apps/web/components/sections/foundations/manage/edit-foundation-form.tsx
+++ b/apps/web/components/sections/foundations/manage/edit-foundation-form.tsx
@@ -19,6 +19,7 @@ import { LogoSection } from '../create/components/logo-section'
 import { MissionVisionSection } from '../create/components/mission-vision-section'
 import { SocialLinksSection } from '../create/components/social-links-section'
 import {
+import { logger } from '@/lib/logger'
 	type CreateFoundationFormData,
 	createFoundationSchema,
 } from '../create/types'
@@ -98,7 +99,7 @@ export function EditFoundationForm({
 				router.refresh()
 				router.push(`/foundations/${slug}/manage`)
 			} catch (error) {
-				console.error('Edit foundation error:', error)
+				logger.error('Edit foundation error:', error)
 				toast.error(
 					error instanceof Error
 						? error.message

--- a/apps/web/components/sections/home/community.tsx
+++ b/apps/web/components/sections/home/community.tsx
@@ -8,6 +8,7 @@ import { SectionContainer } from '~/components/shared/section-container'
 import { Testimonial } from '~/components/shared/testimonial-card'
 import { benefits, testimonialData } from '~/lib/constants/community-data'
 import { useI18n } from '~/lib/i18n'
+import { logger } from '@/lib/logger'
 
 export function Community() {
 	const prefersReducedMotion = useReducedMotion()
@@ -40,7 +41,7 @@ export function Community() {
 				message: 'Form submitted successfully!',
 			})
 		} catch (error) {
-			console.error(error) // Logs the error for debugging
+			logger.error(error) // Logs the error for debugging
 			setFormStatus({
 				type: 'error',
 				message: 'Failed to submit the form. Please try again.',

--- a/apps/web/components/sections/profile/cards/account-info-card.tsx
+++ b/apps/web/components/sections/profile/cards/account-info-card.tsx
@@ -9,6 +9,7 @@ import { Input } from '~/components/base/input'
 import { Label } from '~/components/base/label'
 import { useI18n } from '~/lib/i18n'
 import { ProfileSurfaceCard } from '../profile-surface-card'
+import { logger } from '@/lib/logger'
 
 interface AccountInfoCardProps {
 	userEmail: string
@@ -49,7 +50,7 @@ export function AccountInfoCard({
 			setIsEditing(false)
 			window.location.reload()
 		} catch (error) {
-			console.error('Failed to update slug:', error)
+			logger.error('Failed to update slug:', error)
 			toast.error(
 				error instanceof Error ? error.message : t('profile.handleUpdateFailed'),
 			)

--- a/apps/web/components/sections/profile/cards/kyc-card.tsx
+++ b/apps/web/components/sections/profile/cards/kyc-card.tsx
@@ -18,6 +18,7 @@ import { cn } from '~/lib/utils'
 import { profileFadeUp } from '../profile-motion'
 import { ProfileSurfaceCard } from '../profile-surface-card'
 import { KYCRedirectModal } from '../modals/kyc-redirect-modal'
+import { logger } from '@/lib/logger'
 
 interface KYCCardProps {
 	userId: string
@@ -63,7 +64,7 @@ export function KYCCard({ userId, shouldRefresh = false }: KYCCardProps) {
 				toast.error(result.error || t('profile.kycStartFailed'))
 			}
 		} catch (error) {
-			console.error('Failed to start KYC:', error)
+			logger.error('Failed to start KYC:', error)
 			toast.error(t('profile.kycStartFailed'))
 		} finally {
 			setIsCreating(false)

--- a/apps/web/components/sections/profile/cards/personal-info-card.tsx
+++ b/apps/web/components/sections/profile/cards/personal-info-card.tsx
@@ -11,6 +11,7 @@ import { Label } from '~/components/base/label'
 import { Textarea } from '~/components/base/textarea'
 import { useI18n } from '~/lib/i18n'
 import { ProfileSurfaceCard } from '../profile-surface-card'
+import { logger } from '@/lib/logger'
 
 interface PersonalInfoCardProps {
 	userId: string
@@ -51,7 +52,7 @@ export function PersonalInfoCard({
 			setIsEditing(false)
 			window.location.reload()
 		} catch (error) {
-			console.error(error)
+			logger.error(error)
 			toast.error(t('profile.profileUpdateFailed'))
 		} finally {
 			setIsSaving(false)

--- a/apps/web/components/sections/profile/cards/role-card.tsx
+++ b/apps/web/components/sections/profile/cards/role-card.tsx
@@ -12,6 +12,7 @@ import {
 	CardTitle,
 } from '~/components/base/card'
 import {
+import { logger } from '@/lib/logger'
 	Select,
 	SelectContent,
 	SelectItem,
@@ -48,7 +49,7 @@ export function RoleCard({ userId, currentRole }: RoleCardProps) {
 			// Reload page to reflect changes
 			window.location.reload()
 		} catch (error) {
-			console.error('Failed to update role:', error)
+			logger.error('Failed to update role:', error)
 			toast.error('Failed to update role')
 		} finally {
 			setIsChanging(false)

--- a/apps/web/components/sections/profile/modals/role-selection-modal.tsx
+++ b/apps/web/components/sections/profile/modals/role-selection-modal.tsx
@@ -7,6 +7,7 @@ import { Heart, Lightbulb } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import {
+import { logger } from '@/lib/logger'
 	Dialog,
 	DialogContent,
 	DialogDescription,
@@ -54,7 +55,7 @@ export function RoleSelectionModal({
 			// Reload page to reflect changes
 			window.location.reload()
 		} catch (error) {
-			console.error('Failed to update role:', error)
+			logger.error('Failed to update role:', error)
 			toast.error('Failed to update role. Please try again.')
 		} finally {
 			setIsSaving(false)

--- a/apps/web/components/sections/profile/views/creator-profile.tsx
+++ b/apps/web/components/sections/profile/views/creator-profile.tsx
@@ -23,6 +23,7 @@ import { ProfileSectionHeader } from '../profile-section-header'
 import { ProfileStatCard } from '../profile-stat-card'
 import { ProfileSurfaceCard } from '../profile-surface-card'
 import { FoundationsSection } from './foundations-section'
+import { logger } from '@/lib/logger'
 
 interface CreatorProfileProps {
 	userId: string
@@ -74,7 +75,7 @@ export function CreatorProfile({
 				})
 				setEscrowBalances(balanceMap)
 			} catch (error) {
-				console.error('Failed to fetch escrow balances', error)
+				logger.error('Failed to fetch escrow balances', error)
 			}
 		}
 

--- a/apps/web/components/sections/profile/views/donor-profile.tsx
+++ b/apps/web/components/sections/profile/views/donor-profile.tsx
@@ -23,6 +23,7 @@ import { getUserSupportedProjects } from '~/lib/queries/projects/get-user-projec
 import { ProfileSectionHeader } from '../profile-section-header'
 import { ProfileStatCard } from '../profile-stat-card'
 import { ProfileSurfaceCard } from '../profile-surface-card'
+import { logger } from '@/lib/logger'
 
 interface DonorProfileProps {
 	userId: string
@@ -77,7 +78,7 @@ export function DonorProfile({
 				})
 				setEscrowBalances(balanceMap)
 			} catch (error) {
-				console.error('Failed to fetch escrow balances', error)
+				logger.error('Failed to fetch escrow balances', error)
 			}
 		}
 

--- a/apps/web/components/sections/project/update/update-card.tsx
+++ b/apps/web/components/sections/project/update/update-card.tsx
@@ -19,6 +19,7 @@ import { Button } from '~/components/base/button'
 import { Card, CardContent } from '~/components/base/card'
 import { PLACEHOLDER_IMG } from '~/lib/constants/paths'
 import { UpdateForm } from './update-form'
+import { logger } from '@/lib/logger'
 
 // Define the Update type based on actual DB structure
 type Update = {
@@ -70,7 +71,7 @@ export function UpdateCard({
 			setIsDeleting(true)
 			await onDelete(deletingUpdateId)
 		} catch (error) {
-			console.error('Error deleting update:', error)
+			logger.error('Error deleting update:', error)
 		} finally {
 			setIsDeleting(false)
 			setDeletingUpdateId(null)

--- a/apps/web/components/sections/project/update/update-tab-section.tsx
+++ b/apps/web/components/sections/project/update/update-tab-section.tsx
@@ -7,6 +7,7 @@ import { Button } from '~/components/base/button'
 import { LoadMoreButton } from './load-more-button'
 import { UpdateCard } from './update-card'
 import { UpdateForm } from './update-form'
+import { logger } from '@/lib/logger'
 
 // Define types for project updates based on actual DB structure
 type ProjectUpdate = {
@@ -48,7 +49,7 @@ export function ProjectUpdatesTabSection() {
 				.range((page - 1) * pageSize, page * pageSize - 1)
 
 			if (error) {
-				console.error('Error fetching updates:', error)
+				logger.error('Error fetching updates:', error)
 				throw error
 			}
 
@@ -56,7 +57,7 @@ export function ProjectUpdatesTabSection() {
 				page === 1 ? data : [...prevUpdates, ...data],
 			)
 		} catch (err) {
-			console.error('Failed to fetch updates:', err)
+			logger.error('Failed to fetch updates:', err)
 			setError(
 				err instanceof Error ? err : new Error('Failed to fetch updates'),
 			)
@@ -87,7 +88,7 @@ export function ProjectUpdatesTabSection() {
 				.select()
 
 			if (error) {
-				console.error('Error creating update:', error)
+				logger.error('Error creating update:', error)
 				throw new Error(`Insert error: ${error.message}`)
 			}
 
@@ -96,7 +97,7 @@ export function ProjectUpdatesTabSection() {
 			await fetchUpdates()
 			setIsCreatingUpdate(false)
 		} catch (err) {
-			console.error('Error creating update:', err)
+			logger.error('Error creating update:', err)
 			alert(
 				`Failed to create update: ${err instanceof Error ? err.message : 'Unknown error'}`,
 			)
@@ -117,14 +118,14 @@ export function ProjectUpdatesTabSection() {
 				.eq('id', id)
 
 			if (error) {
-				console.error('Error updating update:', error)
+				logger.error('Error updating update:', error)
 				throw error
 			}
 
 			// Refetch updates after editing
 			await fetchUpdates()
 		} catch (err) {
-			console.error('Error updating update:', err)
+			logger.error('Error updating update:', err)
 			alert('Failed to update. Please try again.')
 		} finally {
 			setIsSubmitting(false)
@@ -142,7 +143,7 @@ export function ProjectUpdatesTabSection() {
 				.eq('id', id)
 
 			if (error) {
-				console.error('Error deleting update:', error)
+				logger.error('Error deleting update:', error)
 				throw error
 			}
 
@@ -150,7 +151,7 @@ export function ProjectUpdatesTabSection() {
 			await fetchUpdates()
 			return Promise.resolve()
 		} catch (err) {
-			console.error('Error deleting update:', err)
+			logger.error('Error deleting update:', err)
 			alert('Failed to delete update. Please try again.')
 			return Promise.reject(err)
 		}

--- a/apps/web/components/sections/projects/create/image-upload.tsx
+++ b/apps/web/components/sections/projects/create/image-upload.tsx
@@ -7,6 +7,7 @@ import { useDropzone } from 'react-dropzone'
 
 import { Button } from '~/components/base/button'
 import { cn } from '~/lib/utils'
+import { logger } from '@/lib/logger'
 
 interface ImageUploadProps {
 	value: File | string | null
@@ -25,7 +26,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
 				const reader = new FileReader()
 				reader.onload = () => setPreview(reader.result as string)
 				reader.onerror = () => {
-					console.error('Error reading file')
+					logger.error('Error reading file')
 					setPreview(null)
 				}
 				reader.readAsDataURL(file)
@@ -63,7 +64,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
 			const reader = new FileReader()
 			reader.onload = () => setPreview(reader.result as string)
 			reader.onerror = () => {
-				console.error('Error reading file')
+				logger.error('Error reading file')
 				setPreview(null)
 			}
 			reader.readAsDataURL(value)

--- a/apps/web/components/sections/projects/detail/like-button.tsx
+++ b/apps/web/components/sections/projects/detail/like-button.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { ThumbsUp } from 'lucide-react'
 import { useState } from 'react'
 import { Button } from '~/components/base/button'
+import { logger } from '@/lib/logger'
 
 interface LikeButtonProps {
     initialCount: number
@@ -31,7 +32,7 @@ export function LikeButton({ initialCount = 0, commentId, onLike }: LikeButtonPr
                 const likes = json.data?.metadata?.likes ?? count
                 setCount(likes)
             } catch (e) {
-                console.error('Failed to persist like', e)
+                logger.error('Failed to persist like', e)
             }
         }
 

--- a/apps/web/components/sections/projects/detail/project-sidebar.tsx
+++ b/apps/web/components/sections/projects/detail/project-sidebar.tsx
@@ -37,6 +37,7 @@ import type { ProjectDetail } from '~/lib/types/project/project-detail.types'
 import { cn } from '~/lib/utils'
 import { getContrastTextColor } from '~/lib/utils/color-utils'
 import { getStellarExplorerUrl } from '~/lib/utils/escrow/stellar-explorer'
+import { logger } from '@/lib/logger'
 
 interface ProjectSidebarProps {
 	project: ProjectDetail
@@ -122,7 +123,7 @@ export function ProjectSidebar({ project }: ProjectSidebarProps) {
                             body: JSON.stringify({ targetUserId: project.kindlerId, action }),
                     })
                     if (!res.ok) throw new Error('Follow request failed')
-			console.error(error)
+			logger.error(error)
 			toast.error('Unable to update follow status', {
 				icon: <CircleAlert className="text-destructive" />,
 			})
@@ -140,7 +141,7 @@ export function ProjectSidebar({ project }: ProjectSidebarProps) {
 			const first = balances?.[0]
 			if (first) setOnChainRaised(first.balance)
 		} catch (error) {
-			console.error('Failed to fetch escrow balance', error)
+			logger.error('Failed to fetch escrow balance', error)
 		} finally {
 			setIsFetchingBalance(false)
 		}
@@ -215,11 +216,11 @@ export function ProjectSidebar({ project }: ProjectSidebarProps) {
 
 					if (!response.ok) {
 						const errorData = await response.json()
-						console.error('Failed to create contribution:', errorData)
+						logger.error('Failed to create contribution:', errorData)
 						// Don't throw - donation succeeded on-chain, just log the error
 					}
 				} catch (error) {
-					console.error('Error creating contribution record:', error)
+					logger.error('Error creating contribution record:', error)
 					// Don't throw - donation succeeded on-chain
 				}
 			}
@@ -232,7 +233,7 @@ export function ProjectSidebar({ project }: ProjectSidebarProps) {
 			// 6) Refresh balance
 			fetchEscrowBalance()
 		} catch (error) {
-			console.error('Fund escrow error:', error)
+			logger.error('Fund escrow error:', error)
 
 			// Extract error message from various error formats
 			let errorMessage = ''

--- a/apps/web/components/sections/projects/detail/tabs/community-tab.tsx
+++ b/apps/web/components/sections/projects/detail/tabs/community-tab.tsx
@@ -7,6 +7,7 @@ import { Button } from '~/components/base/button'
 import { CommentForm } from '~/components/sections/projects/detail/comment-form'
 import { CommentThread } from '~/components/sections/projects/detail/comment-thread'
 import type { Comment } from '~/lib/types/project/project-detail.types'
+import { logger } from '@/lib/logger'
 
 interface CommunityTabProps {
 	comments: Comment[]
@@ -52,7 +53,7 @@ export function CommunityTab({ comments, projectId }: CommunityTabProps) {
 					    }
 				    }
 			    } catch (e) {
-				    console.error('Failed to persist question', e)
+				    logger.error('Failed to persist question', e)
 			    }
 		    })()
 
@@ -96,7 +97,7 @@ export function CommunityTab({ comments, projectId }: CommunityTabProps) {
 					    }
 				    }
 			    } catch (e) {
-				    console.error('Failed to persist answer', e)
+				    logger.error('Failed to persist answer', e)
 			    }
 		    })()
 

--- a/apps/web/components/sections/projects/detail/tabs/updates-tab.tsx
+++ b/apps/web/components/sections/projects/detail/tabs/updates-tab.tsx
@@ -10,6 +10,7 @@ import { CommentForm } from '~/components/sections/projects/detail/comment-form'
 import { CommentThread } from '~/components/sections/projects/detail/comment-thread'
 import { PLACEHOLDER_IMG } from '~/lib/constants/paths'
 import type { Comment, Update } from '~/lib/types/project/project-detail.types'
+import { logger } from '@/lib/logger'
 
 interface UpdatesTabProps {
 	updates: Update[]
@@ -82,7 +83,7 @@ export function UpdatesTab({ updates, projectId }: UpdatesTabProps) {
 					    }
 				    }
 			    } catch (e) {
-				    console.error('Failed to persist comment', e)
+				    logger.error('Failed to persist comment', e)
 			    }
 		    })()
 
@@ -146,7 +147,7 @@ export function UpdatesTab({ updates, projectId }: UpdatesTabProps) {
 					    }
 				    }
 			    } catch (e) {
-				    console.error('Failed to persist reply', e)
+				    logger.error('Failed to persist reply', e)
 			    }
 		    })()
 

--- a/apps/web/components/sections/projects/manage/escrow/tabs/fund-escrow-tab.tsx
+++ b/apps/web/components/sections/projects/manage/escrow/tabs/fund-escrow-tab.tsx
@@ -16,6 +16,7 @@ import { Input } from '~/components/base/input'
 import { Label } from '~/components/base/label'
 import { useEscrow } from '~/hooks/contexts/use-escrow.context'
 import { useTrustlessSigner } from '~/hooks/escrow/use-trustless-signer'
+import { logger } from '@/lib/logger'
 
 interface FundEscrowTabProps {
 	escrowContractAddress: string
@@ -92,7 +93,7 @@ export function FundEscrowTab({
 			setFundAmount('')
 			onSuccess()
 		} catch (error) {
-			console.error('Fund escrow error:', error)
+			logger.error('Fund escrow error:', error)
 
 			// Extract error message from various error formats
 			let errorMessage = ''

--- a/apps/web/components/sections/projects/manage/escrow/tabs/milestones-tab.tsx
+++ b/apps/web/components/sections/projects/manage/escrow/tabs/milestones-tab.tsx
@@ -28,6 +28,7 @@ import {
 import { useEscrow } from '~/hooks/contexts/use-escrow.context'
 import { useTrustlessSigner } from '~/hooks/escrow/use-trustless-signer'
 import {
+import { logger } from '@/lib/logger'
 	getMilestoneStatus,
 	isSingleReleaseMilestone,
 } from '~/lib/utils/escrow/milestone-utils'
@@ -87,7 +88,7 @@ export function MilestonesTab({
 			toast.success('Milestone approved successfully!')
 			onSuccess()
 		} catch (error) {
-			console.error(error)
+			logger.error(error)
 			const errorMessage =
 				error instanceof Error ? error.message : 'Failed to approve milestone'
 			toast.error(errorMessage)
@@ -131,7 +132,7 @@ export function MilestonesTab({
 			setMilestoneEvidence('')
 			onSuccess()
 		} catch (error) {
-			console.error(error)
+			logger.error(error)
 			const errorMessage =
 				error instanceof Error
 					? error.message

--- a/apps/web/components/sections/projects/manage/escrow/tabs/release-tab.tsx
+++ b/apps/web/components/sections/projects/manage/escrow/tabs/release-tab.tsx
@@ -26,6 +26,7 @@ import {
 } from '~/components/base/select'
 import { useEscrow } from '~/hooks/contexts/use-escrow.context'
 import { useTrustlessSigner } from '~/hooks/escrow/use-trustless-signer'
+import { logger } from '@/lib/logger'
 
 interface ReleaseTabProps {
 	escrowContractAddress: string
@@ -84,7 +85,7 @@ export function ReleaseTab({
 			toast.success('Funds released successfully!')
 			onSuccess()
 		} catch (error) {
-			console.error(error)
+			logger.error(error)
 			const errorMessage =
 				error instanceof Error ? error.message : 'Failed to release funds'
 			toast.error(errorMessage)

--- a/apps/web/components/sections/projects/members/add-team-member-form.tsx
+++ b/apps/web/components/sections/projects/members/add-team-member-form.tsx
@@ -25,6 +25,7 @@ import {
 import { Input } from '~/components/base/input'
 import { Textarea } from '~/components/base/textarea'
 import type { CreateTeamMemberData } from '~/lib/types/project/project-team.types'
+import { logger } from '@/lib/logger'
 
 interface AddTeamMemberFormProps {
 	onAdd: (data: CreateTeamMemberData) => Promise<void>
@@ -91,7 +92,7 @@ export function AddTeamMemberForm({
 			})
 			form.reset()
 		} catch (error) {
-			console.error('Failed to add team member:', error)
+			logger.error('Failed to add team member:', error)
 		} finally {
 			setIsSubmitting(false)
 		}

--- a/apps/web/components/sections/projects/members/invite-member-form.tsx
+++ b/apps/web/components/sections/projects/members/invite-member-form.tsx
@@ -26,6 +26,7 @@ import {
 import { Input } from '~/components/base/input'
 import type { InviteMemberData } from '~/lib/types/project/team-members.types'
 import { RoleSelect } from './role-select'
+import { logger } from '@/lib/logger'
 
 interface InviteMemberFormProps {
 	onInvite: (data: InviteMemberData) => Promise<void>
@@ -57,7 +58,7 @@ export function InviteMemberForm({
 			})
 			form.reset()
 		} catch (error) {
-			console.error('Failed to invite member:', error)
+			logger.error('Failed to invite member:', error)
 		} finally {
 			setIsSubmitting(false)
 		}

--- a/apps/web/components/shared/layout/header/mobile-navigation.tsx
+++ b/apps/web/components/shared/layout/header/mobile-navigation.tsx
@@ -14,6 +14,7 @@ import { useWallet } from '~/hooks/contexts/use-stellar-wallet.context'
 import { useI18n } from '~/lib/i18n/context'
 import { cn, getAvatarFallback } from '~/lib/utils'
 import { getStellarExplorerUrl } from '~/lib/utils/escrow/stellar-explorer'
+import { logger } from '@/lib/logger'
 
 const WalletCopyButton = ({
 	address,
@@ -154,21 +155,21 @@ export const MobileUserMenu = ({ user }: { user: User }) => {
 			try {
 				disconnect()
 			} catch (error) {
-				console.error('Error disconnecting wallet:', error)
+				logger.error('Error disconnecting wallet:', error)
 			}
 
 			try {
 				const supabase = createSupabaseBrowserClient()
 				await supabase.auth.signOut()
 			} catch (error) {
-				console.error('Error signing out from Supabase:', error)
+				logger.error('Error signing out from Supabase:', error)
 			}
 
 			await signOut({
 				callbackUrl: '/sign-in?success=Successfully signed out',
 			})
 		} catch (error) {
-			console.error('Error signing out:', error)
+			logger.error('Error signing out:', error)
 			toast.error(t('auth.signOutError'))
 			router.push('/')
 			setIsSigningOut(false)

--- a/apps/web/components/shared/layout/header/user-menu.tsx
+++ b/apps/web/components/shared/layout/header/user-menu.tsx
@@ -30,6 +30,7 @@ import { useWallet } from '~/hooks/contexts/use-stellar-wallet.context'
 import { useI18n } from '~/lib/i18n/context'
 import { getAvatarFallback } from '~/lib/utils'
 import { getStellarExplorerUrl } from '~/lib/utils/escrow/stellar-explorer'
+import { logger } from '@/lib/logger'
 
 const WalletAddressSection = ({
 	address,
@@ -51,7 +52,7 @@ const WalletAddressSection = ({
 			toast.success('Wallet address copied to clipboard')
 			setTimeout(() => setCopied(false), 2000)
 		} catch (error) {
-			console.error('Failed to copy address:', error)
+			logger.error('Failed to copy address:', error)
 			toast.error('Failed to copy address')
 		}
 	}
@@ -112,21 +113,21 @@ export const UserMenu = ({ user }: { user: User }) => {
 			try {
 				disconnect()
 			} catch (error) {
-				console.error('Error disconnecting wallet:', error)
+				logger.error('Error disconnecting wallet:', error)
 			}
 
 			try {
 				const supabase = createSupabaseBrowserClient()
 				await supabase.auth.signOut()
 			} catch (error) {
-				console.error('Error signing out from Supabase:', error)
+				logger.error('Error signing out from Supabase:', error)
 			}
 
 			await signOut({
 				callbackUrl: '/sign-in?success=Successfully signed out',
 			})
 		} catch (error) {
-			console.error('Error signing out:', error)
+			logger.error('Error signing out:', error)
 			toast.error(t('auth.signOutError'))
 			router.push('/')
 			setIsSigningOut(false)

--- a/apps/web/components/shared/layout/providers.tsx
+++ b/apps/web/components/shared/layout/providers.tsx
@@ -13,6 +13,7 @@ import { WaitlistProvider } from '~/hooks/contexts/use-waitlist.context'
 import { AuthProvider } from '~/hooks/use-auth'
 import { I18nProvider } from '~/lib/i18n/context'
 import { translations } from '~/lib/i18n/translations'
+import { logger } from '@/lib/logger'
 
 interface ProvidersProps {
 	children: React.ReactNode
@@ -51,15 +52,15 @@ export function Providers({ children, initSession }: ProvidersProps) {
 							// 		minInterval: 24 * 60 * 60 * 1000, // 24 hours
 							// 	})
 							// 	.catch((error) => {
-							// 		console.error('Periodic sync registration failed:', error)
+
 							// 	})
 						}
 					} catch (error) {
-						console.error('Periodic sync not supported:', error)
+						logger.error('Periodic sync not supported:', error)
 					}
 				})
 				.catch((error) => {
-					console.error('Service worker registration failed:', error)
+					logger.error('Service worker registration failed:', error)
 				})
 		}
 	}, [])

--- a/apps/web/components/shared/qa-client.tsx
+++ b/apps/web/components/shared/qa-client.tsx
@@ -28,6 +28,7 @@ import type {
 	QAClientProps,
 } from '~/lib/types/project/project-qa.types'
 import {
+import { logger } from '@/lib/logger'
 	buildQuestionThreads,
 	getGuestRemainingComments as utilGetGuestRemainingComments,
 	getGuestUserId as utilGetGuestUserId,
@@ -110,14 +111,14 @@ export default function QAClient({
 				if (error) throw error
 
 				if (!data || !data.length) {
-					console.warn('No questions found for this project')
+					logger.warn('No questions found for this project')
 					return []
 				}
 
 				const mapped = await fetchQuestions(supabase, projectId)
 				return mapped
 			} catch (err) {
-				console.error('Error fetching questions:', err)
+				logger.error('Error fetching questions:', err)
 				return []
 			}
 		},
@@ -134,12 +135,12 @@ export default function QAClient({
 			try {
 				const data = await fetchChildComments(supabase, projectId)
 				if (!data || data.length === 0) {
-					console.warn('No comments found for this project')
+					logger.warn('No comments found for this project')
 					return []
 				}
 				return data
 			} catch (err) {
-				console.error('Error fetching comments:', err)
+				logger.error('Error fetching comments:', err)
 				return []
 			}
 		},
@@ -156,7 +157,7 @@ export default function QAClient({
 			const threads = buildQuestionThreads(questions, commentsData)
 			setProcessedQuestions(threads)
 		} catch (err) {
-			console.error('Error processing comments:', err)
+			logger.error('Error processing comments:', err)
 		}
 	}, [questions, commentsData])
 
@@ -356,7 +357,7 @@ export default function QAClient({
 			setTimeout(() => setRealtimeStatus(null), 3000)
 		},
 		onError: (error) => {
-			console.error('Error submitting question:', error)
+			logger.error('Error submitting question:', error)
 			setRealtimeStatus(
 				`Error: ${error instanceof Error ? error.message : String(error)}`,
 			)
@@ -409,7 +410,7 @@ export default function QAClient({
 			setTimeout(() => setRealtimeStatus(null), 3000)
 		},
 		onError: (error) => {
-			console.error('Error submitting answer:', error)
+			logger.error('Error submitting answer:', error)
 			setRealtimeStatus(
 				`Error: ${error instanceof Error ? error.message : String(error)}`,
 			)
@@ -456,7 +457,7 @@ export default function QAClient({
 			setTimeout(() => setRealtimeStatus(null), 3000)
 		},
 		onError: (error) => {
-			console.error('Error submitting reply:', error)
+			logger.error('Error submitting reply:', error)
 			setRealtimeStatus(
 				`Error: ${error instanceof Error ? error.message : String(error)}`,
 			)
@@ -507,7 +508,7 @@ export default function QAClient({
 			setTimeout(() => setRealtimeStatus(null), 3000)
 		},
 		onError: (error) => {
-			console.error('Error marking as resolved:', error)
+			logger.error('Error marking as resolved:', error)
 			setRealtimeStatus(
 				`Error: ${error instanceof Error ? error.message : String(error)}`,
 			)

--- a/apps/web/components/shared/smart-wallet-transfer-demo.tsx
+++ b/apps/web/components/shared/smart-wallet-transfer-demo.tsx
@@ -16,6 +16,7 @@ import {
 } from '~/components/base/card'
 import { Input } from '~/components/base/input'
 import { ErrorCode, InAppError } from '~/lib/passkey/errors'
+import { logger } from '@/lib/logger'
 
 interface TransferFormData {
 	to: string
@@ -82,7 +83,7 @@ export function SmartWalletTransferDemo() {
 				duration: 5000,
 			})
 		} catch (error) {
-			console.error('Error approving account:', error)
+			logger.error('Error approving account:', error)
 			toast.error(
 				error instanceof Error ? error.message : 'Failed to approve account',
 			)
@@ -126,7 +127,7 @@ export function SmartWalletTransferDemo() {
 			// Refresh balance after funding
 			await fetchBalance()
 		} catch (error) {
-			console.error('Error funding wallet:', error)
+			logger.error('Error funding wallet:', error)
 			toast.error(
 				error instanceof Error ? error.message : 'Failed to fund wallet',
 			)
@@ -153,7 +154,7 @@ export function SmartWalletTransferDemo() {
 			setBalance(data.data.xlm.balance)
 			toast.success(`Balance: ${data.data.xlm.balance} XLM`)
 		} catch (error) {
-			console.error('Error fetching balance:', error)
+			logger.error('Error fetching balance:', error)
 			toast.error('Failed to fetch balance')
 		} finally {
 			setIsLoading(false)
@@ -301,7 +302,7 @@ export function SmartWalletTransferDemo() {
 			// Refresh balance
 			await fetchBalance()
 		} catch (error) {
-			console.error('Error preparing transfer:', error)
+			logger.error('Error preparing transfer:', error)
 
 			if (error instanceof Error) {
 				if (error.message.includes('NotAllowedError')) {

--- a/apps/web/hooks/contexts/use-stellar-wallet.context.tsx
+++ b/apps/web/hooks/contexts/use-stellar-wallet.context.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useRef, useState } from 'react'
 import { getStellarWalletTheme } from '~/lib/config/stellar-wallet-theme'
 import {
+import { logger } from '@/lib/logger'
 	getTrustlessSignerError,
 	isExternalStellarWalletAddress,
 } from '~/lib/utils/escrow/trustless-signer'
@@ -72,7 +73,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 
 				const storage = globalThis.localStorage
 				if (typeof storage?.getItem !== 'function') {
-					console.error(
+					logger.error(
 						'StellarWalletsKit requires browser localStorage. Check NODE_OPTIONS for a broken --localstorage-file flag.',
 					)
 					return
@@ -186,7 +187,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 					unsubscribeWalletSelected,
 				]
 			} catch (error) {
-				console.error('❌ Failed to initialize StellarWalletsKit:', error)
+				logger.error('❌ Failed to initialize StellarWalletsKit:', error)
 				setIsInitialized(false)
 			}
 		})()
@@ -226,7 +227,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 				// This might need adjustment based on actual API behavior
 			}
 		} catch (error) {
-			console.error('❌ Failed to connect wallet:', error)
+			logger.error('❌ Failed to connect wallet:', error)
 			// Re-throw with more context
 			if (error && typeof error === 'object' && 'message' in error) {
 				throw new Error(`Wallet connection failed: ${error.message}`)
@@ -245,7 +246,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 			localStorage.removeItem('stellar_wallet_address')
 			localStorage.removeItem('stellar_wallet_name')
 		} catch (error) {
-			console.error('Failed to disconnect wallet:', error)
+			logger.error('Failed to disconnect wallet:', error)
 		}
 	}
 
@@ -273,7 +274,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 			)
 			return signedTxXdr
 		} catch (error) {
-			console.error('Failed to sign transaction:', error)
+			logger.error('Failed to sign transaction:', error)
 			throw error
 		}
 	}

--- a/apps/web/hooks/escrow/use-escrow-data.ts
+++ b/apps/web/hooks/escrow/use-escrow-data.ts
@@ -7,6 +7,7 @@ import type {
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { useEscrow } from '~/hooks/contexts/use-escrow.context'
+import { logger } from '@/lib/logger'
 
 interface UseEscrowDataParams {
 	escrowContractAddress: string
@@ -91,7 +92,7 @@ export function useEscrowData({
 
 			setEscrowData(processedEscrowData)
 		} catch (err) {
-			console.error('Failed to fetch escrow data:', err)
+			logger.error('Failed to fetch escrow data:', err)
 			const errorMessage =
 				err instanceof Error ? err.message : 'Failed to load escrow data'
 			setError(errorMessage)

--- a/apps/web/hooks/passkey/use-passkey-authentication.ts
+++ b/apps/web/hooks/passkey/use-passkey-authentication.ts
@@ -8,6 +8,7 @@ import { toast } from 'sonner'
 import { createSessionAction } from '~/app/actions/auth'
 import { ErrorCode, InAppError } from '~/lib/passkey/errors'
 import type { PresignResponse, SignParams } from '~/lib/types'
+import { logger } from '@/lib/logger'
 
 export const usePasskeyAuthentication = (
 	identifier: string,
@@ -141,7 +142,7 @@ export const usePasskeyAuthentication = (
 				credentialId: verificationJSON.device.id,
 				address: verificationJSON.device.address,
 			}).catch((error) => {
-				console.error('Error during signIn:', error)
+				logger.error('Error during signIn:', error)
 				throw new InAppError(ErrorCode.UNEXPECTED_ERROR, error.message)
 			})
 
@@ -151,7 +152,7 @@ export const usePasskeyAuthentication = (
 			toast.success(message)
 			success = Boolean(loginResult?.ok)
 		} catch (_error) {
-			console.error('🔴 Error during passkey authentication:', _error)
+			logger.error('🔴 Error during passkey authentication:', _error)
 			const error = _error as Error
 			let message = error.toString()
 			if (

--- a/apps/web/hooks/passkey/use-passkey-registration.ts
+++ b/apps/web/hooks/passkey/use-passkey-registration.ts
@@ -7,6 +7,7 @@ import {
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { ErrorCode, InAppError } from '~/lib/passkey/errors'
+import { logger } from '@/lib/logger'
 
 export const usePasskeyRegistration = (
 	identifier: string,
@@ -143,7 +144,7 @@ export const usePasskeyRegistration = (
 						// Call the onRegister callback for any additional processing (without blockchain deployment)
 						await onRegister(registrationResponse, userId as string)
 					} catch (stellarError) {
-						console.warn('Failed to extract stellar data:', stellarError)
+						logger.warn('Failed to extract stellar data:', stellarError)
 					}
 				}
 				const message = 'Authenticator registered!'

--- a/apps/web/hooks/passkey/use-smart-account-auth.ts
+++ b/apps/web/hooks/passkey/use-smart-account-auth.ts
@@ -9,6 +9,7 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 import { createSessionAction } from '~/app/actions/auth'
 import { ErrorCode, InAppError } from '~/lib/passkey/errors'
+import { logger } from '@/lib/logger'
 
 const mapPasskeyApiError = (errorMessage: string): InAppError => {
 	if (errorMessage === 'User not found') {
@@ -185,7 +186,7 @@ export const useSmartAccountAuth = (identifier: string) => {
 				return { verified: false }
 			}
 
-			console.error('Error during Smart Account authentication:', err)
+			logger.error('Error during Smart Account authentication:', err)
 
 			const message =
 				err.code === ErrorCode.AUTHENTICATOR_NOT_REGISTERED

--- a/apps/web/hooks/passkey/use-smart-account-registration.ts
+++ b/apps/web/hooks/passkey/use-smart-account-registration.ts
@@ -6,6 +6,7 @@ import { startRegistration } from '@simplewebauthn/browser'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { ErrorCode, InAppError } from '~/lib/passkey/errors'
+import { logger } from '@/lib/logger'
 
 /**
  * Hook for Smart Account registration using WebAuthn passkeys
@@ -114,7 +115,7 @@ export const useSmartAccountRegistration = (
 					// Passkey registered but Smart Account creation failed
 					const warning =
 						verificationJSON.warning || 'Smart Account creation failed'
-					console.warn('⚠️ Smart Account creation failed:', warning)
+					logger.warn('⚠️ Smart Account creation failed:', warning)
 					setRegSuccess('Passkey registered successfully')
 					setSmartAccountAddress(null)
 					toast.warning(warning)

--- a/apps/web/hooks/projects/use-pitch-analysis.ts
+++ b/apps/web/hooks/projects/use-pitch-analysis.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useRef, useState } from 'react'
+import { logger } from '@/lib/logger'
 
 export type AnalysisStatus = 'idle' | 'loading' | 'streaming' | 'done' | 'error'
 
@@ -60,7 +61,7 @@ export const usePitchAnalysis = (): UsePitchAnalysisReturn => {
 			setStatus('done')
 		} catch (err) {
 			if ((err as Error).name === 'AbortError') return
-			console.error('[usePitchAnalysis]', err)
+			logger.error('[usePitchAnalysis]', err)
 			setStatus('error')
 		}
 	}, [])

--- a/apps/web/hooks/stellar/use-stellar.ts
+++ b/apps/web/hooks/stellar/use-stellar.ts
@@ -56,7 +56,7 @@ export const useStellar = () => {
 			}
 		},
 		onError: (error) => {
-			console.error('❌ Transaction failed:', error)
+			logger.error('❌ Transaction failed:', error)
 		},
 	})
 
@@ -91,7 +91,7 @@ export const useStellar = () => {
 
 			return deployee
 		} catch (error) {
-			console.error('❌ useStellar::onRegister::>', error)
+			logger.error('❌ useStellar::onRegister::>', error)
 		} finally {
 			setLoadingRegister(false)
 			setCreatingDeployee(false)
@@ -114,7 +114,7 @@ export const useStellar = () => {
 			// if (!deployee) throw new Error('Deployee not found')
 			setContractData({})
 		} catch (error) {
-			console.error(error)
+			logger.error(error)
 		} finally {
 			setLoadingSign(false)
 		}
@@ -144,7 +144,7 @@ export const useStellar = () => {
 					setDeployee(storedDeployee)
 				}
 			} catch (error) {
-				console.error(error)
+				logger.error(error)
 			} finally {
 				setLoadingDeployee(false)
 			}

--- a/apps/web/hooks/use-auth.tsx
+++ b/apps/web/hooks/use-auth.tsx
@@ -9,6 +9,7 @@ import type {
 import type { Session, User } from 'next-auth'
 import { useSession } from 'next-auth/react'
 import { createContext, useContext, useEffect, useState } from 'react'
+import { logger } from '@/lib/logger'
 
 interface AuthContextType {
 	isSupabaseUserLoading: boolean
@@ -57,7 +58,7 @@ export function AuthProvider({
 				} = await supabase.auth.getSession()
 				setSupabaseUser(supabaseSession?.user)
 			} catch (error) {
-				console.error('Auth check failed:', error)
+				logger.error('Auth check failed:', error)
 				setSupabaseUser(undefined)
 			} finally {
 				setIsSupabaseUserLoading(false)

--- a/apps/web/hooks/use-didit-kyc.ts
+++ b/apps/web/hooks/use-didit-kyc.ts
@@ -1,6 +1,7 @@
 // hooks/use-didit-kyc.ts
 
 import { useCallback, useEffect, useState } from 'react'
+import { logger } from '@/lib/logger'
 
 interface KYCStatus {
 	status: 'pending' | 'approved' | 'rejected' | 'verified' | null
@@ -43,7 +44,7 @@ export function useDiditKYC(userId: string) {
 				error: null,
 			})
 		} catch (error) {
-			console.error('❌ Failed to load KYC status:', error)
+			logger.error('❌ Failed to load KYC status:', error)
 			setKycStatus({
 				status: null,
 				isLoading: false,
@@ -103,7 +104,7 @@ export function useDiditKYC(userId: string) {
 
 			return result
 		} catch (error) {
-			console.error('Failed to check status from Didit:', error)
+			logger.error('Failed to check status from Didit:', error)
 			// Fallback to loading from database
 			await loadKYCStatus()
 			return {

--- a/apps/web/lib/auth/auth-options.ts
+++ b/apps/web/lib/auth/auth-options.ts
@@ -5,6 +5,7 @@ import jwt from 'jsonwebtoken'
 import type { NextAuthOptions, User } from 'next-auth'
 import { KindfiSupabaseAdapter } from '~/auth/kindfi-supabase-adapter'
 import { kindfiWebAuthnProvider } from '~/auth/kindfi-webauthn.provider'
+import { logger } from '@/lib/logger'
 
 const appConfig: AppEnvInterface = appEnvConfig('web')
 
@@ -60,7 +61,7 @@ export const nextAuthOption: NextAuthOptions = {
 		},
 		async session({ session, token }) {
 			if (!token) {
-				console.error('❌ No token found in session callback')
+				logger.error('❌ No token found in session callback')
 				return session
 			}
 

--- a/apps/web/lib/auth/clientauth-error-handler.ts
+++ b/apps/web/lib/auth/clientauth-error-handler.ts
@@ -1,6 +1,7 @@
 import type { AuthError } from '@supabase/supabase-js'
 import { ERROR_MESSAGES } from '../constants/error'
 import type { AuthResponse } from '../types/auth'
+import { logger } from '@/lib/logger'
 
 export function handleClientAuthError(error: AuthError): AuthResponse {
 	const errorKey = Object.keys(ERROR_MESSAGES).find((key) =>
@@ -11,7 +12,7 @@ export function handleClientAuthError(error: AuthError): AuthResponse {
 		? ERROR_MESSAGES[errorKey]
 		: error.message || 'An unknown error occurred'
 
-	console.error('[Auth Error]', {
+	logger.error('[Auth Error]', {
 		eventType: 'AUTH_ERROR',
 		action: 'client_side_auth',
 		timestamp: new Date().toISOString(),

--- a/apps/web/lib/auth/rate-limiter.ts
+++ b/apps/web/lib/auth/rate-limiter.ts
@@ -1,5 +1,6 @@
 import { Redis } from '@upstash/redis'
 import { AuthErrorType } from '../types/auth'
+import { logger } from '@/lib/logger'
 
 const RATE_LIMIT_ATTEMPTS = 5
 const RATE_LIMIT_WINDOW = 60 * 15 // 15 minutes in seconds
@@ -13,7 +14,7 @@ function getRedis(): Redis | null {
 		redis = Redis.fromEnv()
 		return redis
 	} catch (err) {
-		console.warn(
+		logger.warn(
 			'[RateLimiter] Failed to initialize Redis — rate limiting disabled:',
 			err,
 		)
@@ -56,7 +57,7 @@ export class RateLimiter {
 			const isBlocked = await client.exists(blockKey)
 			return isBlocked === 1
 		} catch (err) {
-			console.warn(
+			logger.warn(
 				'[RateLimiter] Redis error in isBlocked — failing open:',
 				err,
 			)
@@ -115,7 +116,7 @@ export class RateLimiter {
 				attemptsRemaining: this.maxAttempts - attempts,
 			}
 		} catch (err) {
-			console.warn(
+			logger.warn(
 				'[RateLimiter] Redis error in increment — failing open:',
 				err,
 			)
@@ -136,7 +137,7 @@ export class RateLimiter {
 			const blockKey = this.getBlockKey(identifier, action)
 			await Promise.all([client.del(key), client.del(blockKey)])
 		} catch (err) {
-			console.warn('[RateLimiter] Redis error in reset — failing open:', err)
+			logger.warn('[RateLimiter] Redis error in reset — failing open:', err)
 		}
 	}
 }

--- a/apps/web/lib/email/email-notification-service.tsx
+++ b/apps/web/lib/email/email-notification-service.tsx
@@ -9,6 +9,7 @@ import { FundsReleasedEmail } from './templates/funds-released-email'
 import { MilestoneApprovedEmail } from './templates/milestone-approved-email'
 import { NewProjectEmail } from './templates/new-project-email'
 import { WelcomeNewUserEmail } from './templates/welcome-new-user-email'
+import { logger } from '@/lib/logger'
 
 const appConfig = appEnvConfig('web')
 
@@ -52,12 +53,12 @@ async function sendEmail({
 		})
 
 		if (error) {
-			console.error('[EmailNotificationService] Resend error:', error)
+			logger.error('[EmailNotificationService] Resend error:', error)
 			return { success: false, error: error.message }
 		}
 		return { success: true }
 	} catch (err) {
-		console.error('[EmailNotificationService] Send failed:', err)
+		logger.error('[EmailNotificationService] Send failed:', err)
 		return {
 			success: false,
 			error: err instanceof Error ? err.message : 'Unknown error',
@@ -84,10 +85,10 @@ async function createInAppNotification({
 			type,
 		})
 		if (error) {
-			console.error('[EmailNotificationService] In-app notification failed:', error)
+			logger.error('[EmailNotificationService] In-app notification failed:', error)
 		}
 	} catch (err) {
-		console.error('[EmailNotificationService] In-app notification error:', err)
+		logger.error('[EmailNotificationService] In-app notification error:', err)
 	}
 }
 

--- a/apps/web/lib/logger.ts
+++ b/apps/web/lib/logger.ts
@@ -1,5 +1,21 @@
+/**
+ * KindFi Web App — structured logger.
+ *
+ * Keeps the existing ILogger / Logger class for audit-logger compatibility,
+ * and adds a `logger` singleton that matches the @packages/lib/logger API
+ * so that all api-route / hook code can use a consistent interface.
+ *
+ * Production behaviour:
+ *   - debug / info are no-ops (silenced)
+ *   - warn / error are forwarded to console (necessary for server log ingestion)
+ *   - Sensitive field names are redacted before logging
+ */
+
 import type { ILogger, LoggerData } from './types/logger.types'
 
+// ---------------------------------------------------------------------------
+// ILogger-compatible class (used by audit-logger.ts etc.)
+// ---------------------------------------------------------------------------
 type LogLevel = LoggerData['LogLevel']
 type LogData = LoggerData['LogData']
 
@@ -35,13 +51,7 @@ export class Logger implements ILogger {
 			const jsonData = JSON.stringify(logData, null, 2)
 			logMethod(prefix, eventType, '\n', jsonData)
 		} catch (error) {
-			console.error(`Error stringifying log data: ${error}`)
-			logMethod(
-				prefix,
-				data.eventType,
-				'\n',
-				'Error: Unable to stringify log data',
-			)
+			logMethod(prefix, data.eventType, '\n', 'Error: Unable to stringify log data')
 		}
 	}
 
@@ -57,3 +67,96 @@ export class Logger implements ILogger {
 		this.log('info', data)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Lightweight `logger` singleton — used by api routes, hooks, services
+// ---------------------------------------------------------------------------
+const isDev =
+	typeof process !== 'undefined'
+		? process.env.NODE_ENV !== 'production'
+		: false
+
+const SENSITIVE_KEY_PATTERN =
+	/secret|token|key|password|auth|credential|passphrase|seed/i
+
+function sanitise(data?: Record<string, unknown>): Record<string, unknown> {
+	if (!data) return {}
+	return Object.fromEntries(
+		Object.entries(data).map(([k, v]) => [
+			k,
+			SENSITIVE_KEY_PATTERN.test(k) ? '[REDACTED]' : v,
+		]),
+	)
+}
+
+function fmt(level: string, message: string): string {
+	return `[${level.toUpperCase()}] ${new Date().toISOString()} | ${message}`
+}
+
+export interface KindFiLogger {
+	debug(message: string, data?: Record<string, unknown>): void
+	info(message: string, data?: Record<string, unknown>): void
+	warn(
+		message: string,
+		errorOrData?: unknown,
+		data?: Record<string, unknown>,
+	): void
+	error(
+		message: string,
+		errorOrData?: unknown,
+		data?: Record<string, unknown>,
+	): void
+}
+
+function buildLogger(): KindFiLogger {
+	return {
+		debug(message, data) {
+			if (!isDev) return
+			// biome-ignore lint/suspicious/noConsole: logger internals intentionally use console
+			console.debug(fmt('debug', message), sanitise(data))
+		},
+
+		info(message, data) {
+			if (!isDev) return
+			// biome-ignore lint/suspicious/noConsole: logger internals intentionally use console
+			console.info(fmt('info', message), sanitise(data))
+		},
+
+		warn(message, errorOrData, data) {
+			const formatted = fmt('warn', message)
+			if (errorOrData instanceof Error) {
+				const errInfo = isDev
+					? { message: errorOrData.message, stack: errorOrData.stack }
+					: { message: errorOrData.message }
+				// biome-ignore lint/suspicious/noConsole: logger internals intentionally use console
+				console.warn(formatted, errInfo, sanitise(data))
+			} else {
+				// biome-ignore lint/suspicious/noConsole: logger internals intentionally use console
+				console.warn(
+					formatted,
+					sanitise(errorOrData as Record<string, unknown>),
+				)
+			}
+		},
+
+		error(message, errorOrData, data) {
+			const formatted = fmt('error', message)
+			if (errorOrData instanceof Error) {
+				const errInfo = isDev
+					? { message: errorOrData.message, stack: errorOrData.stack }
+					: { message: errorOrData.message }
+				// biome-ignore lint/suspicious/noConsole: logger internals intentionally use console
+				console.error(formatted, errInfo, sanitise(data))
+			} else {
+				// biome-ignore lint/suspicious/noConsole: logger internals intentionally use console
+				console.error(
+					formatted,
+					sanitise(errorOrData as Record<string, unknown>),
+				)
+			}
+		},
+	}
+}
+
+export const logger: KindFiLogger = buildLogger()
+

--- a/apps/web/lib/middleware/rate-limit.ts
+++ b/apps/web/lib/middleware/rate-limit.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { RateLimiter } from '~/lib/auth/rate-limiter'
+import { logger } from '@/lib/logger'
 
 export const RATE_LIMIT_PRESETS = {
 	strict: { attempts: 3, window: 60, block: 3600 }, // Financial operations
@@ -42,7 +43,7 @@ export function withRateLimit(
 				)
 			}
 		} catch (err) {
-			console.warn('[RateLimit] Redis unavailable, failing open:', err)
+			logger.warn('[RateLimit] Redis unavailable, failing open:', err)
 		}
 
 		return handler(req)

--- a/apps/web/lib/passkey/rp-id-helper.ts
+++ b/apps/web/lib/passkey/rp-id-helper.ts
@@ -1,5 +1,6 @@
 import { appEnvConfig } from '@packages/lib/config'
 import type { AppEnvInterface } from '@packages/lib/types'
+import { logger } from '@/lib/logger'
 
 /**
  * Get the appropriate RP ID based on the origin
@@ -29,7 +30,7 @@ export function getRpIdFromOrigin(origin: string): string {
 		return rpId
 	} catch {
 		// Invalid URL, fall back to first configured RP ID
-		console.warn(
+		logger.warn(
 			`⚠️ Invalid origin format: ${origin}. Using first configured RP ID.`,
 		)
 		return rpIds[0] || 'localhost'

--- a/apps/web/lib/queries/escrow/get-escrow-count-by-project.ts
+++ b/apps/web/lib/queries/escrow/get-escrow-count-by-project.ts
@@ -1,4 +1,5 @@
 import type { TypedSupabaseClient } from '@packages/lib/types'
+import { logger } from '@/lib/logger'
 
 /**
  * Get the count of existing escrows for a project.
@@ -14,7 +15,7 @@ export async function getEscrowCountByProject(
 		.eq('project_id', projectId)
 
 	if (error) {
-		console.error('Error counting escrows:', error)
+		logger.error('Error counting escrows:', error)
 		// Return 0 on error to default to 1 for the first escrow
 		return 0
 	}

--- a/apps/web/lib/queries/foundations/get-foundation-by-slug.ts
+++ b/apps/web/lib/queries/foundations/get-foundation-by-slug.ts
@@ -1,4 +1,5 @@
 import type { TypedSupabaseClient } from '@packages/lib/types'
+import { logger } from '@/lib/logger'
 
 export async function getFoundationBySlug(
 	client: TypedSupabaseClient,
@@ -40,7 +41,7 @@ export async function getFoundationBySlug(
 		.maybeSingle()
 
 	if (error) {
-		console.error('Error fetching foundation by slug:', error)
+		logger.error('Error fetching foundation by slug:', error)
 		throw error
 	}
 

--- a/apps/web/lib/queries/foundations/get-foundation-manage-meta.ts
+++ b/apps/web/lib/queries/foundations/get-foundation-manage-meta.ts
@@ -1,4 +1,5 @@
 import type { TypedSupabaseClient } from '@packages/lib/types'
+import { logger } from '@/lib/logger'
 
 export interface FoundationManageMeta {
 	id: string
@@ -21,7 +22,7 @@ export async function getFoundationManageMeta(
 		.maybeSingle()
 
 	if (error) {
-		console.error('Error fetching foundation meta:', error)
+		logger.error('Error fetching foundation meta:', error)
 		throw error
 	}
 

--- a/apps/web/lib/queries/projects/get-project-team-by-slug.ts
+++ b/apps/web/lib/queries/projects/get-project-team-by-slug.ts
@@ -1,5 +1,6 @@
 import type { TypedSupabaseClient } from '@packages/lib/types'
 import type { ProjectTeamMember } from '~/lib/types/project/project-team.types'
+import { logger } from '@/lib/logger'
 
 export async function getProjectTeamBySlug(
 	client: TypedSupabaseClient,
@@ -30,7 +31,7 @@ export async function getProjectTeamBySlug(
 			teamError.message?.includes('relation') ||
 			teamError.code === '42P01'
 		) {
-			console.warn(
+			logger.warn(
 				'project_team table does not exist yet. Please run the migration.',
 			)
 			return {

--- a/apps/web/lib/queries/projects/get-project-team.ts
+++ b/apps/web/lib/queries/projects/get-project-team.ts
@@ -1,5 +1,6 @@
 import type { TypedSupabaseClient } from '@packages/lib/types'
 import type { TeamMember } from '~/lib/types/project/project-detail.types'
+import { logger } from '@/lib/logger'
 
 export async function getProjectTeam(
 	client: TypedSupabaseClient,
@@ -19,7 +20,7 @@ export async function getProjectTeam(
 			error.message?.includes('relation') ||
 			error.code === '42P01'
 		) {
-			console.warn('project_team table not found')
+			logger.warn('project_team table not found')
 			return []
 		}
 		throw error

--- a/apps/web/lib/services/audit-logger.ts
+++ b/apps/web/lib/services/audit-logger.ts
@@ -1,4 +1,5 @@
 import { createSupabaseBrowserClient } from '@packages/lib/supabase-client'
+import { logger } from '@/lib/logger'
 
 // audit_logs table is not in generated Supabase types
 const AUDIT_LOGS_TABLE = 'audit_logs' as const
@@ -100,7 +101,7 @@ export class AuditLogger {
 			if (error) throw error
 		} catch (dbError) {
 			// eslint-disable-next-line no-console -- last-resort fallback: AuditLogger itself failed, no other logging mechanism available
-			console.error('[AuditLogger] Failed to persist audit log:', dbError)
+			logger.error('[AuditLogger] Failed to persist audit log:', dbError)
 			// Don't throw to avoid disrupting the main flow
 		}
 	}

--- a/apps/web/lib/services/notification-logger.server.ts
+++ b/apps/web/lib/services/notification-logger.server.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@packages/lib/supabase'
+import { logger } from '@/lib/logger'
 
 const NOTIFICATION_LOGS_TABLE = 'notification_logs' as const
 
@@ -81,7 +82,7 @@ export class NotificationLogger {
 
 			if (dbError) throw dbError
 		} catch (logError) {
-			console.error(
+			logger.error(
 				'[NotificationLogger] Failed to log error:',
 				serializeLogError(logError),
 			)
@@ -103,7 +104,7 @@ export class NotificationLogger {
 
 			if (error) throw error
 		} catch (logError) {
-			console.error(
+			logger.error(
 				'[NotificationLogger] Failed to log info:',
 				serializeLogError(logError),
 			)
@@ -125,7 +126,7 @@ export class NotificationLogger {
 
 			if (error) throw error
 		} catch (logError) {
-			console.error(
+			logger.error(
 				'[NotificationLogger] Failed to log warning:',
 				serializeLogError(logError),
 			)
@@ -145,7 +146,7 @@ export class NotificationLogger {
 			if (error) throw error
 			return data || []
 		} catch (error) {
-			console.error('[NotificationLogger] Failed to get notification logs:', error)
+			logger.error('[NotificationLogger] Failed to get notification logs:', error)
 			return []
 		}
 	}
@@ -162,7 +163,7 @@ export class NotificationLogger {
 			if (error) throw error
 			return data || []
 		} catch (error) {
-			console.error('[NotificationLogger] Failed to get error logs:', error)
+			logger.error('[NotificationLogger] Failed to get error logs:', error)
 			return []
 		}
 	}

--- a/apps/web/lib/services/notification-service.ts
+++ b/apps/web/lib/services/notification-service.ts
@@ -10,6 +10,7 @@ import type {
 } from '../types/notification'
 import { notificationTypeToCategory } from '../types/notification'
 import { NotificationLogger } from './notification-logger'
+import { logger } from '@/lib/logger'
 
 type DbNotificationRow = {
 	id: string
@@ -309,7 +310,7 @@ export class NotificationService {
 			if (error) throw error
 			return true
 		} catch (error) {
-			console.error('Failed to mark notification as read:', error)
+			logger.error('Failed to mark notification as read:', error)
 			return false
 		}
 	}
@@ -330,7 +331,7 @@ export class NotificationService {
 			if (error) throw error
 			return true
 		} catch (error) {
-			console.error('Failed to mark all notifications as read:', error)
+			logger.error('Failed to mark all notifications as read:', error)
 			return false
 		}
 	}
@@ -354,7 +355,7 @@ export class NotificationService {
 				mapDbRowToBaseNotification(row as DbNotificationRow),
 			)
 		} catch (error) {
-			console.error('Failed to get unread notifications:', error)
+			logger.error('Failed to get unread notifications:', error)
 			return []
 		}
 	}

--- a/apps/web/lib/stellar/gamification-contracts.ts
+++ b/apps/web/lib/stellar/gamification-contracts.ts
@@ -18,6 +18,7 @@ import {
 } from '@stellar/stellar-sdk'
 import * as SorobanRpc from '@stellar/stellar-sdk/rpc'
 import { Api, assembleTransaction } from '@stellar/stellar-sdk/rpc'
+import { logger } from '@/lib/logger'
 
 interface RecordStreakDonationParams {
 	userAddress: string // User's Stellar address (G... or C...)
@@ -193,7 +194,7 @@ export class GamificationContractService {
 				const simulation = await this.server.simulateTransaction(transaction)
 
 				if (Api.isSimulationError(simulation)) {
-					console.error(
+					logger.error(
 						'[GamificationContractService] Simulation failed:',
 						simulation,
 					)
@@ -212,7 +213,7 @@ export class GamificationContractService {
 				const result = await this.server.sendTransaction(assembledTx)
 
 				if (result.status === 'ERROR') {
-					console.error(
+					logger.error(
 						'[GamificationContractService] Transaction failed:',
 						result,
 					)
@@ -230,7 +231,7 @@ export class GamificationContractService {
 					streak: 1,
 				}
 			} catch (error) {
-				console.error(
+				logger.error(
 					'[GamificationContractService] Error recording streak donation:',
 					error,
 				)
@@ -294,7 +295,7 @@ export class GamificationContractService {
 				const simulation = await this.server.simulateTransaction(transaction)
 
 				if (Api.isSimulationError(simulation)) {
-					console.error(
+					logger.error(
 						'[GamificationContractService] Simulation failed:',
 						simulation,
 					)
@@ -312,7 +313,7 @@ export class GamificationContractService {
 						rewardPoints =
 							(scValToNative(simulation.result.retval) as number) ?? 0
 					} catch {
-						console.warn(
+						logger.warn(
 							'[GamificationContractService] Could not parse reward points from record_donation',
 						)
 					}
@@ -327,7 +328,7 @@ export class GamificationContractService {
 				const result = await this.server.sendTransaction(assembledTx)
 
 				if (result.status === 'ERROR') {
-					console.error(
+					logger.error(
 						'[GamificationContractService] Transaction failed:',
 						result,
 					)
@@ -343,7 +344,7 @@ export class GamificationContractService {
 					rewardPoints,
 				}
 			} catch (error) {
-				console.error(
+				logger.error(
 					'[GamificationContractService] Error recording referral donation:',
 					error,
 				)
@@ -401,7 +402,7 @@ export class GamificationContractService {
 				const simulation = await this.server.simulateTransaction(transaction)
 
 				if (Api.isSimulationError(simulation)) {
-					console.error(
+					logger.error(
 						'[GamificationContractService] createReferral simulation failed:',
 						simulation,
 					)
@@ -425,7 +426,7 @@ export class GamificationContractService {
 
 				return { success: true }
 			} catch (error) {
-				console.error(
+				logger.error(
 					'[GamificationContractService] Error creating referral:',
 					error,
 				)
@@ -480,7 +481,7 @@ export class GamificationContractService {
 				const simulation = await this.server.simulateTransaction(transaction)
 
 				if (Api.isSimulationError(simulation)) {
-					console.error(
+					logger.error(
 						'[GamificationContractService] markOnboarded simulation failed:',
 						simulation,
 					)
@@ -498,7 +499,7 @@ export class GamificationContractService {
 						rewardPoints =
 							(scValToNative(simulation.result.retval) as number) ?? 0
 					} catch {
-						console.warn(
+						logger.warn(
 							'[GamificationContractService] Could not parse reward points from markOnboarded',
 						)
 					}
@@ -518,7 +519,7 @@ export class GamificationContractService {
 
 				return { success: true, rewardPoints }
 			} catch (error) {
-				console.error(
+				logger.error(
 					'[GamificationContractService] Error marking onboarded:',
 					error,
 				)
@@ -584,7 +585,7 @@ export class GamificationContractService {
 				const simulation = await this.server.simulateTransaction(transaction)
 
 				if (Api.isSimulationError(simulation)) {
-					console.error(
+					logger.error(
 						'[GamificationContractService] Simulation failed:',
 						simulation,
 					)
@@ -603,7 +604,7 @@ export class GamificationContractService {
 				const result = await this.server.sendTransaction(assembledTx)
 
 				if (result.status === 'ERROR') {
-					console.error(
+					logger.error(
 						'[GamificationContractService] Transaction failed:',
 						result,
 					)
@@ -619,7 +620,7 @@ export class GamificationContractService {
 					completed: false,
 				}
 			} catch (error) {
-				console.error(
+				logger.error(
 					'[GamificationContractService] Error updating quest progress:',
 					error,
 				)
@@ -660,7 +661,7 @@ export class GamificationContractService {
 						return account
 					})
 					.catch((error) => {
-						console.error(
+						logger.error(
 							'[GamificationContractService] Error fetching admin account:',
 							error,
 						)
@@ -701,7 +702,7 @@ export class GamificationContractService {
 				const simulation = await this.server.simulateTransaction(transaction)
 
 				if (Api.isSimulationError(simulation)) {
-					console.error(
+					logger.error(
 						'[GamificationContractService] Simulation failed:',
 						simulation,
 					)
@@ -720,7 +721,7 @@ export class GamificationContractService {
 				const result = await this.server.sendTransaction(assembledTx)
 
 				if (result.status === 'ERROR') {
-					console.error(
+					logger.error(
 						'[GamificationContractService] Transaction failed:',
 						result,
 					)
@@ -739,7 +740,7 @@ export class GamificationContractService {
 						const { scValToNative } = await import('@stellar/stellar-sdk')
 						questId = scValToNative(simulation.result.retval) as number
 					} catch (e) {
-						console.warn(
+						logger.warn(
 							'[GamificationContractService] Could not parse quest ID from simulation result',
 							e,
 						)
@@ -751,7 +752,7 @@ export class GamificationContractService {
 					questId,
 				}
 			} catch (error) {
-				console.error(
+				logger.error(
 					'[GamificationContractService] Error creating quest:',
 					error,
 				)
@@ -897,7 +898,7 @@ export class GamificationContractService {
 				const simulation = await this.server.simulateTransaction(transaction)
 
 				if (Api.isSimulationError(simulation)) {
-					console.error(
+					logger.error(
 						'[GamificationContractService] mintNFT simulation failed:',
 						simulation,
 					)
@@ -914,7 +915,7 @@ export class GamificationContractService {
 						const { scValToNative } = await import('@stellar/stellar-sdk')
 						tokenId = scValToNative(simulation.result.retval) as number
 					} catch {
-						console.warn(
+						logger.warn(
 							'[GamificationContractService] Could not parse token ID from simulation',
 						)
 					}
@@ -934,7 +935,7 @@ export class GamificationContractService {
 
 				return { success: true, tokenId }
 			} catch (error) {
-				console.error('[GamificationContractService] Error minting NFT:', error)
+				logger.error('[GamificationContractService] Error minting NFT:', error)
 				return {
 					success: false,
 					error: error instanceof Error ? error.message : 'Unknown error',
@@ -989,7 +990,7 @@ export class GamificationContractService {
 				const simulation = await this.server.simulateTransaction(transaction)
 
 				if (Api.isSimulationError(simulation)) {
-					console.error(
+					logger.error(
 						'[GamificationContractService] updateNFTMetadata simulation failed:',
 						simulation,
 					)
@@ -1013,7 +1014,7 @@ export class GamificationContractService {
 
 				return { success: true }
 			} catch (error) {
-				console.error(
+				logger.error(
 					'[GamificationContractService] Error updating NFT metadata:',
 					error,
 				)
@@ -1069,7 +1070,7 @@ export class GamificationContractService {
 				const simulation = await this.server.simulateTransaction(transaction)
 
 				if (Api.isSimulationError(simulation)) {
-					console.error(
+					logger.error(
 						'[GamificationContractService] grant_role simulation failed:',
 						simulation.error,
 					)
@@ -1111,7 +1112,7 @@ export class GamificationContractService {
 
 				return { success: true }
 			} catch (error) {
-				console.error(
+				logger.error(
 					'[GamificationContractService] Error granting role:',
 					error,
 				)

--- a/apps/web/lib/stellar/governance-contract.ts
+++ b/apps/web/lib/stellar/governance-contract.ts
@@ -19,6 +19,7 @@ import { promisify } from 'node:util'
 import { Keypair } from '@stellar/stellar-sdk'
 import { Server } from '@stellar/stellar-sdk/rpc'
 import type { NftTier } from '~/lib/governance/types'
+import { logger } from '@/lib/logger'
 
 const execFile = promisify(execFileCb)
 
@@ -151,7 +152,7 @@ export class GovernanceContractService {
 		)
 
 		if (!result.success) {
-			console.warn('[GovernanceContract] create_round failed:', result.error)
+			logger.warn('[GovernanceContract] create_round failed:', result.error)
 			return { success: false, error: result.error }
 		}
 
@@ -183,7 +184,7 @@ export class GovernanceContractService {
 		)
 
 		if (!result.success) {
-			console.warn('[GovernanceContract] add_option failed:', result.error)
+			logger.warn('[GovernanceContract] add_option failed:', result.error)
 			return { success: false, error: result.error }
 		}
 
@@ -228,7 +229,7 @@ export class GovernanceContractService {
 		)
 
 		if (!result.success) {
-			console.warn('[GovernanceContract] record_vote failed:', result.error)
+			logger.warn('[GovernanceContract] record_vote failed:', result.error)
 			return { success: false, error: result.error }
 		}
 

--- a/apps/web/lib/stellar/smart-account-kit.service.ts
+++ b/apps/web/lib/stellar/smart-account-kit.service.ts
@@ -1,5 +1,6 @@
 import { appEnvConfig } from '@packages/lib/config'
 import type { AppEnvInterface } from '@packages/lib/types'
+import { logger } from '@/lib/logger'
 
 /**
  * Smart Account Kit Service
@@ -192,7 +193,7 @@ export class SmartAccountKitService {
 			// Try to load the package
 			const kitModule = await loadSmartAccountKit()
 			if (!kitModule) {
-				console.warn(
+				logger.warn(
 					'⚠️ smart-account-kit not installed. Install it with: bun add smart-account-kit',
 				)
 				return
@@ -202,7 +203,7 @@ export class SmartAccountKitService {
 				!this.config.accountWasmHash ||
 				!this.config.webauthnVerifierAddress
 			) {
-				console.error(
+				logger.error(
 					'❌ Missing required configuration: accountWasmHash or webauthnVerifierAddress',
 				)
 				return
@@ -273,7 +274,7 @@ export class SmartAccountKitService {
 				this.kit = new kitModule.SmartAccountKit(kitConfig)
 				this.isInitialized = true
 			} catch (error) {
-				console.error('❌ Failed to initialize Smart Account Kit:', error)
+				logger.error('❌ Failed to initialize Smart Account Kit:', error)
 				throw error
 			}
 		})()
@@ -328,7 +329,7 @@ export class SmartAccountKitService {
 				error instanceof Error ? error.message : String(error)
 			const errorStack = error instanceof Error ? error.stack : undefined
 
-			console.error('❌ Failed to create wallet:', {
+			logger.error('❌ Failed to create wallet:', {
 				error: errorMessage,
 				stack: errorStack,
 				config: {
@@ -364,7 +365,7 @@ export class SmartAccountKitService {
 				credentialId: result.credentialId || '',
 			}
 		} catch (error) {
-			console.error('❌ Failed to connect wallet:', error)
+			logger.error('❌ Failed to connect wallet:', error)
 			throw error
 		}
 	}
@@ -380,7 +381,7 @@ export class SmartAccountKitService {
 		try {
 			await this.kit.disconnect()
 		} catch (error) {
-			console.error('❌ Failed to disconnect:', error)
+			logger.error('❌ Failed to disconnect:', error)
 		}
 	}
 
@@ -394,7 +395,7 @@ export class SmartAccountKitService {
 		try {
 			return await this.kit.signAndSubmit(transaction, options)
 		} catch (error) {
-			console.error('❌ Failed to sign and submit transaction:', error)
+			logger.error('❌ Failed to sign and submit transaction:', error)
 			throw error
 		}
 	}
@@ -413,7 +414,7 @@ export class SmartAccountKitService {
 		try {
 			return await this.kit.transfer(tokenContract, recipient, amount, options)
 		} catch (error) {
-			console.error('❌ Failed to transfer tokens:', error)
+			logger.error('❌ Failed to transfer tokens:', error)
 			throw error
 		}
 	}

--- a/apps/web/lib/stellar/smart-wallet-transactions-v2.ts
+++ b/apps/web/lib/stellar/smart-wallet-transactions-v2.ts
@@ -161,7 +161,7 @@ export class SmartWalletTransactionServiceV2 {
 		webAuthnSignature: WebAuthnSignatureData
 		publicKey: Uint8Array
 	}): Promise<{ transactionHash: string; status: string }> {
-		console.warn(
+		logger.warn(
 			'⚠️ submitTransactionWithWebAuthn requires Smart Account Kit SDK. ' +
 				'Use SmartAccountKitService.signAndSubmit() instead.',
 		)
@@ -219,7 +219,7 @@ export class SmartWalletTransactionServiceV2 {
 				tokens: [],
 			}
 		} catch (error) {
-			console.error('❌ Error fetching balances:', error)
+			logger.error('❌ Error fetching balances:', error)
 			return {
 				xlm: '0',
 				tokens: [],
@@ -252,7 +252,7 @@ export class SmartWalletTransactionServiceV2 {
 		})
 
 		if (Api.isSimulationError(simulation)) {
-			console.error('❌ Simulation error:', simulation.error)
+			logger.error('❌ Simulation error:', simulation.error)
 			throw new Error(
 				`Transaction simulation failed: ${simulation.error || 'Unknown error'}`,
 			)
@@ -358,4 +358,5 @@ interface BuildTransactionParamsV2 {
 
 // Import Account and TransactionBuilder for balance queries
 import { Account, TransactionBuilder } from '@stellar/stellar-sdk'
+import { logger } from '@/lib/logger'
 // Api is already imported at the top of the file

--- a/apps/web/lib/stellar/smart-wallet-transactions.ts
+++ b/apps/web/lib/stellar/smart-wallet-transactions.ts
@@ -18,6 +18,7 @@ import {
 	xdr,
 } from '@stellar/stellar-sdk'
 import { Api, assembleTransaction, Server } from '@stellar/stellar-sdk/rpc'
+import { logger } from '@/lib/logger'
 
 const appConfig: AppEnvInterface = appEnvConfig('web')
 
@@ -209,7 +210,7 @@ export class SmartWalletTransactionService {
 				const nativeValue = scValToNative(retval)
 				xlmBalance = nativeValue.toString()
 			} else if (Api.isSimulationError(simulation)) {
-				console.warn('⚠️ Simulation error:', simulation.error)
+				logger.warn('⚠️ Simulation error:', simulation.error)
 				// Return 0 balance if simulation fails (contract not funded yet)
 			}
 
@@ -218,7 +219,7 @@ export class SmartWalletTransactionService {
 				tokens: [],
 			}
 		} catch (error) {
-			console.error('❌ Error fetching balances:', error)
+			logger.error('❌ Error fetching balances:', error)
 			// Return zero balance instead of throwing for better UX
 			return {
 				xlm: '0',
@@ -257,7 +258,7 @@ export class SmartWalletTransactionService {
 		webAuthnSignature: WebAuthnSignatureData
 		publicKey: Uint8Array
 	}): Promise<{ transactionHash: string; status: string }> {
-		console.warn(
+		logger.warn(
 			'⚠️ submitTransactionWithWebAuthn requires Smart Account Kit SDK. ' +
 				'Use SmartAccountKitService.signAndSubmit() instead, or use legacy submitTransaction() method.',
 		)
@@ -348,7 +349,7 @@ export class SmartWalletTransactionService {
 		})
 
 		if (Api.isSimulationError(simulation)) {
-			console.error('❌ Simulation error:', simulation.error)
+			logger.error('❌ Simulation error:', simulation.error)
 			throw new Error(
 				`Transaction simulation failed: ${simulation.error || 'Unknown error'}`,
 			)
@@ -417,7 +418,7 @@ export class SmartWalletTransactionService {
 
 		if (!signaturePayloadResult) {
 			// Fallback to transaction hash if we can't extract signature_payload
-			console.warn(
+			logger.warn(
 				'⚠️  Could not extract signature_payload, falling back to tx hash',
 			)
 			throw new Error('⚠️  Could not extract signature_payload')
@@ -452,14 +453,14 @@ export class SmartWalletTransactionService {
 						checkCredentials.signatureExpirationLedger().toString() !==
 						signatureExpirationLedger.toString()
 					) {
-						console.error(
+						logger.error(
 							'❌ CRITICAL: XDR bytes do NOT contain correct expiration!',
 						)
 					}
 				}
 			}
 		} catch (error) {
-			console.error('❌ Error verifying XDR:', error)
+			logger.error('❌ Error verifying XDR:', error)
 		}
 
 		return {

--- a/apps/web/lib/stellar/utils/send-transaction.ts
+++ b/apps/web/lib/stellar/utils/send-transaction.ts
@@ -1,5 +1,6 @@
 import { httpEscrow } from '~/lib/axios/http'
 import type { SendTransactionResponse } from '~/lib/types/escrow/escrow-response.types'
+import { logger } from '@/lib/logger'
 
 export async function sendTransaction(
 	signedXdr: string,
@@ -14,7 +15,7 @@ export async function sendTransaction(
 		)
 		return response.data
 	} catch (error) {
-		console.error('Error sending transaction:', error)
+		logger.error('Error sending transaction:', error)
 		throw error
 	}
 }

--- a/apps/web/lib/stellar/utils/sign-transaction.ts
+++ b/apps/web/lib/stellar/utils/sign-transaction.ts
@@ -1,6 +1,7 @@
 // todo: sign transaction function
 import { Keypair, Transaction } from '@stellar/stellar-sdk'
 import type { SignTransactionResponse } from '~/lib/types/escrow/escrow-response.types'
+import { logger } from '@/lib/logger'
 
 export function signTransaction(
 	unsignedXDR: string,
@@ -14,7 +15,7 @@ export function signTransaction(
 		const signedXDR = transaction.toXDR()
 		return signedXDR
 	} catch (error) {
-		console.error('Error sending transaction:', error)
+		logger.error('Error sending transaction:', error)
 		throw error
 	}
 }

--- a/apps/web/lib/utils/admin.ts
+++ b/apps/web/lib/utils/admin.ts
@@ -2,6 +2,7 @@ import { createSupabaseServerClient } from '@packages/lib/supabase-server'
 import { redirect } from 'next/navigation'
 import { getServerSession } from 'next-auth'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { logger } from '@/lib/logger'
 
 export async function requireAdmin() {
 	const session = await getServerSession(nextAuthOption)
@@ -18,7 +19,7 @@ export async function requireAdmin() {
 		.single()
 
 	if (error || !profileData) {
-		console.error('Error fetching user profile:', error)
+		logger.error('Error fetching user profile:', error)
 		redirect('/sign-in')
 	}
 

--- a/apps/web/lib/utils/storage.ts
+++ b/apps/web/lib/utils/storage.ts
@@ -1,4 +1,5 @@
 import type { TypedSupabaseClient } from '@packages/lib/types'
+import { logger } from '@/lib/logger'
 
 export interface StorageAdapter {
 	list(
@@ -46,7 +47,7 @@ export async function uploadFile({
 		try {
 			await deleteFolder(client, folder)
 		} catch (e) {
-			console.warn(
+			logger.warn(
 				`Failed to delete existing files in ${folder}:`,
 				(e as Error).message,
 			)

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { type NextRequestWithAuth, withAuth } from 'next-auth/middleware'
 import { ensureCsrfTokenCookie } from '~/app/actions/csrf'
+import { logger } from '@/lib/logger'
 
 // * Infer the type of the first parameter of updateSession
 type ExpectedRequestType = Parameters<typeof updateSession>[0]
@@ -39,7 +40,6 @@ export default withAuth(
 						: 'next-auth.session-token',
 			})
 
-			// console.log('🔑 Middleware token check:', {
 			// 	hasToken: !!token,
 			// 	tokenSub: token?.sub,
 			// 	pathname,
@@ -48,7 +48,7 @@ export default withAuth(
 
 			// Redirect unauthenticated access to protected paths only
 			if (isProtectedPath(pathname) && !token?.sub) {
-				console.warn('⚠️ Unauthorized access attempt to:', pathname)
+				logger.warn('⚠️ Unauthorized access attempt to:', pathname)
 				const url = req.nextUrl.clone()
 				url.pathname = '/sign-in'
 				url.searchParams.set('callbackUrl', pathname)
@@ -58,7 +58,7 @@ export default withAuth(
 			// Pass through Supabase session refresh logic
 			return await updateSession(req as unknown as ExpectedRequestType, null)
 		} catch (error) {
-			console.error('Middleware error:', error)
+			logger.error('Middleware error:', error)
 			return NextResponse.next({
 				request: { headers: req.headers },
 			})

--- a/apps/web/scripts/replace-console-calls.mjs
+++ b/apps/web/scripts/replace-console-calls.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Bulk-replaces bare console.* calls in apps/web source files with
+ * imports of the structured logger and logger.* method calls.
+ *
+ * Rules:
+ *  1. If the file already imports from '@/lib/logger' or '../lib/logger'
+ *     etc., skip adding another import.
+ *  2. Add `import { logger } from '@/lib/logger'` at the top after any
+ *     existing imports.
+ *  3. Replace:
+ *       console.log(...)  → logger.info(...)   [treat as info-level]
+ *       console.debug(...) → logger.debug(...)
+ *       console.warn(...) → logger.warn(...)
+ *       console.error(...) → logger.error(...)
+ *  4. Remove commented-out console.* lines.
+ *  5. Skip files in scripts/, public/, and *.test.* / *.spec.*
+ *
+ * This script uses simple string transforms (no AST). It is safe to run
+ * multiple times (idempotent — already-replaced calls will not match).
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, extname } from 'node:path'
+
+const ROOT = new URL('../../../', import.meta.url).pathname
+const WEB_APP = join(ROOT, 'apps/web')
+
+const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx'])
+const SKIP_DIRS = new Set([
+  '.next',
+  'node_modules',
+  'dist',
+  'build',
+  'public',       // service-workers are excluded via biome override
+  'scripts',      // excluded via biome override
+])
+
+// Match console.log/debug/warn/error calls that are NOT already inside a comment
+// Also match the `console.error` reference used as a callback (e.g. .catch(console.error))
+const COMMENTED_CONSOLE_RE = /^(\s*)\/\/.*console\.(log|debug|warn|error|info).*/gm
+const CONSOLE_LOG_RE = /\bconsole\.log\s*\(/g
+const CONSOLE_DEBUG_RE = /\bconsole\.debug\s*\(/g
+const CONSOLE_WARN_RE = /\bconsole\.warn\s*\(/g
+const CONSOLE_ERROR_RE = /\bconsole\.error\s*\(/g
+// Match usage as callback: .catch(console.error) | .then(null, console.error)
+const CATCH_CONSOLE_RE = /\.catch\(console\.error\)/g
+const THEN_CONSOLE_RE = /,\s*console\.error\)/g
+
+const LOGGER_IMPORT_RE = /from\s+['"][^'"]*\/logger['"]/
+const LOGGER_IMPORT_LINE =
+  "import { logger } from '@/lib/logger'"
+
+let totalFilesModified = 0
+let totalReplacements = 0
+
+function shouldSkipDir(name) {
+  return SKIP_DIRS.has(name)
+}
+
+function shouldSkipFile(name) {
+  return name.includes('.test.') || name.includes('.spec.')
+}
+
+function processFile(filePath) {
+  const ext = extname(filePath)
+  if (!EXTENSIONS.has(ext)) return
+
+  const relPath = relative(ROOT, filePath)
+  let content = readFileSync(filePath, 'utf-8')
+  const original = content
+
+  // 1. Remove commented-out console.* lines
+  content = content.replace(COMMENTED_CONSOLE_RE, '')
+
+  // 2. Replace .catch(console.error) with logger callback
+  content = content.replace(
+    CATCH_CONSOLE_RE,
+    '.catch((err) => logger.error(\'Unhandled error\', err instanceof Error ? err : new Error(String(err))))',
+  )
+
+  // 3. Replace console.log -> logger.info
+  const logCount = (content.match(CONSOLE_LOG_RE) || []).length
+  content = content.replace(CONSOLE_LOG_RE, 'logger.info(')
+
+  // 4. Replace console.debug -> logger.debug
+  const debugCount = (content.match(CONSOLE_DEBUG_RE) || []).length
+  content = content.replace(CONSOLE_DEBUG_RE, 'logger.debug(')
+
+  // 5. Replace console.warn -> logger.warn
+  const warnCount = (content.match(CONSOLE_WARN_RE) || []).length
+  content = content.replace(CONSOLE_WARN_RE, 'logger.warn(')
+
+  // 6. Replace console.error -> logger.error
+  const errorCount = (content.match(CONSOLE_ERROR_RE) || []).length
+  content = content.replace(CONSOLE_ERROR_RE, 'logger.error(')
+
+  const replaced = logCount + debugCount + warnCount + errorCount
+  if (replaced === 0 && content === original) return
+
+  // 7. Add logger import if not already present and we made replacements
+  if (replaced > 0 && !LOGGER_IMPORT_RE.test(content)) {
+    // Find the first import line and insert after all imports
+    const lines = content.split('\n')
+    let lastImportIndex = -1
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].trimStart().startsWith('import ') || lines[i].trimStart().startsWith("'use ") || lines[i].trimStart().startsWith('"use ')) {
+        // Skip 'use client'/'use server' directives
+        if (!lines[i].includes('use client') && !lines[i].includes('use server')) {
+          lastImportIndex = i
+        }
+      }
+    }
+    if (lastImportIndex === -1) {
+      // No imports found, prepend
+      content = LOGGER_IMPORT_LINE + '\n\n' + content
+    } else {
+      lines.splice(lastImportIndex + 1, 0, LOGGER_IMPORT_LINE)
+      content = lines.join('\n')
+    }
+  }
+
+  if (content !== original) {
+    writeFileSync(filePath, content, 'utf-8')
+    console.log(`✅ Modified (${replaced} replacements): ${relPath}`)
+    totalFilesModified++
+    totalReplacements += replaced
+  }
+}
+
+function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    if (shouldSkipDir(entry)) continue
+    const full = join(dir, entry)
+    const stat = statSync(full)
+    if (stat.isDirectory()) {
+      walk(full)
+    } else if (!shouldSkipFile(entry)) {
+      processFile(full)
+    }
+  }
+}
+
+console.log('🔍 Scanning apps/web for console.* calls...\n')
+walk(WEB_APP)
+
+console.log(`\n📊 Summary:`)
+console.log(`  Files modified : ${totalFilesModified}`)
+console.log(`  Total replacements: ${totalReplacements}`)
+console.log('\n✅ Done!')

--- a/biome.json
+++ b/biome.json
@@ -35,10 +35,7 @@
 			"suspicious": {
 				"recommended": true,
 				"noExplicitAny": "error",
-				"noConsole": {
-					"level": "error",
-					"options": { "allow": ["warn", "error"] }
-				}
+				"noConsole": "error"
 			}
 		}
 	},
@@ -48,6 +45,45 @@
 	"overrides": [
 		{
 			"includes": ["**/scripts/**"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noConsole": "off"
+					}
+				}
+			}
+		},
+		{
+			"includes": [
+				"**/lib/logger.ts",
+				"**/logger/index.ts"
+			],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noConsole": "off"
+					}
+				}
+			}
+		},
+		{
+			"includes": [
+				"**/lib/logger.ts",
+				"**/logger/index.ts"
+			],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noConsole": "off"
+					}
+				}
+			}
+		},
+		{
+			"includes": [
+				"apps/indexer/src/mappings/**",
+				"packages/drizzle/src/**"
+			],
 			"linter": {
 				"rules": {
 					"suspicious": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -7,6 +7,10 @@
 			"import": "./src/index.ts",
 			"require": "./src/index.ts"
 		},
+		"./logger": {
+			"import": "./src/logger/index.ts",
+			"require": "./src/logger/index.ts"
+		},
 		"./config": {
 			"import": "./src/config/index.ts",
 			"require": "./src/config/index.ts"

--- a/packages/lib/src/config/app-env.config.ts
+++ b/packages/lib/src/config/app-env.config.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { logger } from '../logger'
 import type { AppEnvInterface, AppName, ValidatedEnvInput } from '../types'
 
 // Transform function with explicit type annotation
@@ -318,13 +319,13 @@ export function appEnvConfig<T extends keyof typeof appRequirements>(
 
 			if (!result.success) {
 				const issues = result.error.issues
-				console.error('❌ Config validation failed:', {
+				logger.error('Config validation failed', undefined, {
 					errorCount: issues.length,
 					errors: issues.map((err) => ({
 						path: err.path.join('.'),
 						message: err.message,
 						code: err.code,
-					})),
+					})) as unknown as Record<string, unknown>[],
 				})
 
 				const missingVars = issues
@@ -334,18 +335,11 @@ export function appEnvConfig<T extends keyof typeof appRequirements>(
 					`❌ Environment validation failed for ${String(appName)}:\n${missingVars}\n\nPlease check your .env file and ensure all required variables are set.`,
 				)
 			}
-			// console.log(
-			// 	`✅ Environment variables for ${String(appName)} validated successfully.`,
-			// )
 		}
 
 		return transformedConfig
 	} catch (error) {
-		console.error('💥 Error in getEnv function:', {
-			errorType: error?.constructor?.name,
-			message: error instanceof Error ? error.message : 'Unknown error',
-			appName,
-		})
+		logger.error('Error in appEnvConfig', error instanceof Error ? error : new Error(String(error)), { appName: String(appName ?? 'unknown') })
 		throw error
 	}
 }

--- a/packages/lib/src/db/webauthn.database.ts
+++ b/packages/lib/src/db/webauthn.database.ts
@@ -4,6 +4,7 @@ import type {
 	WebAuthnCredential as BaseWebAuthnCredential,
 } from '@simplewebauthn/server'
 import { and, desc, eq, gt, lt } from 'drizzle-orm'
+import { logger } from '../logger'
 
 // Extended WebAuthnCredential with Stellar address support (matches passkey-service.ts)
 export interface WebAuthnCredential extends BaseWebAuthnCredential {
@@ -151,7 +152,7 @@ export const getUser = async ({
 			credentials,
 		}
 	} catch (error) {
-		console.error('Error getting user by identifier', error)
+		logger.error('Error getting user by identifier', error instanceof Error ? error : new Error(String(error)), { identifier })
 		return null
 	}
 }

--- a/packages/lib/src/doc-utils/file-processing.ts
+++ b/packages/lib/src/doc-utils/file-processing.ts
@@ -1,4 +1,5 @@
 import Tesseract from 'tesseract.js'
+import { logger } from '../logger'
 import type { ExtractedData } from './types'
 
 interface ProcessFileResult {
@@ -27,7 +28,7 @@ export const processFile = async (file: File): Promise<ProcessFileResult> => {
 
 		extractedText = result.data.text
 	} catch (error) {
-		console.error('Error processing document:', error)
+		logger.error('Error processing document', error instanceof Error ? error : new Error(String(error)))
 		errorMessage = 'Error processing document'
 	}
 

--- a/packages/lib/src/hooks/stellar/use-smart-wallet.hook.ts
+++ b/packages/lib/src/hooks/stellar/use-smart-wallet.hook.ts
@@ -4,6 +4,7 @@ import { debounce } from 'lodash'
 import type { Session, User } from 'next-auth'
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
+import { logger } from '../../logger'
 import { useStellarSignature } from './use-stellar-signature.hook'
 
 export interface ContractOperation {
@@ -39,7 +40,7 @@ export const useStellarSorobanAccount = (session?: Session | null) => {
 			}
 		},
 		onError: (error) => {
-			console.error('❌ Transaction failed:', error)
+			logger.error('Transaction failed', error)
 		},
 		// Pass session directly to avoid useSession call inside useStellarSignature
 		// This prevents the SessionProvider requirement error
@@ -112,7 +113,7 @@ export const useStellarSorobanAccount = (session?: Session | null) => {
 
 			return accountData
 		} catch (error) {
-			console.error('❌ Error initializing account:', error)
+			logger.error('Error initializing account', error instanceof Error ? error : new Error(String(error)))
 			setRequestId(null)
 			throw error
 		}
@@ -140,7 +141,7 @@ export const useStellarSorobanAccount = (session?: Session | null) => {
 					: null,
 			)
 		} catch (error) {
-			console.error('❌ Error refreshing account info:', error)
+			logger.error('Error refreshing account info', error instanceof Error ? error : new Error(String(error)))
 		}
 	}, [account?.contractId, stellarSignature])
 
@@ -177,7 +178,7 @@ export const useStellarSorobanAccount = (session?: Session | null) => {
 			!stellarSignature.isLoading &&
 			!requestId
 		) {
-			debounce(() => initializeAccount().catch(console.error), 6000)()
+			debounce(() => initializeAccount().catch((err) => logger.error('initializeAccount failed', err instanceof Error ? err : new Error(String(err)))), 6000)()
 		}
 	}, [
 		session,

--- a/packages/lib/src/hooks/stellar/use-stellar-signature.hook.ts
+++ b/packages/lib/src/hooks/stellar/use-stellar-signature.hook.ts
@@ -5,6 +5,7 @@ import type { Session } from 'next-auth'
 import { useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { appEnvConfig } from '../../config'
+import { logger } from '../../logger'
 import type { AppEnvInterface } from '../../types'
 
 export interface StellarOperation {
@@ -146,7 +147,7 @@ export const useStellarSignature = (
 			} catch (err) {
 				const error =
 					err instanceof Error ? err : new Error('Unknown error occurred')
-				console.error('❌ Error signing Stellar transaction:', error)
+				logger.error('Error signing Stellar transaction', error)
 
 				setError(error.message)
 				options.onError?.(error)
@@ -218,11 +219,10 @@ export const useStellarSignature = (
 			} catch (err) {
 				const error =
 					err instanceof Error ? err : new Error('Unknown error occurred')
-				console.error('❌ Error creating Stellar account:', error)
+				logger.error('Error creating Stellar account', error)
 
 				setError(error.message)
 				options.onError?.(error)
-				// toast.error(`Account creation failed: ${error.message}`)
 
 				throw error
 			} finally {
@@ -259,7 +259,7 @@ export const useStellarSignature = (
 			} catch (err) {
 				const error =
 					err instanceof Error ? err : new Error('Unknown error occurred')
-				console.error('❌ Error getting account info:', error)
+				logger.error('Error getting account info', error)
 
 				setError(error.message)
 				options.onError?.(error)
@@ -301,7 +301,7 @@ export const useStellarSignature = (
 				const result = await response.json()
 				return result.valid
 			} catch (err) {
-				console.error('❌ Error verifying signature:', err)
+				logger.error('Error verifying signature', err instanceof Error ? err : new Error(String(err)))
 				return false
 			}
 		},

--- a/packages/lib/src/hooks/use-supabase-query.hook.ts
+++ b/packages/lib/src/hooks/use-supabase-query.hook.ts
@@ -5,6 +5,7 @@ import {
 	useQueryClient,
 } from '@tanstack/react-query'
 import { useEffect, useMemo } from 'react'
+import { logger } from '../logger'
 import { createSupabaseBrowserClient } from '../supabase/client/browser-client'
 import type { TypedSupabaseClient } from '../types/supabase-client.types'
 
@@ -57,7 +58,7 @@ export function useSupabaseQuery<TData>(
 			try {
 				return await queryFn(supabase)
 			} catch (error) {
-				console.error(`Error in query ${queryName}:`, error)
+				logger.error(`Error in query: ${queryName}`, error instanceof Error ? error : new Error(String(error)))
 				throw error instanceof Error ? error : new Error(String(error))
 			}
 		},

--- a/packages/lib/src/logger/index.ts
+++ b/packages/lib/src/logger/index.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared structured logger for KindFi.
+ *
+ * Server (Node.js / Edge) – thin wrapper over console that:
+ *  - Is a no-op for non-error levels in production
+ *  - Formats messages as structured JSON-like objects
+ *  - Never leaks sensitive values (keys, tokens, full stack traces) in production
+ *
+ * Client (browser) – debug / info calls are silenced in production; only
+ * error / warn are forwarded so React error boundaries can still surface issues.
+ *
+ * Usage:
+ *   import { logger } from '@packages/lib/logger'
+ *   logger.debug('fetching account', { address })
+ *   logger.info('account loaded', { contractId })
+ *   logger.warn('rate limit approaching', { remaining })
+ *   logger.error('transaction failed', error, { address })
+ */
+
+type Level = 'debug' | 'info' | 'warn' | 'error'
+
+const isDev =
+	typeof process !== 'undefined'
+		? process.env.NODE_ENV !== 'production'
+		: false
+
+const LEVELS: Record<Level, number> = {
+	debug: 0,
+	info: 1,
+	warn: 2,
+	error: 3,
+}
+
+const MIN_LEVEL: Level = isDev ? 'debug' : 'warn'
+
+function shouldLog(level: Level): boolean {
+	return LEVELS[level] >= LEVELS[MIN_LEVEL]
+}
+
+function formatMessage(level: Level, message: string): string {
+	const ts = new Date().toISOString()
+	return `[${level.toUpperCase()}] ${ts} | ${message}`
+}
+
+/**
+ * Sanitise an object before logging – strips fields that should never
+ * appear in logs (secrets, tokens, keys).
+ */
+function sanitise(data?: Record<string, unknown>): Record<string, unknown> {
+	if (!data) return {}
+	const REDACTED = '[REDACTED]'
+	const sensitiveKeys =
+		/secret|token|key|password|auth|credential|passphrase|seed/i
+	return Object.fromEntries(
+		Object.entries(data).map(([k, v]) => [
+			k,
+			sensitiveKeys.test(k) ? REDACTED : v,
+		]),
+	)
+}
+
+export interface KindFiLogger {
+	debug(message: string, data?: Record<string, unknown>): void
+	info(message: string, data?: Record<string, unknown>): void
+	warn(message: string, errorOrData?: unknown, data?: Record<string, unknown>): void
+	error(message: string, errorOrData?: unknown, data?: Record<string, unknown>): void
+}
+
+function buildLogger(): KindFiLogger {
+	return {
+		debug(message, data) {
+			if (!shouldLog('debug')) return
+			// biome-ignore lint/suspicious/noConsole: logger internals intentionally use console
+			console.debug(formatMessage('debug', message), sanitise(data))
+		},
+
+		info(message, data) {
+			if (!shouldLog('info')) return
+			// biome-ignore lint/suspicious/noConsole: logger internals intentionally use console
+			console.info(formatMessage('info', message), sanitise(data))
+		},
+
+		warn(message, errorOrData, data) {
+			if (!shouldLog('warn')) return
+			const formatted = formatMessage('warn', message)
+			if (errorOrData instanceof Error) {
+				// In production, omit the stack trace to avoid leaking internal paths
+				const errInfo = isDev
+					? { message: errorOrData.message, stack: errorOrData.stack }
+					: { message: errorOrData.message }
+				// biome-ignore lint/suspicious/noConsole: logger internals intentionally use console
+				console.warn(formatted, errInfo, sanitise(data))
+			} else {
+				// biome-ignore lint/suspicious/noConsole: logger internals intentionally use console
+				console.warn(formatted, sanitise(errorOrData as Record<string, unknown>))
+			}
+		},
+
+		error(message, errorOrData, data) {
+			if (!shouldLog('error')) return
+			const formatted = formatMessage('error', message)
+			if (errorOrData instanceof Error) {
+				const errInfo = isDev
+					? { message: errorOrData.message, stack: errorOrData.stack }
+					: { message: errorOrData.message }
+				// biome-ignore lint/suspicious/noConsole: logger internals intentionally use console
+				console.error(formatted, errInfo, sanitise(data))
+			} else {
+				// biome-ignore lint/suspicious/noConsole: logger internals intentionally use console
+				console.error(formatted, sanitise(errorOrData as Record<string, unknown>))
+			}
+		},
+	}
+}
+
+export const logger: KindFiLogger = buildLogger()

--- a/packages/lib/src/passkey/passkey.service.ts
+++ b/packages/lib/src/passkey/passkey.service.ts
@@ -15,6 +15,7 @@ import {
 } from '@simplewebauthn/server'
 import base64url from 'base64url'
 import { appEnvConfig } from '../config'
+import { logger } from '../logger'
 import {
 	deleteChallenge,
 	getChallenge,
@@ -199,7 +200,7 @@ export const verifyRegistration = async ({
 				contractAddress = deploymentResult.address
 
 			} catch (error) {
-				console.error('❌ Failed to deploy smart wallet:', error)
+				logger.error('Failed to deploy smart wallet', error instanceof Error ? error : new Error(String(error)))
 				throw new InAppError(
 					ErrorCode.UNEXPECTED_ERROR,
 					`Smart wallet deployment failed: ${error}`,

--- a/packages/lib/src/passkey/webauthn-keys.ts
+++ b/packages/lib/src/passkey/webauthn-keys.ts
@@ -5,6 +5,7 @@
 import { Buffer } from 'buffer'
 import * as CBOR from 'cbor-x/decode'
 import { createHash } from 'crypto'
+import { logger } from '../logger'
 
 /**
  * WebAuthn/COSE Public Key Utilities for Stellar Smart Contracts
@@ -73,7 +74,7 @@ export function convertCoseToUncompressedPublicKey(
 
 		// Validate algorithm (optional check)
 		if (alg && alg !== -7) {
-			console.warn(`⚠️ Unexpected algorithm: ${alg} (expected -7 for ES256)`)
+			logger.warn(`Unexpected algorithm: ${alg} (expected -7 for ES256)`)
 		}
 
 		// Validate curve

--- a/packages/lib/src/stellar/channels-client.service.ts
+++ b/packages/lib/src/stellar/channels-client.service.ts
@@ -1,3 +1,4 @@
+import { logger } from '../logger'
 import type { AppEnvInterface } from '../types'
 
 // Dynamic import for Channels client to handle missing package gracefully
@@ -13,9 +14,7 @@ try {
 	ChannelsFuncAuthRequestType = channelsModule.ChannelsFuncAuthRequest
 	ChannelsTransactionResponseType = channelsModule.ChannelsTransactionResponse
 } catch (error) {
-	console.warn(
-		'⚠️ @openzeppelin/relayer-plugin-channels not installed. Install it with: bun add "@openzeppelin/relayer-plugin-channels"',
-	)
+	logger.warn('Package @openzeppelin/relayer-plugin-channels not installed. Install it with: bun add "@openzeppelin/relayer-plugin-channels"', error instanceof Error ? error : undefined)
 }
 
 export type ChannelsFuncAuthRequest = {
@@ -60,11 +59,7 @@ export class ChannelsClientService {
 		this.apiKey = process.env.CHANNELS_API_KEY || ''
 
 		if (!this.apiKey) {
-			console.warn(
-				'⚠️ CHANNELS_API_KEY not set. Get your API key from:',
-				this.baseUrl + '/gen',
-				'\n   Channels service provides fee-sponsored transactions with automatic parallel processing.',
-			)
+			logger.warn('CHANNELS_API_KEY not set', { setupUrl: this.baseUrl + '/gen' })
 		}
 
 		// Initialize Channels client if package is available
@@ -74,9 +69,7 @@ export class ChannelsClientService {
 				apiKey: this.apiKey,
 			})
 		} else {
-			console.warn(
-				'⚠️ Channels client not initialized. Install @openzeppelin/relayer-plugin-channels package.',
-			)
+			logger.warn('Channels client not initialized – install @openzeppelin/relayer-plugin-channels')
 		}
 	}
 
@@ -105,7 +98,7 @@ export class ChannelsClientService {
 			const response = await this.client.submitSorobanTransaction(request)
 			return response
 		} catch (error) {
-			console.error('❌ Channels transaction submission failed:', error)
+			logger.error('Channels transaction submission failed', error instanceof Error ? error : new Error(String(error)))
 			throw error
 		}
 	}

--- a/packages/lib/src/stellar/deploy.ts
+++ b/packages/lib/src/stellar/deploy.ts
@@ -1,5 +1,6 @@
 import { Address, hash, Keypair, StrKey, xdr } from '@stellar/stellar-sdk'
 import { appEnvConfig } from '../config'
+import { logger } from '../logger'
 import type { AppEnvInterface } from '../types'
 
 /**
@@ -60,7 +61,7 @@ export async function handleDeploy(params: {
 			transactionHash: undefined, // Will be set when actual deployment is implemented
 		}
 	} catch (error) {
-		console.error('❌ Error during deployment:', error)
+		logger.error('Error during deployment', error instanceof Error ? error : new Error(String(error)))
 		throw new Error(`Deployment failed: ${error}`)
 	}
 }

--- a/packages/lib/src/stellar/rate-limiter.ts
+++ b/packages/lib/src/stellar/rate-limiter.ts
@@ -1,4 +1,5 @@
 import { Redis } from '@upstash/redis'
+import { logger } from '../logger'
 
 export interface RateLimitConfig {
 	maxAttempts: number
@@ -34,10 +35,7 @@ export class SignatureRateLimiter {
 					token: config.redisToken,
 				})
 			} catch (error) {
-				console.warn(
-					'⚠️ Failed to initialize Upstash Redis, using in-memory store:',
-					error,
-				)
+				logger.warn('Failed to initialize Upstash Redis, using in-memory store', error instanceof Error ? error : undefined)
 			}
 		} else {
 		}
@@ -55,7 +53,7 @@ export class SignatureRateLimiter {
 				return await this.checkRedisLimit(key)
 			}
 		} catch (error) {
-			console.warn('⚠️ Redis rate limit check failed, using in-memory:', error)
+			logger.warn('Redis rate limit check failed, using in-memory fallback', error instanceof Error ? error : undefined)
 		}
 
 		// Fallback to in-memory
@@ -71,7 +69,7 @@ export class SignatureRateLimiter {
 				await this.redis.del(this.getRedisKey(key))
 			}
 		} catch (error) {
-			console.warn('⚠️ Redis reset failed:', error)
+			logger.warn('Redis reset failed', error instanceof Error ? error : undefined)
 		}
 
 		// Always reset in-memory as well

--- a/packages/lib/src/stellar/smart-account.service.ts
+++ b/packages/lib/src/stellar/smart-account.service.ts
@@ -11,6 +11,7 @@ import {
 	TransactionBuilder,
 } from '@stellar/stellar-sdk'
 import type { AppEnvInterface } from '../types'
+import { logger } from '../logger'
 import { ChannelsClientService } from './channels-client.service'
 
 /**
@@ -78,7 +79,7 @@ export class SmartAccountService {
 				}
 			}
 		} catch (error) {
-			console.warn('⚠️ Smart Account Kit not available, using fallback:', error)
+			logger.warn('Smart Account Kit not available, using fallback', error instanceof Error ? error : undefined)
 		}
 
 		// Fallback: throw error if Smart Account Kit is not available
@@ -197,7 +198,7 @@ export class SmartAccountService {
 				status: result.status,
 			}
 		} catch (error) {
-			console.error('❌ Transaction signing/submission failed:', error)
+			logger.error('Transaction signing/submission failed', error instanceof Error ? error : new Error(String(error)))
 			throw error
 		}
 	}

--- a/packages/lib/src/stellar/stellar-passkey.service.ts
+++ b/packages/lib/src/stellar/stellar-passkey.service.ts
@@ -17,6 +17,7 @@ import {
 import { Api, assembleTransaction, Server } from '@stellar/stellar-sdk/rpc'
 import { eq } from 'drizzle-orm'
 import { appEnvConfig } from '../config'
+import { logger } from '../logger'
 import {
 	computeDeviceIdFromCoseKey,
 	convertCoseToUncompressedPublicKey,
@@ -118,7 +119,7 @@ export class StellarPasskeyService {
 				isExisting: false,
 			}
 		} catch (error) {
-			console.error('❌ Error deploying smart wallet:', error)
+			logger.error('Error deploying smart wallet', error instanceof Error ? error : new Error(String(error)))
 			throw new Error(`Failed to deploy smart wallet: ${error}`)
 		}
 	}
@@ -137,10 +138,6 @@ export class StellarPasskeyService {
 
 			try {
 				const ledgerEntries = await this.server.getLedgerEntries(ledgerKey)
-				// console.log(
-				// 	'ℹ️ LedgerEntries for webauthn account',
-				// 	JSON.stringify(ledgerEntries.entries, null, 2),
-				// )
 				return {
 					address: contractAddress,
 					balance: '0', // Contracts don't have balances directly
@@ -187,9 +184,7 @@ export class StellarPasskeyService {
 					'Account Factory',
 				)
 			} catch {
-				console.warn(
-					'⚠️ Factory contract verification failed. Continuing with deployment attempt.'
-				)
+				logger.warn('Factory contract verification failed – continuing with deployment attempt')
 			}
 
 			// Verify controller contract exists (non-blocking)
@@ -199,9 +194,7 @@ export class StellarPasskeyService {
 					'Auth Controller',
 				)
 			} catch {
-				console.warn(
-					'⚠️ Controller contract verification failed. Continuing with deployment attempt.'
-				)
+				logger.warn('Controller contract verification failed – continuing with deployment attempt')
 			}
 
 			const fundingAccount = await this.server.getAccount(
@@ -321,7 +314,7 @@ export class StellarPasskeyService {
 			}
 
 		} catch (error) {
-			console.error(`❌ Failed to verify ${contractName}:`, error)
+			logger.error(`Failed to verify ${contractName}`, error instanceof Error ? error : new Error(String(error)), { contractId })
 			throw new Error(
 				`${contractName} (${contractId}) verification failed: ${error}. ` +
 					'Please ensure the contract is deployed on this network.',
@@ -453,7 +446,7 @@ export class StellarPasskeyService {
 
 			return isValid
 		} catch (error) {
-			console.error('❌ Error verifying signature:', error)
+			logger.error('Error verifying signature', error instanceof Error ? error : new Error(String(error)))
 			return false
 		}
 	}
@@ -495,7 +488,7 @@ export class StellarPasskeyService {
 
 			return isValid
 		} catch (error) {
-			console.error('❌ SECP256R1 verification failed:', error)
+			logger.error('SECP256R1 verification failed', error instanceof Error ? error : new Error(String(error)))
 			return false
 		}
 	}
@@ -587,7 +580,7 @@ export class StellarPasskeyService {
 
 			return publicKeyBuffer
 		} catch (error) {
-			console.error('❌ Error retrieving public key from database:', error)
+			logger.error('Error retrieving public key from database', error instanceof Error ? error : new Error(String(error)), { contractId })
 			return null
 		}
 	}
@@ -637,7 +630,7 @@ export class StellarPasskeyService {
 					throw new Error('Unsupported operation type')
 			}
 		} catch (error) {
-			console.error('❌ Error executing transaction:', error)
+			logger.error('Error executing transaction', error instanceof Error ? error : new Error(String(error)), { address })
 			throw new Error(`Transaction execution failed: ${error}`)
 		}
 	}
@@ -828,7 +821,6 @@ export class StellarPasskeyService {
 
 
 					if (txResult.status === Api.GetTransactionStatus.SUCCESS) {
-						// console.log('📋 Transaction result:', JSON.stringify(txResult.resultMetaXdr, null, 2))
 						return sendResult.hash
 					}
 
@@ -914,10 +906,10 @@ export async function queryContractDevices(
 			}
 		}
 
-		console.warn('⚠️ Failed to query contract devices')
+		logger.warn('Failed to query contract devices')
 		return []
 	} catch (error) {
-		console.error('❌ Error querying contract devices:', error)
+		logger.error('Error querying contract devices', error instanceof Error ? error : new Error(String(error)), { contractAddress })
 		return []
 	}
 }

--- a/packages/lib/src/supabase/server/server-query.ts
+++ b/packages/lib/src/supabase/server/server-query.ts
@@ -1,4 +1,5 @@
 import type { QueryClient } from '@tanstack/react-query'
+import { logger } from '../../logger'
 import type { TypedSupabaseClient } from '../../types/supabase-client.types'
 import { createSupabaseServerClient } from './server-client'
 
@@ -28,7 +29,7 @@ export async function fetchSupabaseServer<TData>(
 	try {
 		return await queryFn(supabase)
 	} catch (error) {
-		console.error(`Error in server query ${queryName}:`, error)
+		logger.error(`Error in server query: ${queryName}`, error instanceof Error ? error : new Error(String(error)))
 		throw error instanceof Error ? error : new Error(String(error))
 	}
 }

--- a/services/ai/src/middlewares/error-handler.ts
+++ b/services/ai/src/middlewares/error-handler.ts
@@ -14,6 +14,7 @@ export function errorHandler(
 	res: Response,
 	_next?: Function,
 ): void {
+	// biome-ignore lint/suspicious/noConsole: Express error boundary — console.error is intentional here
 	console.error('Error details:', {
 		message: err.message,
 		name: err.name,


### PR DESCRIPTION
## What was done

A shared structured logger singleton was created in packages/lib/src/logger/ and mirrored in apps/web/lib/logger.ts. Both are production-safe — debug/info are silenced in production, stack traces are stripped from warn/error, and sensitive field names (keys, tokens, secrets) are auto-redacted before anything hits the log output. All ~14 hotspot files in packages/lib/src were manually updated to use the logger, commented-out console lines were removed, and a migration script handled the remaining 133 files and ~380 replacements across apps/web.

The biome.json lint rule was tightened from noConsole: { allow: ["warn","error"] } to a flat noConsole: "error" covering all console methods, with targeted overrides for logger internals, CI scripts, the SubQuery indexer, and the Drizzle migration CLI where console output is intentional. The net result: ~470 raw console.* calls reduced to 1 (an Express error boundary with an explicit biome-ignore annotation), and any future unguarded console call will now fail the linter.

Close #854 