### PR TITLE
feat(seo): align KindFi with AIO and Search Everywhere Optimization standards

### DIFF
--- a/apps/web/app/(routes)/about/page.tsx
+++ b/apps/web/app/(routes)/about/page.tsx
@@ -7,29 +7,50 @@ import { MissionVision } from '~/components/sections/about-us/mission-vision'
 import { Problems } from '~/components/sections/about-us/problems'
 import { Roadmap } from '~/components/sections/about-us/roadmap'
 import { WhyKindFiIsDifferent } from '~/components/sections/about-us/why-is-different'
+import { JsonLd } from '~/components/shared/json-ld'
+import { getBreadcrumbSchema } from '~/lib/seo/structured-data'
 
 export const metadata: Metadata = {
 	title: 'About Us | KindFi',
 	description:
-		'Mission, how KindFi works, and why milestone-based funding on Stellar is built for transparent social impact.',
+		"Learn about KindFi's mission, how milestone-based crowdfunding on Stellar works, and why transparent, blockchain-powered funding is the future of social impact.",
 	openGraph: {
-		title: 'About Us | KindFi',
+		title: 'About KindFi — Blockchain Crowdfunding for Social Impact',
 		description:
-			'Milestone-based crowdfunding on Stellar: mission, product story, and roadmap.',
+			'Milestone-based crowdfunding on Stellar: mission, product story, how it works, and our roadmap for transparent social impact funding.',
+		type: 'website',
+		url: '/about',
+	},
+	twitter: {
+		card: 'summary_large_image',
+		title: 'About KindFi | Web3 Crowdfunding for Social Impact',
+		description:
+			'Milestone-based crowdfunding on Stellar: our mission, how it works, and our roadmap.',
+	},
+	alternates: {
+		canonical: '/about',
 	},
 }
 
 export default function AboutPage() {
 	return (
-		<main className="w-full flex flex-col" aria-label="About KindFi">
-			<Hero />
-			<MissionVision />
-			<Problems />
-			<KindFiStellar />
-			<HowItWorks />
-			<WhyKindFiIsDifferent />
-			<Roadmap />
-			<CallToAction />
-		</main>
+		<>
+			<JsonLd
+				data={getBreadcrumbSchema([
+					{ name: 'Home', url: '/' },
+					{ name: 'About Us', url: '/about' },
+				])}
+			/>
+			<main className="w-full flex flex-col" aria-label="About KindFi">
+				<Hero />
+				<MissionVision />
+				<Problems />
+				<KindFiStellar />
+				<HowItWorks />
+				<WhyKindFiIsDifferent />
+				<Roadmap />
+				<CallToAction />
+			</main>
+		</>
 	)
 }

--- a/apps/web/app/(routes)/faqs/page.tsx
+++ b/apps/web/app/(routes)/faqs/page.tsx
@@ -1,5 +1,51 @@
+import type { Metadata } from 'next'
 import { FaqContainer } from '~/components/sections/faqs/faq-container'
+import { JsonLd } from '~/components/shared/json-ld'
+import { faqData } from '~/lib/mock-data/project/project-card-variants.mock'
+import {
+	getBreadcrumbSchema,
+	getFaqPageSchema,
+} from '~/lib/seo/structured-data'
+
+export const metadata: Metadata = {
+	title: 'FAQs | KindFi',
+	description:
+		'Find answers to the most common questions about KindFi — how the platform works, how to support campaigns, how funds are secured on Stellar, and more.',
+	openGraph: {
+		title: 'Frequently Asked Questions | KindFi',
+		description:
+			'Everything you need to know about donating, launching campaigns, and how KindFi uses Stellar blockchain to ensure transparent, milestone-based funding.',
+		type: 'website',
+		url: '/faqs',
+	},
+	twitter: {
+		card: 'summary',
+		title: 'FAQs | KindFi',
+		description:
+			'Answers to common questions about KindFi — crypto donations, campaign milestones, and platform security.',
+	},
+	alternates: {
+		canonical: '/faqs',
+	},
+}
+
+const allFaqs = Object.values(faqData).flat()
 
 export default function FaqsPage() {
-	return <FaqContainer />
+	return (
+		<>
+			<JsonLd
+				data={getFaqPageSchema(
+					allFaqs.map(({ question, answer }) => ({ question, answer })),
+				)}
+			/>
+			<JsonLd
+				data={getBreadcrumbSchema([
+					{ name: 'Home', url: '/' },
+					{ name: 'FAQs', url: '/faqs' },
+				])}
+			/>
+			<FaqContainer />
+		</>
+	)
 }

--- a/apps/web/app/(routes)/governance/page.tsx
+++ b/apps/web/app/(routes)/governance/page.tsx
@@ -1,12 +1,40 @@
 import type { Metadata } from 'next'
 import { GovernanceSection } from '~/components/sections/governance'
+import { JsonLd } from '~/components/shared/json-ld'
+import { getBreadcrumbSchema } from '~/lib/seo/structured-data'
 
 export const metadata: Metadata = {
 	title: 'Community Governance | KindFi',
 	description:
-		'Vote on how the KindFi community fund is redistributed to impactful campaigns.',
+		'Participate in KindFi community governance. Vote on how the community fund is redistributed to high-impact campaigns and help shape the future of decentralized social impact funding.',
+	openGraph: {
+		title: 'Community Governance | KindFi',
+		description:
+			'Vote on how the KindFi community fund is redistributed to impactful campaigns. Decentralized governance powered by the Stellar blockchain.',
+		type: 'website',
+		url: '/governance',
+	},
+	twitter: {
+		card: 'summary',
+		title: 'Community Governance | KindFi',
+		description:
+			'Vote on fund redistribution to impactful campaigns. Decentralized community governance on KindFi.',
+	},
+	alternates: {
+		canonical: '/governance',
+	},
 }
 
 export default function GovernancePage() {
-	return <GovernanceSection />
+	return (
+		<>
+			<JsonLd
+				data={getBreadcrumbSchema([
+					{ name: 'Home', url: '/' },
+					{ name: 'Governance', url: '/governance' },
+				])}
+			/>
+			<GovernanceSection />
+		</>
+	)
 }

--- a/apps/web/app/(routes)/home/page.tsx
+++ b/apps/web/app/(routes)/home/page.tsx
@@ -4,8 +4,50 @@ import {
 	HydrationBoundary,
 	QueryClient,
 } from '@tanstack/react-query'
+import type { Metadata } from 'next'
 import { HomeDashboard } from '~/components/pages/home'
 import { getAllProjects } from '~/lib/queries/projects'
+
+export const metadata: Metadata = {
+	title: 'KindFi — Web3 Crowdfunding for Social Impact',
+	description:
+		'KindFi is the first blockchain-powered crowdfunding platform connecting donors with impactful social and environmental causes. Milestone-based funding on Stellar ensures transparency and accountability.',
+	keywords: [
+		'crypto crowdfunding',
+		'social impact',
+		'blockchain donations',
+		'Stellar network',
+		'Web3 philanthropy',
+		'NGO funding',
+		'transparent crowdfunding',
+		'decentralized fundraising',
+	],
+	openGraph: {
+		title: 'KindFi — Web3 Crowdfunding for Social Impact',
+		description:
+			'The first blockchain-powered crowdfunding platform connecting donors with impactful causes. Milestone-based escrow on Stellar guarantees your donation creates real change.',
+		type: 'website',
+		url: '/',
+		images: [
+			{
+				url: '/images/og-home.png',
+				width: 1200,
+				height: 630,
+				alt: 'KindFi — Web3 Crowdfunding for Social Impact',
+			},
+		],
+	},
+	twitter: {
+		card: 'summary_large_image',
+		title: 'KindFi — Web3 Crowdfunding for Social Impact',
+		description:
+			'The first blockchain-powered crowdfunding platform for social and environmental causes. Built on Stellar.',
+		images: ['/images/og-home.png'],
+	},
+	alternates: {
+		canonical: '/',
+	},
+}
 
 export default async function HomePage() {
 	const queryClient = new QueryClient()

--- a/apps/web/app/(routes)/profile/page.tsx
+++ b/apps/web/app/(routes)/profile/page.tsx
@@ -1,11 +1,22 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
 import { createSupabaseServerClient } from '@packages/lib/supabase-server'
+import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getServerSession } from 'next-auth'
+import { logger } from '@/lib/logger'
 import { ProfileDashboard } from '~/components/sections/profile/profile-dashboard'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { mapDiditStatusToKYC } from '~/lib/services/didit'
-import { logger } from '@/lib/logger'
+
+export const metadata: Metadata = {
+	title: 'My Profile | KindFi',
+	description:
+		'Manage your KindFi profile, view your donation history, and track your social impact contributions.',
+	robots: {
+		index: false,
+		follow: false,
+	},
+}
 
 interface ProfilePageProps {
 	searchParams: Promise<{

--- a/apps/web/app/(routes)/projects/[slug]/page.tsx
+++ b/apps/web/app/(routes)/projects/[slug]/page.tsx
@@ -1,5 +1,3 @@
-import type { Metadata } from 'next'
-import { notFound } from 'next/navigation'
 import {
 	createSupabaseServerClient,
 	prefetchSupabaseQuery,
@@ -9,9 +7,15 @@ import {
 	HydrationBoundary,
 	QueryClient,
 } from '@tanstack/react-query'
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
 import { ProjectClientWrapper } from '~/components/sections/projects/detail/project-client-wrapper'
+import { JsonLd } from '~/components/shared/json-ld'
 import { getProjectBySlug } from '~/lib/queries/projects'
+import { getBreadcrumbSchema } from '~/lib/seo/structured-data'
 import { validateProjectSlug } from '~/lib/validation/project-slug'
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.kindfi.org'
 
 export async function generateMetadata({
 	params,
@@ -29,7 +33,20 @@ export async function generateMetadata({
 		openGraph: {
 			title: project.title,
 			description: project.description ?? undefined,
+			type: 'website',
+			url: `/projects/${slug}`,
+			images: project.image
+				? [{ url: project.image, alt: project.title }]
+				: undefined,
+		},
+		twitter: {
+			card: 'summary_large_image',
+			title: project.title,
+			description: project.description ?? undefined,
 			images: project.image ? [project.image] : undefined,
+		},
+		alternates: {
+			canonical: `/projects/${slug}`,
 		},
 	}
 }
@@ -45,26 +62,52 @@ export default async function ProjectDetailPage({
 	if (!validateProjectSlug(slug)) notFound()
 
 	const queryClient = new QueryClient()
+	const client = await createSupabaseServerClient()
+	const project = await getProjectBySlug(client, slug)
 
-	// Prefetch single project data
 	await prefetchSupabaseQuery(
 		queryClient,
 		'project',
-		(client) => getProjectBySlug(client, slug),
+		(c) => getProjectBySlug(c, slug),
 		[slug],
 	)
 
-	// Hydrate React Query cache on the client
 	const dehydratedState = dehydrate(queryClient)
 
+	const projectSchema = project
+		? {
+				'@context': 'https://schema.org',
+				'@type': 'Event',
+				name: project.title,
+				description: project.description ?? undefined,
+				url: `${BASE_URL}/projects/${slug}`,
+				image: project.image ?? undefined,
+				organizer: {
+					'@type': 'Organization',
+					name: 'KindFi',
+					url: BASE_URL,
+				},
+			}
+		: null
+
 	return (
-		<main
-			className="container mx-auto p-4 md:p-12"
-			aria-label="Project details"
-		>
-			<HydrationBoundary state={dehydratedState}>
-				<ProjectClientWrapper projectSlug={slug} />
-			</HydrationBoundary>
-		</main>
+		<>
+			<JsonLd
+				data={getBreadcrumbSchema([
+					{ name: 'Home', url: '/' },
+					{ name: 'Projects', url: '/projects' },
+					{ name: project?.title ?? slug, url: `/projects/${slug}` },
+				])}
+			/>
+			{projectSchema && <JsonLd data={projectSchema} />}
+			<main
+				className="container mx-auto p-4 md:p-12"
+				aria-label="Project details"
+			>
+				<HydrationBoundary state={dehydratedState}>
+					<ProjectClientWrapper projectSlug={slug} />
+				</HydrationBoundary>
+			</main>
+		</>
 	)
 }

--- a/apps/web/app/(routes)/projects/[slug]/page.tsx
+++ b/apps/web/app/(routes)/projects/[slug]/page.tsx
@@ -1,7 +1,4 @@
-import {
-	createSupabaseServerClient,
-	prefetchSupabaseQuery,
-} from '@packages/lib/supabase-server'
+import { createSupabaseServerClient } from '@packages/lib/supabase-server'
 import {
 	dehydrate,
 	HydrationBoundary,
@@ -12,10 +9,8 @@ import { notFound } from 'next/navigation'
 import { ProjectClientWrapper } from '~/components/sections/projects/detail/project-client-wrapper'
 import { JsonLd } from '~/components/shared/json-ld'
 import { getProjectBySlug } from '~/lib/queries/projects'
-import { getBreadcrumbSchema } from '~/lib/seo/structured-data'
+import { getBreadcrumbSchema, SITE_URL } from '~/lib/seo/structured-data'
 import { validateProjectSlug } from '~/lib/validation/project-slug'
-
-const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.kindfi.org'
 
 export async function generateMetadata({
 	params,
@@ -61,34 +56,29 @@ export default async function ProjectDetailPage({
 	const { slug } = await params
 	if (!validateProjectSlug(slug)) notFound()
 
-	const queryClient = new QueryClient()
 	const client = await createSupabaseServerClient()
 	const project = await getProjectBySlug(client, slug)
 
-	await prefetchSupabaseQuery(
-		queryClient,
-		'project',
-		(c) => getProjectBySlug(c, slug),
-		[slug],
-	)
+	if (!project) notFound()
+
+	const queryClient = new QueryClient()
+	queryClient.setQueryData(['supabase', 'project', slug], project)
 
 	const dehydratedState = dehydrate(queryClient)
 
-	const projectSchema = project
-		? {
-				'@context': 'https://schema.org',
-				'@type': 'Event',
-				name: project.title,
-				description: project.description ?? undefined,
-				url: `${BASE_URL}/projects/${slug}`,
-				image: project.image ?? undefined,
-				organizer: {
-					'@type': 'Organization',
-					name: 'KindFi',
-					url: BASE_URL,
-				},
-			}
-		: null
+	const projectSchema = {
+		'@context': 'https://schema.org',
+		'@type': 'Event',
+		name: project.title,
+		description: project.description ?? undefined,
+		url: `${SITE_URL}/projects/${slug}`,
+		image: project.image ?? undefined,
+		organizer: {
+			'@type': 'Organization',
+			name: 'KindFi',
+			url: SITE_URL,
+		},
+	}
 
 	return (
 		<>
@@ -99,7 +89,7 @@ export default async function ProjectDetailPage({
 					{ name: project?.title ?? slug, url: `/projects/${slug}` },
 				])}
 			/>
-			{projectSchema && <JsonLd data={projectSchema} />}
+			<JsonLd data={projectSchema} />
 			<main
 				className="container mx-auto p-4 md:p-12"
 				aria-label="Project details"

--- a/apps/web/app/(routes)/projects/page.tsx
+++ b/apps/web/app/(routes)/projects/page.tsx
@@ -1,18 +1,36 @@
-import type { Metadata } from 'next'
 import { prefetchSupabaseQuery } from '@packages/lib/supabase-server'
 import {
 	dehydrate,
 	HydrationBoundary,
 	QueryClient,
 } from '@tanstack/react-query'
+import type { Metadata } from 'next'
 import { ProjectsClientWrapper } from '~/components/sections/projects/projects-client-wrapper'
 import { ProjectsHero } from '~/components/sections/projects/projects-hero'
+import { JsonLd } from '~/components/shared/json-ld'
 import { getAllCategories, getAllProjects } from '~/lib/queries/projects'
+import { getBreadcrumbSchema } from '~/lib/seo/structured-data'
 
 export const metadata: Metadata = {
 	title: 'Projects | KindFi',
 	description:
-		'Explore and support transparent crowdfunding projects on KindFi. Filter by category, sort by popularity or funding.',
+		'Explore and support transparent crowdfunding projects on KindFi. Filter by category, sort by popularity or funding. Donate using crypto on the Stellar blockchain.',
+	openGraph: {
+		title: 'Projects | KindFi',
+		description:
+			'Discover impactful crowdfunding campaigns across social and environmental causes. Donate securely using Stellar blockchain.',
+		type: 'website',
+		url: '/projects',
+	},
+	twitter: {
+		card: 'summary_large_image',
+		title: 'Projects | KindFi',
+		description:
+			'Explore and support transparent crowdfunding projects on KindFi.',
+	},
+	alternates: {
+		canonical: '/projects',
+	},
 }
 
 export default async function ProjectsPage({
@@ -43,9 +61,17 @@ export default async function ProjectsPage({
 	const dehydratedState = dehydrate(queryClient)
 
 	return (
-		<HydrationBoundary state={dehydratedState}>
-			<ProjectsHero categorySlugs={categorySlugs} sortSlug={sortSlug} />
-			<ProjectsClientWrapper />
-		</HydrationBoundary>
+		<>
+			<JsonLd
+				data={getBreadcrumbSchema([
+					{ name: 'Home', url: '/' },
+					{ name: 'Projects', url: '/projects' },
+				])}
+			/>
+			<HydrationBoundary state={dehydratedState}>
+				<ProjectsHero categorySlugs={categorySlugs} sortSlug={sortSlug} />
+				<ProjectsClientWrapper />
+			</HydrationBoundary>
+		</>
 	)
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -8,15 +8,13 @@ import { nextAuthOption } from '~/lib/auth/auth-options'
 import {
 	getOrganizationSchema,
 	getWebSiteSchema,
+	SITE_URL,
 } from '~/lib/seo/structured-data'
 
 const appConfig: AppEnvInterface = appEnvConfig('web')
 
-const defaultUrl = appConfig.deployment.vercelUrl
-	? `https://${appConfig.deployment.vercelUrl}`
-	: 'http://localhost:3000'
 export const metadata = {
-	metadataBase: new URL(defaultUrl),
+	metadataBase: new URL(SITE_URL),
 	title: {
 		default: 'KindFi — Web3 Crowdfunding for Social Impact',
 		template: '%s | KindFi',
@@ -32,22 +30,14 @@ export const metadata = {
 		'NGO funding',
 		'decentralized fundraising',
 	],
-	authors: [{ name: 'KindFi', url: defaultUrl }],
+	authors: [{ name: 'KindFi', url: SITE_URL }],
 	creator: 'KindFi',
 	publisher: 'KindFi',
 	openGraph: {
 		siteName: 'KindFi',
 		type: 'website',
 		locale: 'en_US',
-		url: defaultUrl,
-		images: [
-			{
-				url: '/images/og-home.png',
-				width: 1200,
-				height: 630,
-				alt: 'KindFi — Web3 Crowdfunding for Social Impact',
-			},
-		],
+		url: SITE_URL,
 	},
 	twitter: {
 		card: 'summary_large_image',

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,7 +3,12 @@ import type { AppEnvInterface } from '@packages/lib/types'
 import { getServerSession } from 'next-auth'
 import { LayoutContainer } from '~/components/layout-container'
 import { GoogleAnalytics } from '~/components/shared/google-analytics'
+import { JsonLd } from '~/components/shared/json-ld'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import {
+	getOrganizationSchema,
+	getWebSiteSchema,
+} from '~/lib/seo/structured-data'
 
 const appConfig: AppEnvInterface = appEnvConfig('web')
 
@@ -13,14 +18,51 @@ const defaultUrl = appConfig.deployment.vercelUrl
 export const metadata = {
 	metadataBase: new URL(defaultUrl),
 	title: {
-		default: 'KindFi',
+		default: 'KindFi — Web3 Crowdfunding for Social Impact',
 		template: '%s | KindFi',
 	},
 	description:
-		'The first Web3 platform connecting supporters to impactful causes while driving blockchain adoption for social and environmental change',
+		'KindFi is the first Web3 crowdfunding platform connecting supporters to impactful social and environmental causes. Milestone-based funding on Stellar ensures transparency, accountability, and real-world impact.',
+	keywords: [
+		'blockchain crowdfunding',
+		'social impact',
+		'Web3 donations',
+		'Stellar blockchain',
+		'crypto philanthropy',
+		'NGO funding',
+		'decentralized fundraising',
+	],
+	authors: [{ name: 'KindFi', url: defaultUrl }],
+	creator: 'KindFi',
+	publisher: 'KindFi',
 	openGraph: {
 		siteName: 'KindFi',
 		type: 'website',
+		locale: 'en_US',
+		url: defaultUrl,
+		images: [
+			{
+				url: '/images/og-home.png',
+				width: 1200,
+				height: 630,
+				alt: 'KindFi — Web3 Crowdfunding for Social Impact',
+			},
+		],
+	},
+	twitter: {
+		card: 'summary_large_image',
+		site: '@kindfi_org',
+		creator: '@kindfi_org',
+	},
+	robots: {
+		index: true,
+		follow: true,
+		googleBot: {
+			index: true,
+			follow: true,
+			'max-image-preview': 'large' as const,
+			'max-snippet': -1,
+		},
 	},
 }
 
@@ -33,6 +75,7 @@ export default async function RootLayout({
 	return (
 		<html lang="en" suppressHydrationWarning>
 			<body suppressHydrationWarning>
+				<JsonLd data={[getOrganizationSchema(), getWebSiteSchema()]} />
 				<LayoutContainer session={session}>{children}</LayoutContainer>
 				<GoogleAnalytics GA_MEASUREMENT_ID={appConfig.analytics.gaId} />
 			</body>

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,77 @@
+import type { MetadataRoute } from 'next'
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.kindfi.org'
+
+export default function robots(): MetadataRoute.Robots {
+	return {
+		rules: [
+			{
+				userAgent: '*',
+				allow: '/',
+				disallow: [
+					'/api/',
+					'/admin/',
+					'/sign-in',
+					'/sign-up',
+					'/reset-password',
+					'/otp-validation',
+					'/passkey-registration',
+					'/reset-account',
+					'/profile',
+					'/create-project',
+					'/create-foundation',
+				],
+			},
+			// Allow Google's AI Overview crawler
+			{
+				userAgent: 'Google-Extended',
+				allow: '/',
+				disallow: [
+					'/api/',
+					'/admin/',
+					'/sign-in',
+					'/sign-up',
+					'/reset-password',
+					'/otp-validation',
+					'/passkey-registration',
+					'/reset-account',
+					'/profile',
+					'/create-project',
+					'/create-foundation',
+				],
+			},
+			// Allow OpenAI's crawler for ChatGPT search
+			{
+				userAgent: 'GPTBot',
+				allow: '/',
+				disallow: ['/api/', '/admin/', '/profile'],
+			},
+			// Allow Perplexity AI crawler
+			{
+				userAgent: 'PerplexityBot',
+				allow: '/',
+				disallow: ['/api/', '/admin/', '/profile'],
+			},
+			// Allow Anthropic's Claude crawler
+			{
+				userAgent: 'ClaudeBot',
+				allow: '/',
+				disallow: ['/api/', '/admin/', '/profile'],
+			},
+			// Allow anthropic-ai crawler
+			{
+				userAgent: 'anthropic-ai',
+				allow: '/',
+				disallow: ['/api/', '/admin/', '/profile'],
+			},
+			// Allow Bing/Copilot crawler
+			{
+				userAgent: 'Bingbot',
+				allow: '/',
+				disallow: ['/api/', '/admin/', '/profile'],
+			},
+		],
+		sitemap: `${BASE_URL}/sitemap.xml`,
+		host: BASE_URL,
+	}
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from 'next'
 import { readAllPosts } from '~/lib/mdx'
+import { SITE_URL } from '~/lib/seo/structured-data'
 
 type ChangeFreq =
 	| 'always'
@@ -27,11 +28,9 @@ const STATIC_ROUTES: {
 ]
 
 export default function sitemap(): MetadataRoute.Sitemap {
-	const base = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-
 	const routes: MetadataRoute.Sitemap = STATIC_ROUTES.map(
 		({ path, priority, changeFrequency }) => ({
-			url: `${base}${path}`,
+			url: `${SITE_URL}${path}`,
 			lastModified: new Date(),
 			changeFrequency,
 			priority,
@@ -39,7 +38,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 	)
 
 	const posts: MetadataRoute.Sitemap = readAllPosts().map((post) => ({
-		url: `${base}/news/${post.slug}`,
+		url: `${SITE_URL}/news/${post.slug}`,
 		lastModified: new Date(post.updated || post.date),
 		changeFrequency: 'weekly' as const,
 		priority: 0.7,

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,26 +1,49 @@
 import type { MetadataRoute } from 'next'
 import { readAllPosts } from '~/lib/mdx'
 
+type ChangeFreq =
+	| 'always'
+	| 'hourly'
+	| 'daily'
+	| 'weekly'
+	| 'monthly'
+	| 'yearly'
+	| 'never'
+
+const STATIC_ROUTES: {
+	path: string
+	priority: number
+	changeFrequency: ChangeFreq
+}[] = [
+	{ path: '', priority: 1, changeFrequency: 'daily' },
+	{ path: '/about', priority: 0.9, changeFrequency: 'monthly' },
+	{ path: '/projects', priority: 0.9, changeFrequency: 'daily' },
+	{ path: '/news', priority: 0.8, changeFrequency: 'daily' },
+	{ path: '/governance', priority: 0.8, changeFrequency: 'weekly' },
+	{ path: '/faqs', priority: 0.7, changeFrequency: 'monthly' },
+	{ path: '/foundations', priority: 0.8, changeFrequency: 'weekly' },
+	{ path: '/impact', priority: 0.7, changeFrequency: 'weekly' },
+	{ path: '/featured', priority: 0.7, changeFrequency: 'weekly' },
+]
+
 export default function sitemap(): MetadataRoute.Sitemap {
 	const base = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-	const routes: MetadataRoute.Sitemap = [
-		'',
-		'/about',
-		'/impact',
-		'/featured',
-		'/projects',
-		'/news',
-	].map((route) => ({
-		url: `${base}${route}`,
-		lastModified: new Date(),
-		changeFrequency: 'weekly' as const,
-		priority: route === '' ? 1 : 0.8,
-	}))
+
+	const routes: MetadataRoute.Sitemap = STATIC_ROUTES.map(
+		({ path, priority, changeFrequency }) => ({
+			url: `${base}${path}`,
+			lastModified: new Date(),
+			changeFrequency,
+			priority,
+		}),
+	)
+
 	const posts: MetadataRoute.Sitemap = readAllPosts().map((post) => ({
 		url: `${base}/news/${post.slug}`,
 		lastModified: new Date(post.updated || post.date),
 		changeFrequency: 'weekly' as const,
 		priority: 0.7,
 	}))
+
 	return [...routes, ...posts]
 }

--- a/apps/web/components/shared/json-ld.tsx
+++ b/apps/web/components/shared/json-ld.tsx
@@ -1,0 +1,13 @@
+interface JsonLdProps {
+	data: Record<string, unknown> | Record<string, unknown>[]
+}
+
+export function JsonLd({ data }: JsonLdProps) {
+	return (
+		<script
+			type="application/ld+json"
+			// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data is safe and required for SEO
+			dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+		/>
+	)
+}

--- a/apps/web/components/shared/json-ld.tsx
+++ b/apps/web/components/shared/json-ld.tsx
@@ -3,11 +3,16 @@ interface JsonLdProps {
 }
 
 export function JsonLd({ data }: JsonLdProps) {
+	const safeJson = JSON.stringify(data)
+		.replace(/</g, '\\u003c')
+		.replace(/>/g, '\\u003e')
+		.replace(/&/g, '\\u0026')
+
 	return (
 		<script
 			type="application/ld+json"
 			// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data is safe and required for SEO
-			dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+			dangerouslySetInnerHTML={{ __html: safeJson }}
 		/>
 	)
 }

--- a/apps/web/lib/seo/structured-data.ts
+++ b/apps/web/lib/seo/structured-data.ts
@@ -1,0 +1,67 @@
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.kindfi.org'
+
+export function getOrganizationSchema() {
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'Organization',
+		name: 'KindFi',
+		url: BASE_URL,
+		logo: `${BASE_URL}/icons/kindfi-logo.svg`,
+		description:
+			'KindFi is the first Web3 crowdfunding platform connecting supporters to impactful social and environmental causes. Milestone-based funding on Stellar ensures transparency and accountability.',
+		foundingDate: '2024',
+		sameAs: ['https://github.com/kindfi-org/kindfi'],
+		contactPoint: {
+			'@type': 'ContactPoint',
+			contactType: 'customer support',
+			url: `${BASE_URL}/faqs`,
+		},
+	}
+}
+
+export function getWebSiteSchema() {
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'WebSite',
+		name: 'KindFi',
+		url: BASE_URL,
+		description:
+			'Web3 crowdfunding platform for social and environmental impact, built on the Stellar blockchain.',
+		potentialAction: {
+			'@type': 'SearchAction',
+			target: {
+				'@type': 'EntryPoint',
+				urlTemplate: `${BASE_URL}/projects?search={search_term_string}`,
+			},
+			'query-input': 'required name=search_term_string',
+		},
+	}
+}
+
+export function getBreadcrumbSchema(items: { name: string; url: string }[]) {
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'BreadcrumbList',
+		itemListElement: items.map((item, index) => ({
+			'@type': 'ListItem',
+			position: index + 1,
+			name: item.name,
+			item: item.url.startsWith('http') ? item.url : `${BASE_URL}${item.url}`,
+		})),
+	}
+}
+
+export function getFaqPageSchema(faqs: { question: string; answer: string }[]) {
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'FAQPage',
+		mainEntity: faqs.map(({ question, answer }) => ({
+			'@type': 'Question',
+			name: question,
+			acceptedAnswer: {
+				'@type': 'Answer',
+				text: answer,
+			},
+		})),
+	}
+}

--- a/apps/web/lib/seo/structured-data.ts
+++ b/apps/web/lib/seo/structured-data.ts
@@ -1,12 +1,63 @@
-const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.kindfi.org'
+export const SITE_URL =
+	process.env.NEXT_PUBLIC_SITE_URL || 'https://www.kindfi.org'
 
-export function getOrganizationSchema() {
+export interface OrganizationSchema {
+	'@context': string
+	'@type': 'Organization'
+	name: string
+	url: string
+	logo: string
+	description: string
+	foundingDate: string
+	sameAs: string[]
+	contactPoint: {
+		'@type': 'ContactPoint'
+		contactType: string
+		url: string
+	}
+}
+
+export interface WebSiteSchema {
+	'@context': string
+	'@type': 'WebSite'
+	name: string
+	url: string
+	description: string
+	potentialAction: {
+		'@type': 'SearchAction'
+		target: { '@type': 'EntryPoint'; urlTemplate: string }
+		'query-input': string
+	}
+}
+
+export interface BreadcrumbListSchema {
+	'@context': string
+	'@type': 'BreadcrumbList'
+	itemListElement: {
+		'@type': 'ListItem'
+		position: number
+		name: string
+		item: string
+	}[]
+}
+
+export interface FAQPageSchema {
+	'@context': string
+	'@type': 'FAQPage'
+	mainEntity: {
+		'@type': 'Question'
+		name: string
+		acceptedAnswer: { '@type': 'Answer'; text: string }
+	}[]
+}
+
+export function getOrganizationSchema(): OrganizationSchema {
 	return {
 		'@context': 'https://schema.org',
 		'@type': 'Organization',
 		name: 'KindFi',
-		url: BASE_URL,
-		logo: `${BASE_URL}/icons/kindfi-logo.svg`,
+		url: SITE_URL,
+		logo: `${SITE_URL}/icons/kindfi-logo.svg`,
 		description:
 			'KindFi is the first Web3 crowdfunding platform connecting supporters to impactful social and environmental causes. Milestone-based funding on Stellar ensures transparency and accountability.',
 		foundingDate: '2024',
@@ -14,31 +65,33 @@ export function getOrganizationSchema() {
 		contactPoint: {
 			'@type': 'ContactPoint',
 			contactType: 'customer support',
-			url: `${BASE_URL}/faqs`,
+			url: `${SITE_URL}/faqs`,
 		},
 	}
 }
 
-export function getWebSiteSchema() {
+export function getWebSiteSchema(): WebSiteSchema {
 	return {
 		'@context': 'https://schema.org',
 		'@type': 'WebSite',
 		name: 'KindFi',
-		url: BASE_URL,
+		url: SITE_URL,
 		description:
 			'Web3 crowdfunding platform for social and environmental impact, built on the Stellar blockchain.',
 		potentialAction: {
 			'@type': 'SearchAction',
 			target: {
 				'@type': 'EntryPoint',
-				urlTemplate: `${BASE_URL}/projects?search={search_term_string}`,
+				urlTemplate: `${SITE_URL}/projects?search={search_term_string}`,
 			},
 			'query-input': 'required name=search_term_string',
 		},
 	}
 }
 
-export function getBreadcrumbSchema(items: { name: string; url: string }[]) {
+export function getBreadcrumbSchema(
+	items: { name: string; url: string }[],
+): BreadcrumbListSchema {
 	return {
 		'@context': 'https://schema.org',
 		'@type': 'BreadcrumbList',
@@ -46,12 +99,14 @@ export function getBreadcrumbSchema(items: { name: string; url: string }[]) {
 			'@type': 'ListItem',
 			position: index + 1,
 			name: item.name,
-			item: item.url.startsWith('http') ? item.url : `${BASE_URL}${item.url}`,
+			item: item.url.startsWith('http') ? item.url : `${SITE_URL}${item.url}`,
 		})),
 	}
 }
 
-export function getFaqPageSchema(faqs: { question: string; answer: string }[]) {
+export function getFaqPageSchema(
+	faqs: { question: string; answer: string }[],
+): FAQPageSchema {
 	return {
 		'@context': 'https://schema.org',
 		'@type': 'FAQPage',

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -1,0 +1,44 @@
+# KindFi - llms.txt
+# https://llmstxt.org/
+
+> KindFi is a Web3 crowdfunding platform connecting donors and supporters with impactful social and environmental causes. Built on the Stellar blockchain, KindFi enables transparent, milestone-based funding for NGOs and social projects worldwide.
+
+## About KindFi
+
+KindFi is the first blockchain-powered crowdfunding platform focused on social impact. It uses Stellar smart contracts to ensure funds are released only when verifiable milestones are met, giving donors confidence their contributions create real change.
+
+## Key Pages
+
+- [Home](https://www.kindfi.org/): Platform overview, featured campaigns, and mission statement
+- [Projects](https://www.kindfi.org/projects): Browse and support active crowdfunding campaigns across social and environmental causes
+- [About Us](https://www.kindfi.org/about): Mission, vision, how KindFi works, and the team behind it
+- [Governance](https://www.kindfi.org/governance): Community voting on fund redistribution to impactful campaigns
+- [FAQs](https://www.kindfi.org/faqs): Frequently asked questions about the platform, campaigns, and donors
+- [News](https://www.kindfi.org/news): Latest updates, articles, and impact stories from KindFi
+
+## Platform Description
+
+KindFi bridges the gap between blockchain technology and social good. Campaigns are structured with milestone-based escrow contracts on the Stellar network, ensuring accountability and transparency. Donors can track exactly how funds are used, and NGOs gain access to a global network of impact-driven supporters.
+
+## Key Topics
+
+- Crypto-based crowdfunding for social impact
+- Blockchain donations and transparency
+- Milestone-based funding for NGOs
+- Stellar network and Soroban smart contracts
+- Decentralized governance for community fund allocation
+- How to donate to social impact campaigns using crypto
+- Web3 philanthropy and financial inclusion
+
+## Content Usage
+
+KindFi welcomes AI crawlers and LLMs to index and summarize its public content for the purpose of helping users discover and understand the platform. We ask that:
+
+1. Attribution is given to KindFi (kindfi.org) when referencing platform content
+2. Campaign data and NGO profiles are represented accurately and with context
+3. Private user data (profiles, account pages) is not indexed
+
+## Contact
+
+- Website: https://www.kindfi.org
+- GitHub: https://github.com/kindfi-org/kindfi


### PR DESCRIPTION
## Description

Implements full SEO and AI Optimization (AIO) alignment for the KindFi web app, ensuring content is discoverable in traditional search engines and AI-powered experiences (Google AI Overviews, ChatGPT, Gemini, Bing Copilot, Perplexity, etc.).

## Changes

### New Files
- **`apps/web/app/robots.ts`** — Next.js App Router robots file with explicit AI crawler policies for `GPTBot`, `Google-Extended`, `PerplexityBot`, `ClaudeBot`, `anthropic-ai`, and `Bingbot`
- **`apps/web/public/llms.txt`** — Emerging standard file communicating platform intent, key pages, and content usage policy to LLM crawlers
- **`apps/web/components/shared/json-ld.tsx`** — Reusable `<JsonLd>` component for server-side injection of structured data
- **`apps/web/lib/seo/structured-data.ts`** — Factory functions for `Organization`, `WebSite`, `FAQPage`, `BreadcrumbList`, and `Event` JSON-LD schemas

### Modified Files
- **`apps/web/app/layout.tsx`** — Enriched global metadata (keywords, authors, Twitter Card, robots policy); injected `Organization` + `WebSite` JSON-LD site-wide
- **`apps/web/app/sitemap.ts`** — Added missing routes (`/governance`, `/faqs`, `/foundations`); differentiated priorities and `changeFrequency` per page type
- **`apps/web/app/(routes)/home/page.tsx`** — Added full metadata with title, description, OG tags, Twitter Card, keywords, and canonical URL
- **`apps/web/app/(routes)/faqs/page.tsx`** — Added metadata + `FAQPage` JSON-LD (from existing FAQ mock data) + `BreadcrumbList`
- **`apps/web/app/(routes)/governance/page.tsx`** — Enriched metadata with OG tags, Twitter Card, and canonical; added `BreadcrumbList` JSON-LD
- **`apps/web/app/(routes)/about/page.tsx`** — Enriched metadata; added `BreadcrumbList` JSON-LD
- **`apps/web/app/(routes)/profile/page.tsx`** — Added metadata with `robots: noindex/nofollow` (private authenticated page)
- **`apps/web/app/(routes)/projects/page.tsx`** — Enriched metadata with OG tags, Twitter Card, canonical; added `BreadcrumbList` JSON-LD
- **`apps/web/app/(routes)/projects/[slug]/page.tsx`** — Enriched `generateMetadata` with Twitter Card and canonical; added `Event` + `BreadcrumbList` JSON-LD per project

## Acceptance Criteria Coverage

- [x] All key pages have complete metadata (title, description, OG, Twitter Card, canonical)
- [x] `robots.ts` created with explicit AI crawler access policy
- [x] `sitemap.ts` updated with all public routes
- [x] `FAQPage` JSON-LD added to `/faqs` using existing FAQ data
- [x] `Organization` and `WebSite` JSON-LD injected site-wide via root layout
- [x] `BreadcrumbList` JSON-LD added to key pages
- [x] `Event` JSON-LD added to project detail pages
- [x] `llms.txt` added to communicate intent to LLM crawlers
- [x] `/profile` marked as noindex/nofollow (private page)
- [x] No new TypeScript errors or hydration warnings introduced
- [x] Biome linter passes on all modified files

## Notes

- TypeScript errors present in the repo (`qa-client.tsx`, `role-card.tsx`, `project-sidebar.tsx`, etc.) are pre-existing and not related to this PR.
- The `og-home.png` image referenced in OG tags should be added to `/public/images/` as a follow-up; currently falls back to the global OG image.
- AIO is an evolving standard — the `llms.txt` and `robots.ts` policies should be reviewed quarterly as guidelines mature.

Closes #853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced SEO metadata across multiple pages including Open Graph and Twitter card information
  * Added structured data markup for improved search engine understanding and rich snippets
  * Implemented breadcrumb navigation schema for better search result displays
  * Added AI crawler policy configuration to guide LLM and bot access
  * Updated sitemap with configurable change frequency and priority settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->