### PR TITLE
chore(perf): replace lodash barrel imports with subpath imports

### DIFF
--- a/apps/web/hooks/use-form-validation.ts
+++ b/apps/web/hooks/use-form-validation.ts
@@ -1,5 +1,5 @@
 import { createSupabaseBrowserClient } from '@packages/lib/supabase-client'
-import { throttle } from 'lodash'
+import throttle from 'lodash/throttle'
 import { useState } from 'react'
 
 /**

--- a/packages/lib/src/hooks/stellar/use-smart-wallet.hook.ts
+++ b/packages/lib/src/hooks/stellar/use-smart-wallet.hook.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { debounce } from 'lodash'
+import debounce from 'lodash/debounce'
 import type { Session } from 'next-auth'
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'


### PR DESCRIPTION
Closes #888 

## Description
Replaced full lodash barrel imports (`import { ... } from 'lodash'`) with per-method subpath imports (`import throttle from 'lodash/throttle'`) to avoid pulling the entire lodash tree into our client bundles. 

## Impact
This improves tree-shaking and optimizes the bundle size for `use-form-validation.ts` and `use-smart-wallet.hook.ts`. It also brings them in line with the rest of the codebase which already uses tree-shakeable subpaths.

## Files Changed
- `apps/web/hooks/use-form-validation.ts`
- `packages/lib/src/hooks/stellar/use-smart-wallet.hook.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module imports for optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->