### PR TITLE
feat: paginate unbounded list API endpoints

### DIFF
--- a/apps/web/app/api/governance/rounds/route.ts
+++ b/apps/web/app/api/governance/rounds/route.ts
@@ -19,13 +19,17 @@ import { validateRequest } from '~/lib/utils/validation'
 export async function GET(req: NextRequest) {
 	try {
 		const { supabase } = await import('@packages/lib/supabase')
-		const { searchParams } = new URL(req.url)
-		const queryData = { status: searchParams.get('status') ?? undefined }
+		const { searchParams } = req.nextUrl
+		const queryData = {
+			status: searchParams.get('status') ?? undefined,
+			limit: searchParams.get('limit'),
+			offset: searchParams.get('offset'),
+		}
 		const validation = validateRequest(governanceRoundsQuerySchema, queryData)
 		if (!validation.success) {
 			return validation.response
 		}
-		const { status } = validation.data
+		const { status, limit, offset } = validation.data
 
 		// Auto-activate and close rounds based on current time
 		await supabase.rpc('activate_governance_rounds')
@@ -38,6 +42,7 @@ export async function GET(req: NextRequest) {
 				*,
 				options:governance_options!governance_options_round_id_fkey(*)
 			`,
+				{ count: 'exact' },
 			)
 			.order('starts_at', { ascending: false })
 
@@ -45,7 +50,7 @@ export async function GET(req: NextRequest) {
 			query = query.eq('status', status)
 		}
 
-		const { data: rounds, error } = await query
+		const { data: rounds, error, count } = await query.range(offset, offset + limit - 1)
 
 		if (error) {
 			logger.error('Error fetching governance rounds:', error)
@@ -82,7 +87,11 @@ export async function GET(req: NextRequest) {
 			}),
 		)
 
-		return NextResponse.json({ success: true, data: enrichedRounds })
+		return NextResponse.json({
+			success: true,
+			data: enrichedRounds,
+			pagination: { limit, offset, total: count ?? 0 },
+		})
 	} catch (error) {
 		logger.error('Error in GET /api/governance/rounds:', error)
 		return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/apps/web/app/api/referrals/route.ts
+++ b/apps/web/app/api/referrals/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { limitOffsetQuerySchema } from '~/lib/schemas/common.schemas'
 import { createReferralSchema } from '~/lib/schemas/referral.schemas'
 import { GamificationContractService } from '~/lib/stellar/gamification-contracts'
 import { validateRequest } from '~/lib/utils/validation'
@@ -34,12 +35,22 @@ async function resolveUserStellarAddress(
  * but this app authenticates via NextAuth. The session check above ensures
  * only authenticated users can access this endpoint.
  */
-export async function GET(_req: NextRequest) {
+export async function GET(req: NextRequest) {
 	try {
 		const session = await getServerSession(nextAuthOption)
 		if (!session?.user?.id) {
 			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 		}
+
+		const { searchParams } = req.nextUrl
+		const paginationValidation = validateRequest(limitOffsetQuerySchema, {
+			limit: searchParams.get('limit'),
+			offset: searchParams.get('offset'),
+		})
+		if (!paginationValidation.success) {
+			return paginationValidation.response
+		}
+		const { limit, offset } = paginationValidation.data
 
 		// Use service role client to bypass RLS — auth is handled by NextAuth session above
 		const { supabase } = await import('@packages/lib/supabase')
@@ -48,14 +59,15 @@ export async function GET(_req: NextRequest) {
 		const [referralsResult, statsResult, referredResult] = await Promise.all([
 			supabase
 				.from('referral_records')
-				.select('*')
+				.select('*', { count: 'exact' })
 				.eq('referrer_id', session.user.id)
-				.order('created_at', { ascending: false }),
+				.order('created_at', { ascending: false })
+				.range(offset, offset + limit - 1),
 			supabase.from('referrer_statistics').select('*').eq('referrer_id', session.user.id).single(),
 			supabase.from('referral_records').select('*').eq('referred_id', session.user.id).single(),
 		])
 
-		const { data: referrals, error: referralsError } = referralsResult
+		const { data: referrals, error: referralsError, count: referralsCount } = referralsResult
 		const { data: stats, error: statsError } = statsResult
 		const { data: referredRecord } = referredResult
 
@@ -75,6 +87,7 @@ export async function GET(_req: NextRequest) {
 				total_reward_points: 0,
 			},
 			referred_by: referredRecord?.referrer_id || null,
+			pagination: { limit, offset, total: referralsCount ?? 0 },
 		})
 	} catch (error) {
 		logger.error('Error in GET /api/referrals:', error)

--- a/apps/web/app/api/streaks/route.ts
+++ b/apps/web/app/api/streaks/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { limitOffsetQuerySchema } from '~/lib/schemas/common.schemas'
 import { recordStreakSchema } from '~/lib/schemas/streak.schemas'
 import { GamificationContractService } from '~/lib/stellar/gamification-contracts'
 import { validateRequest } from '~/lib/utils/validation'
@@ -15,28 +16,46 @@ import { validateRequest } from '~/lib/utils/validation'
  * but this app authenticates via NextAuth. The session check above ensures
  * only authenticated users can access this endpoint.
  */
-export async function GET(_req: NextRequest) {
+export async function GET(req: NextRequest) {
 	try {
 		const session = await getServerSession(nextAuthOption)
 		if (!session?.user?.id) {
 			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 		}
 
+		const { searchParams } = req.nextUrl
+		const paginationValidation = validateRequest(limitOffsetQuerySchema, {
+			limit: searchParams.get('limit'),
+			offset: searchParams.get('offset'),
+		})
+		if (!paginationValidation.success) {
+			return paginationValidation.response
+		}
+		const { limit, offset } = paginationValidation.data
+
 		// Use service role client to bypass RLS — auth is handled by NextAuth session above
 		const { supabase } = await import('@packages/lib/supabase')
 
-		const { data: streaks, error } = await supabase
+		const {
+			data: streaks,
+			error,
+			count,
+		} = await supabase
 			.from('user_streaks')
-			.select('*')
+			.select('*', { count: 'exact' })
 			.eq('user_id', session.user.id)
 			.order('period', { ascending: true })
+			.range(offset, offset + limit - 1)
 
 		if (error) {
 			logger.error('Error fetching streaks:', error)
 			return NextResponse.json({ error: 'Failed to fetch streaks' }, { status: 500 })
 		}
 
-		return NextResponse.json({ streaks: streaks || [] })
+		return NextResponse.json({
+			streaks: streaks || [],
+			pagination: { limit, offset, total: count ?? 0 },
+		})
 	} catch (error) {
 		logger.error('Error in GET /api/streaks:', error)
 		return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/apps/web/lib/schemas/governance.schemas.ts
+++ b/apps/web/lib/schemas/governance.schemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
+import { limitOffsetQuerySchema } from './common.schemas'
 
-export const governanceRoundsQuerySchema = z.object({
+export const governanceRoundsQuerySchema = limitOffsetQuerySchema.extend({
 	status: z.enum(['upcoming', 'active', 'ended']).optional(),
 })
 


### PR DESCRIPTION
## Summary
- Add capped `limit`/`offset` pagination (default 50, max 100) to `GET /api/referrals`, `GET /api/governance/rounds`, and `GET /api/streaks`
- Reuse `limitOffsetQuerySchema` and apply Supabase `.range()` with `count: 'exact'` for accurate totals
- Preserve existing response shapes and add a `pagination: { limit, offset, total }` object for backward compatibility

Closes #886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pagination support added to governance rounds, referrals, and streaks API endpoints with configurable limit and offset parameters.
  * API responses now include pagination metadata (total count, limit, offset) to help users navigate large result sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->