### PR TITLE
perf: reduce Q&A server fetch waterfall and over-fetch

### DIFF
--- a/apps/web/components/shared/qa-server.tsx
+++ b/apps/web/components/shared/qa-server.tsx
@@ -2,93 +2,82 @@ import { createSupabaseServerClient } from '@packages/lib/supabase-server'
 import type { Tables } from '@services/supabase'
 import { Loader2 } from 'lucide-react'
 import { Suspense } from 'react'
-import type {
-	CommentData,
-	QAProps,
-	QuestionData,
-	UserData,
-} from '~/lib/types/project/project-qa.types'
+import type { CommentData, QAProps, QuestionData } from '~/lib/types/project/project-qa.types'
 import QAClient from './qa-client'
+
+type QAAuthor = Pick<Tables<'profiles'>, 'id' | 'display_name' | 'image_url' | 'role'>
 
 export default async function QA({ projectId, currentUser }: QAProps) {
 	const supabase = await createSupabaseServerClient()
 
-	const { data: initialQuestions, error: questionsError } = await supabase
-		.from('comments')
-		.select('id, content, created_at, project_id, author_id, type, parent_comment_id, metadata')
-		.eq('project_id', projectId)
-		.eq('type', 'question')
-		.is('parent_comment_id', null)
-		.order('created_at', { ascending: false })
+	const [questionsResult, commentsResult] = await Promise.all([
+		supabase
+			.from('comments')
+			.select('id, content, created_at, project_id, author_id, type, parent_comment_id, metadata')
+			.eq('project_id', projectId)
+			.eq('type', 'question')
+			.is('parent_comment_id', null)
+			.order('created_at', { ascending: false }),
+		supabase
+			.from('comments')
+			.select('*')
+			.eq('project_id', projectId)
+			.not('parent_comment_id', 'is', null)
+			.order('created_at', { ascending: true })
+			.limit(50),
+	])
 
-	let questionsWithAuthors: QuestionData[] = []
+	const { data: initialQuestions, error: questionsError } = questionsResult
+	const { data: commentsData } = commentsResult
 
-	if (initialQuestions && initialQuestions.length > 0) {
-		const authorIds = [...new Set(initialQuestions.map((item) => item.author_id))]
+	const authorIds = [
+		...new Set([
+			...(initialQuestions ?? []).map((item) => item.author_id),
+			...(commentsData ?? []).map((item) => item.author_id),
+		]),
+	].filter(Boolean)
 
-		const { data: authors } = await supabase.from('profiles').select('*').in('id', authorIds)
+	let authorsMap: Record<string, QAAuthor> = {}
+	if (authorIds.length > 0) {
+		const { data: authors } = await supabase
+			.from('profiles')
+			.select('id, display_name, image_url, role')
+			.in('id', authorIds)
 
-		const authorsMap = authors
-			? authors.reduce(
-					(acc: Record<string, Tables<'profiles'>>, author: Tables<'profiles'>) => {
-						acc[author.id] = author
-						return acc
-					},
-					{} as Record<string, Tables<'profiles'>>,
-				)
-			: {}
-
-		questionsWithAuthors = initialQuestions.map((question) => ({
-			...question,
-			author:
-				authorsMap[question.author_id] ||
-				(question.author_id?.includes('-')
-					? {
-							id: question.author_id,
-							full_name: 'Guest User',
-							is_team_member: false,
-						}
-					: undefined),
-		})) as unknown as QuestionData[]
+		authorsMap = (authors ?? []).reduce(
+			(acc: Record<string, QAAuthor>, author: QAAuthor) => {
+				acc[author.id] = author
+				return acc
+			},
+			{} as Record<string, QAAuthor>,
+		)
 	}
 
-	const { data: commentsData } = await supabase
-		.from('comments')
-		.select('*')
-		.eq('project_id', projectId)
-		.not('parent_comment_id', 'is', null)
-		.order('created_at', { ascending: true })
+	const questionsWithAuthors = (initialQuestions ?? []).map((question) => ({
+		...question,
+		author:
+			authorsMap[question.author_id] ||
+			(question.author_id?.includes('-')
+				? {
+						id: question.author_id,
+						full_name: 'Guest User',
+						is_team_member: false,
+					}
+				: undefined),
+	})) as unknown as QuestionData[]
 
-	let commentsWithAuthors: CommentData[] = []
-
-	if (commentsData && commentsData.length > 0) {
-		const authorIds = [...new Set(commentsData.map((item) => item.author_id))]
-
-		const { data: authors } = await supabase.from('profiles').select('*').in('id', authorIds)
-
-		const authorsMap = authors
-			? authors.reduce(
-					(acc: Record<string, UserData>, author: Tables<'profiles'>) => {
-						acc[author.id] = author
-						return acc
-					},
-					{} as Record<string, UserData>,
-				)
-			: {}
-
-		commentsWithAuthors = commentsData.map((comment) => ({
-			...comment,
-			author:
-				authorsMap[comment.author_id] ||
-				(comment.author_id?.includes('-')
-					? {
-							id: comment.author_id,
-							full_name: 'Guest User',
-							is_team_member: false,
-						}
-					: undefined),
-		})) as CommentData[]
-	}
+	const commentsWithAuthors = (commentsData ?? []).map((comment) => ({
+		...comment,
+		author:
+			authorsMap[comment.author_id] ||
+			(comment.author_id?.includes('-')
+				? {
+						id: comment.author_id,
+						full_name: 'Guest User',
+						is_team_member: false,
+					}
+				: undefined),
+	})) as CommentData[]
 
 	if (questionsError) {
 		return (


### PR DESCRIPTION
## Summary
- Parallelize the questions and child-comment queries in `qa-server.tsx` (wave 1)
- Batch author profile lookups into a single narrowed select: `id, display_name, image_url, role` (wave 2)
- Cap the initial child-comment fetch at 50 rows to prevent unbounded payloads
- Preserve existing guest-author fallback logic and client `initialData` contract

## Before / after
| Before | After |
|--------|-------|
| 4 sequential Supabase round-trips | 3 round-trips in 2 waves (questions + comments parallel, then one profiles fetch) |
| 2x `profiles.select('*')` | 1x narrowed profile select |
| Unbounded child comments | `.limit(50)` on initial server fetch |

## Why `display_name` not `full_name`?
The `profiles` table has `display_name`, not `full_name`. `UserInfo` discriminates profile vs guest via `'display_name' in authorData` and reads `role` for badges.

Closes #885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved data fetching efficiency in the Q&A component with concurrent processing and optimized database queries.
  * Enhanced guest user handling with fallback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->