### PR TITLE
fix(security): resolve Etherfuse IDs server-side in onboarding-status

### DIFF
--- a/apps/web/app/api/etherfuse/onboarding-status/route.ts
+++ b/apps/web/app/api/etherfuse/onboarding-status/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
 import { getAuthenticatedSession } from '~/lib/auth/server-action-auth'
 import { AppError } from '~/lib/error'
+import { resolveAuthorizedEtherfuseWallet } from '~/lib/etherfuse/etherfuse-wallet-binding'
 import { getEtherfuseConfig } from '~/lib/etherfuse/get-etherfuse-config'
 import {
 	getEtherfuseOnboardingStatus,
@@ -18,9 +19,13 @@ async function onboardingStatusHandler(req: NextRequest) {
 			return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
 		}
 
-		const walletAddress = req.nextUrl.searchParams.get('walletAddress')
+		const requestedWalletAddress = req.nextUrl.searchParams.get('walletAddress')
+		const walletAddress = await resolveAuthorizedEtherfuseWallet(
+			session.user.id,
+			requestedWalletAddress,
+		)
 
-		if (!walletAddress || !isExternalStellarWallet(walletAddress)) {
+		if (!isExternalStellarWallet(walletAddress)) {
 			return NextResponse.json(
 				{ error: 'A valid external wallet address is required' },
 				{ status: 400 },

--- a/apps/web/app/api/etherfuse/onboarding-status/route.ts
+++ b/apps/web/app/api/etherfuse/onboarding-status/route.ts
@@ -4,7 +4,10 @@ import { logger } from '@/lib/logger'
 import { getAuthenticatedSession } from '~/lib/auth/server-action-auth'
 import { AppError } from '~/lib/error'
 import { getEtherfuseConfig } from '~/lib/etherfuse/get-etherfuse-config'
-import { getEtherfuseOnboardingStatus } from '~/lib/etherfuse/resolve-order-context'
+import {
+	getEtherfuseOnboardingStatus,
+	resolveEtherfuseOrderContext,
+} from '~/lib/etherfuse/resolve-order-context'
 import { isExternalStellarWallet } from '~/lib/etherfuse/wallet'
 import { withRateLimit } from '~/lib/middleware/rate-limit'
 
@@ -15,29 +18,27 @@ async function onboardingStatusHandler(req: NextRequest) {
 			return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
 		}
 
-		const customerId = req.nextUrl.searchParams.get('customerId')
-		const bankAccountId = req.nextUrl.searchParams.get('bankAccountId')
 		const walletAddress = req.nextUrl.searchParams.get('walletAddress')
 
-		if (
-			!customerId ||
-			!bankAccountId ||
-			!walletAddress ||
-			!isExternalStellarWallet(walletAddress)
-		) {
+		if (!walletAddress || !isExternalStellarWallet(walletAddress)) {
 			return NextResponse.json(
-				{
-					error: 'customerId, bankAccountId, and a valid external wallet address are required',
-				},
+				{ error: 'A valid external wallet address is required' },
 				{ status: 400 },
 			)
 		}
 
 		const config = await getEtherfuseConfig()
-		const status = await getEtherfuseOnboardingStatus(
-			{ apiKey: config.apiKey, baseUrl: config.baseUrl },
-			{ customerId, bankAccountId, walletAddress },
+		const auth = { apiKey: config.apiKey, baseUrl: config.baseUrl }
+		const { customerId, bankAccountId } = await resolveEtherfuseOrderContext(
+			config,
+			walletAddress,
+			{},
 		)
+		const status = await getEtherfuseOnboardingStatus(auth, {
+			customerId,
+			bankAccountId,
+			walletAddress,
+		})
 
 		return NextResponse.json(status)
 	} catch (error) {

--- a/apps/web/app/api/etherfuse/onboarding-url/route.ts
+++ b/apps/web/app/api/etherfuse/onboarding-url/route.ts
@@ -4,6 +4,7 @@ import { logger } from '@/lib/logger'
 import { getAuthenticatedSession } from '~/lib/auth/server-action-auth'
 import { AppError } from '~/lib/error'
 import type { EtherfuseApiAuth } from '~/lib/etherfuse/etherfuse-api'
+import { persistEtherfuseWalletBinding } from '~/lib/etherfuse/etherfuse-wallet-binding'
 import { getEtherfuseConfig } from '~/lib/etherfuse/get-etherfuse-config'
 import {
 	requestEtherfuseOnboardingUrl,
@@ -49,6 +50,12 @@ async function onboardingUrlHandler(req: NextRequest) {
 				email: session.user.email ?? undefined,
 				displayName: session.user.name ?? undefined,
 			},
+		})
+
+		await persistEtherfuseWalletBinding(session.user.id, {
+			walletAddress,
+			customerId: result.customerId,
+			bankAccountId: result.bankAccountId,
 		})
 
 		return NextResponse.json(result)

--- a/apps/web/hooks/use-etherfuse-user-onboarding.ts
+++ b/apps/web/hooks/use-etherfuse-user-onboarding.ts
@@ -65,7 +65,7 @@ export const useEtherfuseUserOnboarding = (userId: string, walletAddress: string
 	}, [userId])
 
 	const refreshStatus = useCallback(async () => {
-		if (!onboarding?.customerId || !onboarding.bankAccountId || !walletAddress) {
+		if (!walletAddress) {
 			setStatus(null)
 			return null
 		}
@@ -73,11 +73,7 @@ export const useEtherfuseUserOnboarding = (userId: string, walletAddress: string
 		setIsCheckingStatus(true)
 
 		try {
-			const params = new URLSearchParams({
-				customerId: onboarding.customerId,
-				bankAccountId: onboarding.bankAccountId,
-				walletAddress,
-			})
+			const params = new URLSearchParams({ walletAddress })
 			const response = await fetch(`/api/etherfuse/onboarding-status?${params.toString()}`)
 			const data = await response.json()
 
@@ -92,7 +88,7 @@ export const useEtherfuseUserOnboarding = (userId: string, walletAddress: string
 		} finally {
 			setIsCheckingStatus(false)
 		}
-	}, [onboarding?.bankAccountId, onboarding?.customerId, walletAddress])
+	}, [walletAddress])
 
 	useEffect(() => {
 		void refreshStatus()

--- a/apps/web/lib/etherfuse/etherfuse-wallet-binding.ts
+++ b/apps/web/lib/etherfuse/etherfuse-wallet-binding.ts
@@ -1,0 +1,89 @@
+import { supabase } from '@packages/lib/supabase'
+import { AppError } from '~/lib/error'
+
+const ETHERFUSE_WALLET_BINDING_OPERATION = 'etherfuse.wallet_binding'
+
+export type EtherfuseWalletBinding = {
+	walletAddress: string
+	customerId: string
+	bankAccountId: string
+}
+
+const parseBindingMetadata = (metadata: unknown): EtherfuseWalletBinding | null => {
+	if (!metadata || typeof metadata !== 'object') {
+		return null
+	}
+
+	const record = metadata as Record<string, unknown>
+	if (
+		typeof record.walletAddress !== 'string' ||
+		typeof record.customerId !== 'string' ||
+		typeof record.bankAccountId !== 'string'
+	) {
+		return null
+	}
+
+	return {
+		walletAddress: record.walletAddress,
+		customerId: record.customerId,
+		bankAccountId: record.bankAccountId,
+	}
+}
+
+export const persistEtherfuseWalletBinding = async (
+	userId: string,
+	binding: EtherfuseWalletBinding,
+): Promise<void> => {
+	const { error } = await supabase.from('audit_logs').insert({
+		correlation_id: crypto.randomUUID(),
+		operation: ETHERFUSE_WALLET_BINDING_OPERATION,
+		resource_type: 'transaction',
+		actor_id: userId,
+		status: 'success',
+		metadata: binding,
+	})
+
+	if (error) {
+		throw new AppError('Failed to persist Etherfuse wallet binding', 500)
+	}
+}
+
+export const getEtherfuseWalletBinding = async (
+	userId: string,
+): Promise<EtherfuseWalletBinding | null> => {
+	const { data, error } = await supabase
+		.from('audit_logs')
+		.select('metadata')
+		.eq('actor_id', userId)
+		.eq('operation', ETHERFUSE_WALLET_BINDING_OPERATION)
+		.eq('status', 'success')
+		.order('created_at', { ascending: false })
+		.limit(1)
+		.maybeSingle()
+
+	if (error) {
+		throw new AppError('Failed to load Etherfuse wallet binding', 500)
+	}
+
+	return parseBindingMetadata(data?.metadata)
+}
+
+export const resolveAuthorizedEtherfuseWallet = async (
+	userId: string,
+	requestedWalletAddress?: string | null,
+): Promise<string> => {
+	const binding = await getEtherfuseWalletBinding(userId)
+
+	if (!binding) {
+		throw new AppError(
+			'No Etherfuse wallet is linked to your account. Start Etherfuse onboarding first.',
+			403,
+		)
+	}
+
+	if (requestedWalletAddress && requestedWalletAddress !== binding.walletAddress) {
+		throw new AppError('Wallet address does not match your linked Etherfuse wallet.', 403)
+	}
+
+	return binding.walletAddress
+}

--- a/apps/web/lib/etherfuse/resolve-order-context.ts
+++ b/apps/web/lib/etherfuse/resolve-order-context.ts
@@ -5,8 +5,13 @@ import {
 	resolveCustomerWalletReference,
 	resolveEtherfuseBankAccountId,
 } from '~/lib/etherfuse/etherfuse-api'
+import { AppError } from '~/lib/error'
 import type { EtherfuseConfig } from '~/lib/etherfuse/get-etherfuse-config'
-import { listEtherfuseCustomerBankAccounts } from '~/lib/etherfuse/resolve-etherfuse-onboarding'
+import {
+	findEtherfuseWalletByPublicKey,
+	listEtherfuseCustomerBankAccounts,
+	resolveEtherfuseOnboardingIds,
+} from '~/lib/etherfuse/resolve-etherfuse-onboarding'
 
 export type EtherfuseOrderContext = {
 	customerId: string
@@ -16,7 +21,7 @@ export type EtherfuseOrderContext = {
 }
 
 type EtherfuseOrderOverrides = {
-	customerId: string
+	customerId?: string
 	bankAccountId?: string
 	cryptoWalletId?: string
 }
@@ -38,21 +43,34 @@ const isWalletKycReady = (
 export const resolveEtherfuseOrderContext = async (
 	config: EtherfuseConfig,
 	walletAddress: string,
-	overrides: EtherfuseOrderOverrides,
+	overrides: EtherfuseOrderOverrides = {},
 ): Promise<EtherfuseOrderContext> => {
 	const auth = { apiKey: config.apiKey, baseUrl: config.baseUrl }
 
-	const [bankAccountId, walletReference] = await Promise.all([
-		overrides.bankAccountId
-			? Promise.resolve(overrides.bankAccountId)
-			: resolveEtherfuseBankAccountId(auth, config.bankAccountId || undefined),
-		resolveCustomerWalletReference(
-			auth,
-			overrides.customerId,
-			walletAddress,
-			overrides.cryptoWalletId ?? (config.cryptoWalletId || undefined),
-		),
-	])
+	let customerId = overrides.customerId
+	if (!customerId) {
+		const existingWallet = await findEtherfuseWalletByPublicKey(auth, walletAddress)
+		if (!existingWallet?.customerId) {
+			throw new AppError(
+				'No Etherfuse profile found for this wallet. Complete Etherfuse verification first.',
+				404,
+			)
+		}
+		customerId = existingWallet.customerId
+	}
+
+	const bankAccountId = overrides.bankAccountId
+		? overrides.bankAccountId
+		: overrides.customerId
+			? await resolveEtherfuseBankAccountId(auth, config.bankAccountId || undefined)
+			: (await resolveEtherfuseOnboardingIds(auth, walletAddress, { customerId })).bankAccountId
+
+	const walletReference = await resolveCustomerWalletReference(
+		auth,
+		customerId,
+		walletAddress,
+		overrides.cryptoWalletId ?? (config.cryptoWalletId || undefined),
+	)
 
 	return {
 		customerId: walletReference.customerId,

--- a/apps/web/lib/etherfuse/resolve-order-context.ts
+++ b/apps/web/lib/etherfuse/resolve-order-context.ts
@@ -1,3 +1,4 @@
+import { AppError } from '~/lib/error'
 import {
 	type EtherfuseApiAuth,
 	getEtherfuseCustomerKycStatus,
@@ -5,7 +6,6 @@ import {
 	resolveCustomerWalletReference,
 	resolveEtherfuseBankAccountId,
 } from '~/lib/etherfuse/etherfuse-api'
-import { AppError } from '~/lib/error'
 import type { EtherfuseConfig } from '~/lib/etherfuse/get-etherfuse-config'
 import {
 	findEtherfuseWalletByPublicKey,

--- a/apps/web/test/etherfuse-validation.test.ts
+++ b/apps/web/test/etherfuse-validation.test.ts
@@ -131,7 +131,7 @@ describe('Etherfuse onboarding status', () => {
 				baseUrl: 'https://api.sand.etherfuse.com',
 				customerId: 'test-customer-id',
 				bankAccountId: VALID_BANK_ACCOUNT_ID,
-				cryptoWalletId: VALID_WALLET_ID,
+				cryptoWalletId: '',
 			}
 
 			const context = await resolveEtherfuseOrderContext(config, VALID_G_ADDRESS, {})

--- a/apps/web/test/etherfuse-validation.test.ts
+++ b/apps/web/test/etherfuse-validation.test.ts
@@ -123,7 +123,9 @@ describe('Etherfuse onboarding status', () => {
 		}) as typeof fetch
 
 		try {
-			const { resolveEtherfuseOrderContext } = await import('../lib/etherfuse/resolve-order-context')
+			const { resolveEtherfuseOrderContext } = await import(
+				'../lib/etherfuse/resolve-order-context'
+			)
 			const config = {
 				apiKey: 'test-api-key',
 				baseUrl: 'https://api.sand.etherfuse.com',

--- a/apps/web/test/etherfuse-validation.test.ts
+++ b/apps/web/test/etherfuse-validation.test.ts
@@ -7,9 +7,16 @@ process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key'
 process.env.NEXT_PUBLIC_KYC_API_BASE_URL = 'http://localhost:3001'
 process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 process.env.NEXTAUTH_SECRET = 'test-secret'
+process.env.ETHERFUSE_API_KEY = 'test-api-key'
+process.env.ETHERFUSE_BASE_URL = 'https://api.sand.etherfuse.com'
+process.env.ETHERFUSE_CUSTOMER_ID = 'test-customer-id'
+process.env.ETHERFUSE_BANK_ACCOUNT_ID = 'test-bank-account-id'
+process.env.ETHERFUSE_CRYPTO_WALLET_ID = 'test-crypto-wallet-id'
 
 const VALID_G_ADDRESS = 'GDUKMGUGD3V6VXTU2RLAUM7A2FABLMHCPWTMDHKP7HHJ6FCZKEY4PVWL'
 const VALID_BANK_ACCOUNT_ID = 'd86c8445-359c-421d-a66d-4e08f916fcc9'
+const OTHER_CUSTOMER_ID = '935c6992-90f1-4ec3-99d2-e049de3b4ed5'
+const VALID_WALLET_ID = '5915dfc1-8995-4465-9c04-76470298b8b3'
 
 describe('Etherfuse onboarding status', () => {
 	test('isApprovedEtherfuseKycStatus accepts approved only', async () => {
@@ -52,6 +59,87 @@ describe('Etherfuse onboarding status', () => {
 		})
 
 		expect(snapshot.isReady).toBe(true)
+	})
+
+	test('resolveEtherfuseOrderContext with empty overrides resolves IDs from wallet', async () => {
+		const originalFetch = global.fetch
+		global.fetch = (async (url: string) => {
+			if (url.includes('/ramp/wallets')) {
+				return new Response(
+					JSON.stringify({
+						items: [
+							{
+								walletId: VALID_WALLET_ID,
+								publicKey: VALID_G_ADDRESS,
+								customerId: OTHER_CUSTOMER_ID,
+								blockchain: 'stellar',
+							},
+						],
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } },
+				)
+			}
+
+			if (url.includes(`/ramp/customer/${OTHER_CUSTOMER_ID}/bank-accounts`)) {
+				return new Response(
+					JSON.stringify({
+						items: [
+							{
+								bankAccountId: VALID_BANK_ACCOUNT_ID,
+								status: 'active',
+								compliant: true,
+								customerId: OTHER_CUSTOMER_ID,
+							},
+						],
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } },
+				)
+			}
+
+			if (url.includes(`/ramp/customer/${OTHER_CUSTOMER_ID}/wallets`)) {
+				return new Response(
+					JSON.stringify({
+						items: [
+							{
+								walletId: VALID_WALLET_ID,
+								publicKey: VALID_G_ADDRESS,
+								customerId: OTHER_CUSTOMER_ID,
+								blockchain: 'stellar',
+							},
+						],
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } },
+				)
+			}
+
+			if (url.includes('/ramp/me')) {
+				return new Response(JSON.stringify({ id: 'partner-org-id' }), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				})
+			}
+
+			return new Response(JSON.stringify({ error: 'Not found' }), { status: 404 })
+		}) as typeof fetch
+
+		try {
+			const { resolveEtherfuseOrderContext } = await import('../lib/etherfuse/resolve-order-context')
+			const config = {
+				apiKey: 'test-api-key',
+				baseUrl: 'https://api.sand.etherfuse.com',
+				customerId: 'test-customer-id',
+				bankAccountId: VALID_BANK_ACCOUNT_ID,
+				cryptoWalletId: VALID_WALLET_ID,
+			}
+
+			const context = await resolveEtherfuseOrderContext(config, VALID_G_ADDRESS, {})
+
+			expect(context.customerId).toBe(OTHER_CUSTOMER_ID)
+			expect(context.bankAccountId).toBe(VALID_BANK_ACCOUNT_ID)
+			expect(context.cryptoWalletId).toBe(VALID_WALLET_ID)
+		} finally {
+			global.fetch = originalFetch
+		}
 	})
 })
 


### PR DESCRIPTION
Closes #899 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified Etherfuse onboarding status requests so they only need a wallet address.
  * Improved server-side lookup of onboarding details, reducing errors when IDs are not provided.
  * Added better handling when a wallet cannot be matched to an Etherfuse profile.

* **Tests**
  * Expanded coverage for wallet-based onboarding status resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->