### PR TITLE
refactor: standardize Etherfuse error logging and sanitize error mess…

### DIFF
--- a/apps/web/app/api/etherfuse/off-ramp/route.ts
+++ b/apps/web/app/api/etherfuse/off-ramp/route.ts
@@ -105,7 +105,10 @@ async function offRampHandler(req: NextRequest) {
 
 		if (!quoteResponse.ok) {
 			const errorText = await quoteResponse.text()
-			logger.error('Etherfuse quote creation failed', { status: quoteResponse.status, body: errorText })
+			logger.error('Etherfuse quote creation failed', {
+				status: quoteResponse.status,
+				body: errorText,
+			})
 			throw new AppError('Failed to create off-ramp quote', quoteResponse.status)
 		}
 
@@ -130,7 +133,10 @@ async function offRampHandler(req: NextRequest) {
 
 		if (!orderResponse.ok) {
 			const errorText = await orderResponse.text()
-			logger.error('Etherfuse order creation failed', { status: orderResponse.status, body: errorText })
+			logger.error('Etherfuse order creation failed', {
+				status: orderResponse.status,
+				body: errorText,
+			})
 			throw new AppError('Failed to create off-ramp order', orderResponse.status)
 		}
 

--- a/apps/web/app/api/etherfuse/off-ramp/route.ts
+++ b/apps/web/app/api/etherfuse/off-ramp/route.ts
@@ -105,8 +105,8 @@ async function offRampHandler(req: NextRequest) {
 
 		if (!quoteResponse.ok) {
 			const errorText = await quoteResponse.text()
-			logger.error('Etherfuse quote creation failed:', errorText)
-			throw new AppError(`Failed to create quote: ${errorText}`, quoteResponse.status)
+			logger.error('Etherfuse quote creation failed', { status: quoteResponse.status, body: errorText })
+			throw new AppError('Failed to create off-ramp quote', quoteResponse.status)
 		}
 
 		const quoteData = await quoteResponse.json()
@@ -130,8 +130,8 @@ async function offRampHandler(req: NextRequest) {
 
 		if (!orderResponse.ok) {
 			const errorText = await orderResponse.text()
-			logger.error('Etherfuse order creation failed:', errorText)
-			throw new AppError(`Failed to create order: ${errorText}`, orderResponse.status)
+			logger.error('Etherfuse order creation failed', { status: orderResponse.status, body: errorText })
+			throw new AppError('Failed to create off-ramp order', orderResponse.status)
 		}
 
 		const orderData = await orderResponse.json()

--- a/apps/web/app/api/etherfuse/on-ramp/route.ts
+++ b/apps/web/app/api/etherfuse/on-ramp/route.ts
@@ -100,8 +100,8 @@ async function onRampHandler(req: NextRequest) {
 
 		if (!quoteResponse.ok) {
 			const errorText = await quoteResponse.text()
-			logger.error('Etherfuse quote creation failed:', errorText)
-			throw new AppError(`Failed to create quote: ${errorText}`, quoteResponse.status)
+			logger.error('Etherfuse quote creation failed', { status: quoteResponse.status, body: errorText })
+			throw new AppError('Failed to create on-ramp quote', quoteResponse.status)
 		}
 
 		const quoteData = await quoteResponse.json()
@@ -125,8 +125,8 @@ async function onRampHandler(req: NextRequest) {
 
 		if (!orderResponse.ok) {
 			const errorText = await orderResponse.text()
-			logger.error('Etherfuse order creation failed:', errorText)
-			throw new AppError(`Failed to create order: ${errorText}`, orderResponse.status)
+			logger.error('Etherfuse order creation failed', { status: orderResponse.status, body: errorText })
+			throw new AppError('Failed to create on-ramp order', orderResponse.status)
 		}
 
 		const orderData = await orderResponse.json()

--- a/apps/web/app/api/etherfuse/on-ramp/route.ts
+++ b/apps/web/app/api/etherfuse/on-ramp/route.ts
@@ -100,7 +100,10 @@ async function onRampHandler(req: NextRequest) {
 
 		if (!quoteResponse.ok) {
 			const errorText = await quoteResponse.text()
-			logger.error('Etherfuse quote creation failed', { status: quoteResponse.status, body: errorText })
+			logger.error('Etherfuse quote creation failed', {
+				status: quoteResponse.status,
+				body: errorText,
+			})
 			throw new AppError('Failed to create on-ramp quote', quoteResponse.status)
 		}
 
@@ -125,7 +128,10 @@ async function onRampHandler(req: NextRequest) {
 
 		if (!orderResponse.ok) {
 			const errorText = await orderResponse.text()
-			logger.error('Etherfuse order creation failed', { status: orderResponse.status, body: errorText })
+			logger.error('Etherfuse order creation failed', {
+				status: orderResponse.status,
+				body: errorText,
+			})
 			throw new AppError('Failed to create on-ramp order', orderResponse.status)
 		}
 

--- a/apps/web/lib/etherfuse/etherfuse-api.ts
+++ b/apps/web/lib/etherfuse/etherfuse-api.ts
@@ -1,5 +1,5 @@
-import { AppError } from '~/lib/error'
 import { logger } from '@/lib/logger'
+import { AppError } from '~/lib/error'
 import type { EtherfuseRampAsset } from '~/lib/etherfuse/types'
 
 export type EtherfuseApiAuth = {

--- a/apps/web/lib/etherfuse/etherfuse-api.ts
+++ b/apps/web/lib/etherfuse/etherfuse-api.ts
@@ -1,4 +1,5 @@
 import { AppError } from '~/lib/error'
+import { logger } from '@/lib/logger'
 import type { EtherfuseRampAsset } from '~/lib/etherfuse/types'
 
 export type EtherfuseApiAuth = {
@@ -40,7 +41,8 @@ export const etherfuseRequest = async <T>(
 
 	if (!response.ok) {
 		const errorText = await response.text()
-		throw new AppError(`Etherfuse API error (${path}): ${errorText}`, response.status)
+		logger.error('Etherfuse API error', { path, status: response.status, body: errorText })
+		throw new AppError(`Etherfuse API error (${path})`, response.status)
 	}
 
 	if (response.status === 204) {


### PR DESCRIPTION
- CLose #895 

## Security: Sanitize Etherfuse API Error Responses


Raw Etherfuse API response bodies were being embedded directly in `AppError` messages and forwarded to clients via API routes, potentially leaking internal error details.

### Changes
- **`etherfuse-api.ts`** — `etherfuseRequest` now logs the raw error body server-side (`logger.error`) and throws a sanitized message without it
- **`on-ramp/route.ts`** — same fix for quote and order failure paths
- **`off-ramp/route.ts`** — same fix for quote and order failure paths

### Before
```ts
throw new AppError(`Etherfuse API error (${path}): ${errorText}`, response.status)
// ↑ errorText sent to client
```

### After
```ts
logger.error('Etherfuse API error', { path, status: response.status, body: errorText })
throw new AppError(`Etherfuse API error (${path})`, response.status)
// ↑ raw body stays server-side only
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Etherfuse on-ramp and off-ramp quote/order creation.
  * Error logs now include clearer HTTP status and response body details when external requests fail.
  * End-user-facing error messages are now more consistent and concise, avoiding noisy response text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->