### PR TITLE
fix: preserve org-recovery after user-info fallback retry fails in requestEtherfuseOnboardingUrl

### DIFF
--- a/apps/web/lib/etherfuse/resolve-etherfuse-onboarding.ts
+++ b/apps/web/lib/etherfuse/resolve-etherfuse-onboarding.ts
@@ -166,6 +166,8 @@ export const requestEtherfuseOnboardingUrl = async (
 				throw error
 			}
 
+			let handledError: AppError = error
+
 			if (hasUserInfo && isEtherfuseClientNotLinkedError(error.message)) {
 				try {
 					return await createUrl(ids, false)
@@ -180,13 +182,14 @@ export const requestEtherfuseOnboardingUrl = async (
 						)
 					}
 
-					throw retryError
+					if (!(retryError instanceof AppError)) throw retryError
+					handledError = retryError
 				}
 			}
 
-			const existingOrgId = parseExistingEtherfuseOrgId(error.message)
+			const existingOrgId = parseExistingEtherfuseOrgId(handledError.message)
 			if (!existingOrgId || !allowOrgRecovery) {
-				throw error
+				throw handledError
 			}
 
 			const recoveredIds = await resolveEtherfuseOnboardingIds(auth, params.walletAddress, {


### PR DESCRIPTION
Closes#898
## Summary

Fixes #898

When `hasUserInfo` is true and the initial call fails with a "client not linked" error, the code retries without user info. If that retry fails with an `AppError` that is **not** a "client not linked" error, the previous code threw immediately — bypassing the org-ID recovery logic.

## Changes

- Introduced `handledError` variable initialized to the original error
- In the retry catch block: non-`AppError` exceptions still propagate immediately; `AppError` instances are captured in `handledError`
- Org-recovery logic now uses `handledError` so it works regardless of which attempt produced the error

## References

- PR: https://github.com/kindfi-org/kindfi/pull/893
- Review comment: https://github.com/kindfi-org/kindfi/pull/893#discussion_r3445442392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during onboarding link generation so retries now surface the most relevant failure.
  * Error messages shown after recovery attempts are now more accurate and reflect the latest issue instead of the original one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->