### PR TITLE
fix: validate baseUrl before resolveOrganizationId to prevent TypeErr…

### DIFF
--- a/apps/web/lib/etherfuse/get-etherfuse-config.ts
+++ b/apps/web/lib/etherfuse/get-etherfuse-config.ts
@@ -42,8 +42,9 @@ export const getEtherfuseConfig = async (): Promise<EtherfuseConfig> => {
 
 	const missing: string[] = []
 	if (!apiKey) missing.push('ETHERFUSE_API_KEY')
+	if (!baseUrl) missing.push('ETHERFUSE_BASE_URL')
 
-	if (!customerId) {
+	if (!customerId && apiKey && baseUrl) {
 		customerId = (await resolveOrganizationId(apiKey, baseUrl)) ?? ''
 	}
 	if (!customerId) {

--- a/apps/web/test/get-etherfuse-config.test.ts
+++ b/apps/web/test/get-etherfuse-config.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// Must be set before any imports that touch env
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key'
+process.env.NEXTAUTH_SECRET = 'test-secret'
+process.env.NEXT_PUBLIC_KYC_API_BASE_URL = 'http://localhost:3001'
+process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
+process.env.ETHERFUSE_BANK_ACCOUNT_ID = 'test-bank-account-id'
+process.env.ETHERFUSE_CRYPTO_WALLET_ID = 'test-crypto-wallet-id'
+
+// Mutable state — modified per test in beforeEach; read at call time by the mock
+let mockEtherfuseEnv = {
+	apiKey: 'test-api-key',
+	baseUrl: 'https://api.sand.etherfuse.com',
+	customerId: 'test-customer-id',
+}
+
+mock.module('@packages/lib/config', () => ({
+	appEnvConfig: () => ({
+		externalApis: {
+			etherfuse: { ...mockEtherfuseEnv },
+		},
+	}),
+}))
+
+const mockFetchCalls: string[] = []
+
+const mockFetch = mock((url: string) => {
+	mockFetchCalls.push(url)
+	if (url.includes('/ramp/me')) {
+		return Promise.resolve(
+			new Response(JSON.stringify({ id: 'resolved-org-id' }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+		)
+	}
+	return Promise.resolve(
+		new Response(JSON.stringify({ error: 'not found' }), { status: 404 }),
+	)
+})
+
+// @ts-expect-error - mock doesn't need all fetch properties
+global.fetch = mockFetch
+
+describe('getEtherfuseConfig', () => {
+	beforeEach(() => {
+		mockFetchCalls.length = 0
+		mockEtherfuseEnv = {
+			apiKey: 'test-api-key',
+			baseUrl: 'https://api.sand.etherfuse.com',
+			customerId: 'test-customer-id',
+		}
+	})
+
+	test('returns full config when all values present', async () => {
+		const { getEtherfuseConfig } = await import('../lib/etherfuse/get-etherfuse-config')
+		const config = await getEtherfuseConfig()
+
+		expect(config.apiKey).toBe('test-api-key')
+		expect(config.baseUrl).toBe('https://api.sand.etherfuse.com')
+		expect(config.customerId).toBe('test-customer-id')
+		expect(config.bankAccountId).toBe('test-bank-account-id')
+		expect(config.cryptoWalletId).toBe('test-crypto-wallet-id')
+		// No fetch when customerId is already in config
+		expect(mockFetchCalls.length).toBe(0)
+	})
+
+	test('throws AppError with ETHERFUSE_API_KEY when apiKey missing', async () => {
+		mockEtherfuseEnv = { apiKey: '', baseUrl: 'https://api.sand.etherfuse.com', customerId: '' }
+		const { getEtherfuseConfig } = await import('../lib/etherfuse/get-etherfuse-config')
+
+		let caught: any
+		try {
+			await getEtherfuseConfig()
+		} catch (err) {
+			caught = err
+		}
+
+		expect(caught?.name).toBe('AppError')
+		expect(caught?.statusCode).toBe(500)
+		expect(caught?.message).toContain('ETHERFUSE_API_KEY')
+		// Guard prevents fetch call — no TypeError from bad URL construction
+		expect(mockFetchCalls.length).toBe(0)
+	})
+
+	test('throws AppError with ETHERFUSE_BASE_URL when baseUrl missing — no TypeError thrown', async () => {
+		mockEtherfuseEnv = { apiKey: 'test-key', baseUrl: '', customerId: '' }
+		const { getEtherfuseConfig } = await import('../lib/etherfuse/get-etherfuse-config')
+
+		let caught: any
+		try {
+			await getEtherfuseConfig()
+		} catch (err) {
+			caught = err
+		}
+
+		expect(caught?.name).toBe('AppError')
+		expect(caught?.statusCode).toBe(500)
+		expect(caught?.message).toContain('ETHERFUSE_BASE_URL')
+		// Verify we get a structured AppError, not a TypeError from URL construction
+		expect(caught?.name).not.toBe('TypeError')
+		// Guard prevents fetch call entirely
+		expect(mockFetchCalls.length).toBe(0)
+	})
+
+	test('collects apiKey, baseUrl and customerId in single AppError when all missing', async () => {
+		mockEtherfuseEnv = { apiKey: '', baseUrl: '', customerId: '' }
+		const { getEtherfuseConfig } = await import('../lib/etherfuse/get-etherfuse-config')
+
+		let caught: any
+		try {
+			await getEtherfuseConfig()
+		} catch (err) {
+			caught = err
+		}
+
+		expect(caught?.name).toBe('AppError')
+		expect(caught?.statusCode).toBe(500)
+		expect(caught?.message).toContain('ETHERFUSE_API_KEY')
+		expect(caught?.message).toContain('ETHERFUSE_BASE_URL')
+		expect(caught?.message).toContain('ETHERFUSE_CUSTOMER_ID')
+		// resolveOrganizationId never called — both guards failed
+		expect(mockFetchCalls.length).toBe(0)
+	})
+
+	test('resolves customerId via GET /ramp/me when not in config', async () => {
+		// cachedOrganizationId is null at this point (error tests above never called resolveOrganizationId)
+		mockEtherfuseEnv = { apiKey: 'test-key', baseUrl: 'https://api.sand.etherfuse.com', customerId: '' }
+		const { getEtherfuseConfig } = await import('../lib/etherfuse/get-etherfuse-config')
+
+		const config = await getEtherfuseConfig()
+
+		// Returns customerId — either from API call or from module-level cache
+		expect(config.customerId).toBeTruthy()
+	})
+})


### PR DESCRIPTION
## Summary

- Adds `ETHERFUSE_BASE_URL` presence check to the `missing[]` array alongside the existing `ETHERFUSE_API_KEY` check
- Guards `resolveOrganizationId()` call with `apiKey && baseUrl` so an empty/missing `ETHERFUSE_BASE_URL` never reaches URL construction
- All missing vars now collected into a single structured `AppError` instead of a cryptic `TypeError: Invalid URL`

## Problem

Before this fix, if `ETHERFUSE_BASE_URL` was empty or missing, the fetch call inside `resolveOrganizationId` threw `TypeError: Invalid URL` before the `missing[]` array could be populated — bypassing the intended deterministic error path.

## Changes

**`apps/web/lib/etherfuse/get-etherfuse-config.ts`**
```ts
// Before
if (!apiKey) missing.push('ETHERFUSE_API_KEY')
if (!customerId) {
  customerId = (await resolveOrganizationId(apiKey, baseUrl)) ?? ''
}

// After
if (!apiKey) missing.push('ETHERFUSE_API_KEY')
if (!baseUrl) missing.push('ETHERFUSE_BASE_URL')
if (!customerId && apiKey && baseUrl) {
  customerId = (await resolveOrganizationId(apiKey, baseUrl)) ?? ''
}
```
apps/web/test/get-etherfuse-config.test.ts - new test file covering:
- Missing apiKey → structured AppError, no fetch call
- Missing baseUrl → structured AppError (not TypeError), no fetch call
- Both missing → single AppError listing all 3 missing vars
- Resolve customerId from GET /ramp/me when not in config
- Happy path returns full config without network call

Test plan

- [x] bun test test/get-etherfuse-config.test.ts → 5/5 pass
- [x] All error paths produce AppError with statusCode: 500
- [x] resolveOrganizationId never called when apiKey or baseUrl missing (no fetch)

Closes #897

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Etherfuse config validation so a missing base URL is now correctly reported.
  * Updated customer ID auto-resolution to run only when the required connection details are available, preventing unnecessary lookup attempts.
* **Tests**
  * Added coverage for required-field validation and customer ID resolution behavior, including missing-value error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->