### PR TITLE
fix(web): hotfix navbar auth state after login

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,7 +1,6 @@
 import { appEnvConfig } from '@packages/lib/config'
 import type { AppEnvInterface } from '@packages/lib/types'
 import { Suspense } from 'react'
-import { LayoutContainer } from '~/components/layout-container'
 import { SessionShell } from '~/components/session-shell'
 import { DeferredGoogleAnalytics } from '~/components/shared/deferred-google-analytics'
 import { JsonLd } from '~/components/shared/json-ld'
@@ -59,7 +58,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 				<JsonLd data={[getOrganizationSchema(), getWebSiteSchema()]} />
 			</head>
 			<body suppressHydrationWarning>
-				<Suspense fallback={<LayoutContainer session={null}>{children}</LayoutContainer>}>
+				<Suspense
+					fallback={
+						<div className="flex min-h-screen items-center justify-center bg-background">
+							<div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+						</div>
+					}
+				>
 					<SessionShell>{children}</SessionShell>
 				</Suspense>
 				<DeferredGoogleAnalytics gaMeasurementId={appConfig.analytics.gaId} />

--- a/apps/web/components/pages/auth/passkey-registration.tsx
+++ b/apps/web/components/pages/auth/passkey-registration.tsx
@@ -105,7 +105,7 @@ export function PasskeyRegistrationComponent() {
 
 			// Mark this as a new session so role selection modal can be shown
 			sessionStorage.setItem('kindfi_new_session', 'true')
-			router.refresh()
+			await router.refresh()
 			router.push('/profile')
 		} catch (e) {
 			logger.error('Finalize passkey registration error', e)

--- a/apps/web/components/shared/layout/providers.tsx
+++ b/apps/web/components/shared/layout/providers.tsx
@@ -67,7 +67,11 @@ export function Providers({ children, initSession }: ProvidersProps) {
 					forcedTheme="light"
 					disableTransitionOnChange
 				>
-					<SessionProvider session={initSession} refetchOnWindowFocus>
+					<SessionProvider
+						key={initSession?.user?.id ?? 'guest'}
+						session={initSession ?? undefined}
+						refetchOnWindowFocus
+					>
 						<AuthProvider initSession={initSession}>
 							<WaitlistProvider>{children}</WaitlistProvider>
 						</AuthProvider>

--- a/apps/web/components/shared/layout/providers.tsx
+++ b/apps/web/components/shared/layout/providers.tsx
@@ -6,6 +6,7 @@ import { SessionProvider } from 'next-auth/react'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 import { useEffect } from 'react'
 import { logger } from '@/lib/logger'
+import { WalletProvider } from '~/hooks/contexts/use-stellar-wallet.context'
 import { WaitlistProvider } from '~/hooks/contexts/use-waitlist.context'
 import { AuthProvider } from '~/hooks/use-auth'
 import { I18nProvider } from '~/lib/i18n/context'
@@ -73,7 +74,9 @@ export function Providers({ children, initSession }: ProvidersProps) {
 						refetchOnWindowFocus
 					>
 						<AuthProvider initSession={initSession}>
-							<WaitlistProvider>{children}</WaitlistProvider>
+							<WalletProvider>
+								<WaitlistProvider>{children}</WaitlistProvider>
+							</WalletProvider>
 						</AuthProvider>
 					</SessionProvider>
 				</NextThemesProvider>

--- a/apps/web/components/shared/layout/web3-providers.tsx
+++ b/apps/web/components/shared/layout/web3-providers.tsx
@@ -3,7 +3,6 @@
 import { TrustlessWorkConfig } from '@trustless-work/escrow'
 import { StellarProvider } from '~/hooks/contexts/stellar-context'
 import { EscrowProvider } from '~/hooks/contexts/use-escrow.context'
-import { WalletProvider } from '~/hooks/contexts/use-stellar-wallet.context'
 import { getTrustlessWorkSdkBaseUrl } from '~/lib/config/trustless-work.config'
 
 interface Web3ProvidersProps {
@@ -14,11 +13,9 @@ interface Web3ProvidersProps {
 export function Web3Providers({ children }: Web3ProvidersProps) {
 	return (
 		<TrustlessWorkConfig baseURL={getTrustlessWorkSdkBaseUrl()} apiKey="">
-			<WalletProvider>
-				<EscrowProvider>
-					<StellarProvider>{children}</StellarProvider>
-				</EscrowProvider>
-			</WalletProvider>
+			<EscrowProvider>
+				<StellarProvider>{children}</StellarProvider>
+			</EscrowProvider>
 		</TrustlessWorkConfig>
 	)
 }

--- a/apps/web/hooks/passkey/use-smart-account-auth.ts
+++ b/apps/web/hooks/passkey/use-smart-account-auth.ts
@@ -156,7 +156,7 @@ export const useSmartAccountAuth = (identifier: string) => {
 
 			sessionStorage.setItem('kindfi_new_session', 'true')
 
-			router.refresh()
+			await router.refresh()
 			router.push('/profile')
 
 			return {

--- a/apps/web/hooks/use-auth.tsx
+++ b/apps/web/hooks/use-auth.tsx
@@ -32,9 +32,11 @@ export function AuthProvider({
 	children: React.ReactNode
 	initSession: Session | null
 }) {
-	// Use null as initial state to prevent hydration mismatch
-	const { data: session } = useSession()
-	const userSession = (session ?? initSession) as Session | null
+	const { data: session, status } = useSession()
+	// Prefer authenticated client session; fall back to server session during load or after refresh
+	const userSession = (
+		status === 'authenticated' ? session : (session ?? initSession)
+	) as Session | null
 	const [supabaseUser, setSupabaseUser] = useState<SupabaseUser | undefined>(undefined)
 	const [isSupabaseUserLoading, setIsSupabaseUserLoading] = useState(true)
 	const supabase = createSupabaseBrowserClient()


### PR DESCRIPTION
## Summary

- Sync client auth state after passkey login so the header shows the user menu instead of Sign in / Sign up
- Avoid resetting session during root layout Suspense fallback
- Mount `WalletProvider` at the app root so `UserMenu` can call `useWallet()` on all routes

## Context

After login, protected routes (e.g. `/profile`) worked because the NextAuth cookie was set, but the navbar still showed logged-out buttons. Rendering the user menu also crashed with `useWallet must be used within WalletProvider` because wallet context was only mounted on Web3 route layouts, not in the root header.

## Test plan

- [ ] Sign in with passkey and confirm navbar shows user menu on `/profile`
- [ ] Confirm no `useWallet must be used within WalletProvider` error in console
- [ ] Sign out from user menu and confirm redirect to sign-in
- [ ] Verify external wallet disconnect still works when a Freighter wallet was linked


Made with [Cursor](https://cursor.com)