### PR TITLE
docs(agents): add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,3 +186,33 @@ Specialized skills live in `.agents/skills/`. Read the relevant `SKILL.md` befor
 - [README.md](./README.md) — community, contributing, quick start
 - [apps/web/README.md](./apps/web/README.md) — web app structure and features
 - [Architecture docs](https://kindfis-organization.gitbook.io/development/kindfi-architecture)
+
+## Cursor Cloud specific instructions
+
+Durable, non-obvious caveats for running this repo in the Cursor Cloud VM. Standard commands live in `Taskfile.yml` / `apps/web/README.md`; the update script already runs `bun install`.
+
+### Running the web app (primary product)
+- Start: `task web:dev` (or `cd apps/web && bun dev`) → http://localhost:3000. Turbopack compiles routes on first request.
+- `apps/web/.env` is required (gitignored). It is generated during setup with **local Supabase** keys. Regenerate keys with `cd services/supabase && bunx supabase status --workdir . -o env`.
+- Env gotcha: do **not** put `CHALLENGE_TTL_SECONDS` in `apps/web/.env`. `transformEnv()` reads it raw and the schema requires a number; a string value fails startup validation. Leaving it unset yields the numeric default.
+
+### Local Supabase (Docker) — non-obvious CLI quirk
+- Docker is preinstalled (fuse-overlayfs, `containerd-snapshotter` disabled, iptables-legacy). If `docker info` fails, start the daemon: `sudo dockerd &` (then `sudo chmod 666 /var/run/docker.sock`).
+- Start Supabase from the config dir with an explicit workdir: `cd services/supabase && bunx supabase start --workdir .`. Plain `supabase start` mis-detects the workdir (the project dir is itself named `supabase`) and aborts on `auth.email.template.*.content_path`. In this CLI version, `content_path` resolves relative to workdir while migrations/seed resolve under `<workdir>/supabase`.
+- Because of that split, `--workdir .` brings the stack up but does **not** auto-apply the migrations in `services/supabase/migrations`.
+
+### Known schema drift (applies to a fresh local DB)
+The committed `services/supabase/migrations` do not cleanly build a working schema from scratch:
+- The RLS-policy migration for `kyc_reviews` predates the migration that creates the table (filename order ≠ dependency order).
+- `user_role` enum value `pending` (and `admin`) is referenced by profile-creation triggers but added in a later migration — apply `ALTER TYPE user_role ADD VALUE IF NOT EXISTS 'pending'` / `'admin'` if triggers fail.
+- App code (`lib/queries/projects/get-basic-project-info-by-slug.ts`) selects `projects.foundation_id` and reads a `foundations` table, but **no committed migration creates them**; project detail pages throw Postgres `42703` without `projects.foundation_id`. Add `ALTER TABLE public.projects ADD COLUMN IF NOT EXISTS foundation_id uuid;` locally.
+- Practical local setup: apply migrations tolerantly via `psql` (multiple passes, no `ON_ERROR_STOP`), then patch the objects above, then `NOTIFY pgrst, 'reload schema';` so PostgREST sees new columns. The committed `services/supabase/seed.sql` is also drifted (enum/FK mismatches) and only partially loads.
+
+### Flows that need external services (cannot be exercised locally without secrets)
+- **Email signup / OTP**: `lib/auth/signup-otp.service.ts` sends the code via **Resend** and hard-requires `RESEND_SMTP_API_KEY` (no dev/Mailpit fallback). Supabase Auth has `enable_confirmations = false`, so it is only the Resend send that blocks.
+- **KYC**: needs Didit + the `services/ai` Express service (`task ai:dev`).
+- **Passkey / smart-account auth** (the primary auth): needs a WebAuthn authenticator; not feasible headless.
+- Unauthenticated **project discovery** (browse `/projects`, filter by category, open `/projects/[slug]`) is fully exercisable locally and is the recommended smoke test.
+
+### Lint / test status
+- `bun run lint` (Biome) and `cd apps/web && bun test` both run, but have **pre-existing** failures unrelated to setup (formatting nits; several tests time out waiting on unconfigured Redis/Upstash and external APIs).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Sets up the KindFi development environment for Cursor Cloud and documents the non-obvious caveats discovered while doing so. The only code/docs change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`; everything else (Bun, Docker, local Supabase, `apps/web/.env`, seeded data) is environment state, captured via the VM snapshot + update script.

## Environment set up

- **Bun 1.3.14** (pinned) installed and symlinked onto `PATH`; `bun install` restores all workspace deps.
- **Docker** installed (fuse-overlayfs, `containerd-snapshotter` disabled, iptables-legacy) to run **local Supabase**.
- **Local Supabase** started via `bunx supabase start --workdir .` (plain `supabase start` mis-detects the workdir and aborts on email-template `content_path`).
- **`apps/web/.env`** generated with local Supabase keys; schema applied tolerantly + drift patched so the app has real data.

## Update script

`bun install` — minimal, idempotent dependency refresh. One-time system setup (Bun, Docker, Supabase CLI) is captured in the snapshot, not the update script.

## Hello-world verified (core crowdfunding flow)

Browsed `/projects` (3 seeded campaigns), filtered by the **Education** category (narrowed to 1 result), and opened the **Clean Water for Rural Schools** detail page — all against the local DB with no errors.

[kindfi_project_discovery_clean.mp4](https://cursor.com/agents/bc-6fc34ba8-311c-4003-ab93-328ea47d96e2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkindfi_project_discovery_clean.mp4)

[Projects list with three campaigns](https://cursor.com/agents/bc-6fc34ba8-311c-4003-ab93-328ea47d96e2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprojects_list_3_campaigns.webp)
[Filtered to Education category (1 result)](https://cursor.com/agents/bc-6fc34ba8-311c-4003-ab93-328ea47d96e2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprojects_filtered_education.webp)
[Clean Water project detail page](https://cursor.com/agents/bc-6fc34ba8-311c-4003-ab93-328ea47d96e2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fproject_detail_clean_water.webp)

## Notes / known pre-existing issues (documented in AGENTS.md)

- Committed Supabase migrations don't cleanly build a schema from scratch (RLS policy precedes its table; `user_role` `pending`/`admin` enum values added late; app expects `projects.foundation_id` + a `foundations` table that no migration creates).
- Email signup/KYC/passkey flows require external secrets (Resend, Didit) / a WebAuthn authenticator and can't be exercised locally.
- `bun run lint` and `apps/web` `bun test` run but have pre-existing failures (formatting nits; tests that time out on unconfigured Redis/external APIs).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fc34ba8-311c-4003-ab93-328ea47d96e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fc34ba8-311c-4003-ab93-328ea47d96e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

