### PR TITLE
fix(web): prevent client crash when browser storage is blocked

### DIFF
--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect } from 'react'
+import { logger } from '@/lib/logger'
+import { Button } from '~/components/base/button'
+
+// biome-ignore lint/suspicious/noShadowRestrictedNames: Next.js requires this export name
+export default function Error({
+	error,
+	reset,
+}: {
+	error: Error & { digest?: string }
+	reset: () => void
+}) {
+	useEffect(() => {
+		logger.error('Route error boundary caught an error', error)
+	}, [error])
+
+	return (
+		<div className="flex min-h-[50vh] items-center justify-center p-6">
+			<div className="max-w-md space-y-4 text-center">
+				<h2 className="text-xl font-semibold text-foreground">Unable to load this section</h2>
+				<p className="text-sm text-muted-foreground">
+					An unexpected error occurred. Please try again.
+				</p>
+				<Button type="button" onClick={() => reset()}>
+					Try again
+				</Button>
+			</div>
+		</div>
+	)
+}

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useEffect } from 'react'
+import { logger } from '@/lib/logger'
+import { Button } from '~/components/base/button'
+
+export default function GlobalError({
+	error,
+	reset,
+}: {
+	error: Error & { digest?: string }
+	reset: () => void
+}) {
+	useEffect(() => {
+		logger.error('Global error boundary caught an error', error)
+	}, [error])
+
+	return (
+		<html lang="en">
+			<body className="flex min-h-screen items-center justify-center bg-background p-6">
+				<div className="max-w-md space-y-4 text-center">
+					<h1 className="text-2xl font-semibold text-foreground">Something went wrong</h1>
+					<p className="text-sm text-muted-foreground">
+						KindFi hit an unexpected error while loading this page. You can try again, or continue
+						without wallet features if storage is blocked in your browser.
+					</p>
+					<div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
+						<Button type="button" onClick={() => reset()}>
+							Try again
+						</Button>
+						<Button type="button" variant="outline" onClick={() => window.location.assign('/')}>
+							Go to homepage
+						</Button>
+					</div>
+				</div>
+			</body>
+		</html>
+	)
+}

--- a/apps/web/components/base/button.tsx
+++ b/apps/web/components/base/button.tsx
@@ -1,5 +1,3 @@
-import { appEnvConfig } from '@packages/lib/config'
-import type { AppEnvInterface } from '@packages/lib/types'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
 import * as React from 'react'
@@ -75,8 +73,6 @@ export interface ButtonProps
 	'aria-label'?: boolean extends true ? string : string | undefined
 }
 
-const appConfig: AppEnvInterface = appEnvConfig('web')
-
 /**
  * `Button` component used for triggering actions within the UI. It supports various variants and sizes,
  * and it can optionally render as a child component to integrate with other UI elements.
@@ -144,7 +140,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 			role: isLink ? 'link' : undefined,
 			'aria-label': ariaLabel || (isIconOnly ? String(children) : 'Button'),
 			title: ariaLabel || (typeof children === 'string' ? children : 'Button'),
-			...(appConfig.env.nodeEnv !== 'production' &&
+			...(process.env.NODE_ENV !== 'production' &&
 				isLink &&
 				!('href' in props) && {
 					onClick: (e) => {

--- a/apps/web/components/pages/auth/passkey-registration.tsx
+++ b/apps/web/components/pages/auth/passkey-registration.tsx
@@ -18,6 +18,7 @@ import { useSmartAccountRegistration } from '~/hooks/passkey/use-smart-account-r
 import { useWebAuthnSupport } from '~/hooks/passkey/use-web-authn-support'
 import { formLayoutClasses } from '~/lib/form/form-styles'
 import { useI18n } from '~/lib/i18n'
+import { safeSessionStorageSet } from '~/lib/utils/safe-storage'
 
 export function PasskeyRegistrationComponent() {
 	const router = useRouter()
@@ -95,8 +96,8 @@ export function PasskeyRegistrationComponent() {
 
 			await getSession()
 
-			// Mark this as a new session so role selection modal can be shown
-			sessionStorage.setItem('kindfi_new_session', 'true')
+			// Best-effort only — blocked sessionStorage must not fail registration on iOS Safari.
+			safeSessionStorageSet('kindfi_new_session', 'true')
 			await router.refresh()
 			router.push('/profile')
 		} catch (e) {

--- a/apps/web/components/sections/profile/profile-dashboard.tsx
+++ b/apps/web/components/sections/profile/profile-dashboard.tsx
@@ -11,6 +11,7 @@ import { SectionContainer } from '~/components/shared/section-container'
 import { useWallet } from '~/hooks/contexts/use-stellar-wallet.context'
 import { useI18n } from '~/lib/i18n'
 import { cn } from '~/lib/utils'
+import { safeLocalStorageSet } from '~/lib/utils/safe-storage'
 import { AccountInfoCard } from './cards/account-info-card'
 import { GovernanceCard } from './cards/governance-card'
 import { KYCCard } from './cards/kyc-card'
@@ -108,7 +109,7 @@ export function ProfileDashboard({
 	}, [role])
 
 	const handleRoleSelected = () => {
-		localStorage.setItem('kindfi_role_chosen', 'true')
+		safeLocalStorageSet('kindfi_role_chosen', 'true')
 		setShowRoleModal(false)
 	}
 

--- a/apps/web/components/sections/projects/manage/escrow/tabs/milestones-tab.tsx
+++ b/apps/web/components/sections/projects/manage/escrow/tabs/milestones-tab.tsx
@@ -6,15 +6,7 @@ import type {
 	MultiReleaseMilestone,
 	SingleReleaseMilestone,
 } from '@trustless-work/escrow'
-import {
-	ArrowRight,
-	CheckCircle2,
-	FileText,
-	Loader2,
-	Plus,
-	Send,
-	TrendingUp,
-} from 'lucide-react'
+import { ArrowRight, CheckCircle2, FileText, Loader2, Plus, Send, TrendingUp } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { logger } from '@/lib/logger'
@@ -414,10 +406,7 @@ export function MilestonesTab({
 						) : (
 							<p className="text-sm text-muted-foreground">
 								Approving release {selectedIndex + 1} allows the Release Signer to disburse
-								{escrowType === 'multi-release'
-									? ' this release’s amount'
-									: ' the escrow balance'}
-								.
+								{escrowType === 'multi-release' ? ' this release’s amount' : ' the escrow balance'}.
 							</p>
 						)}
 

--- a/apps/web/hooks/contexts/use-stellar-wallet.context.tsx
+++ b/apps/web/hooks/contexts/use-stellar-wallet.context.tsx
@@ -8,6 +8,12 @@ import {
 	getTrustlessSignerError,
 	isExternalStellarWalletAddress,
 } from '~/lib/utils/escrow/trustless-signer'
+import {
+	isLocalStorageAvailable,
+	safeLocalStorageGet,
+	safeLocalStorageRemove,
+	safeLocalStorageSet,
+} from '~/lib/utils/safe-storage'
 
 /** Loaded only in the browser so kit state does not touch Node's broken `localStorage` polyfill. */
 type StellarWalletsKitModules = {
@@ -57,16 +63,16 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 	// Initialize state from localStorage if available (client-side only)
 	const [address, setAddress] = useState<string | null>(() => {
 		if (typeof window === 'undefined') return null
-		const stored = localStorage.getItem('stellar_wallet_address')
+		const stored = safeLocalStorageGet('stellar_wallet_address')
 		if (stored && !isExternalStellarWalletAddress(stored)) {
-			localStorage.removeItem('stellar_wallet_address')
-			localStorage.removeItem('stellar_wallet_name')
+			safeLocalStorageRemove('stellar_wallet_address')
+			safeLocalStorageRemove('stellar_wallet_name')
 		}
 		return isExternalStellarWalletAddress(stored) ? stored : null
 	})
 	const [walletName, setWalletName] = useState<string | null>(() => {
 		if (typeof window === 'undefined') return null
-		return localStorage.getItem('stellar_wallet_name')
+		return safeLocalStorageGet('stellar_wallet_name')
 	})
 	const [isInitialized, setIsInitialized] = useState(false)
 	const subscriptionsRef = useRef<Array<() => void>>([])
@@ -84,10 +90,9 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 				const swk = await loadStellarWalletsKit()
 				if (cancelled) return
 
-				const storage = globalThis.localStorage
-				if (typeof storage?.getItem !== 'function') {
+				if (!isLocalStorageAvailable()) {
 					logger.error(
-						'StellarWalletsKit requires browser localStorage. Check NODE_OPTIONS for a broken --localstorage-file flag.',
+						'StellarWalletsKit requires browser localStorage. Storage may be blocked by privacy settings.',
 					)
 					return
 				}
@@ -114,15 +119,15 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 					},
 				})
 				// Try to get address if already connected (read from localStorage directly to avoid dependency)
-				const storedAddress = localStorage.getItem('stellar_wallet_address')
+				const storedAddress = safeLocalStorageGet('stellar_wallet_address')
 				if (storedAddress) {
 					StellarWalletsKit.getAddress()
 						.then(({ address: fetchedAddress }: { address: string }) => {
 							if (fetchedAddress && !isExternalStellarWalletAddress(fetchedAddress)) {
 								setAddress(null)
 								setWalletName(null)
-								localStorage.removeItem('stellar_wallet_address')
-								localStorage.removeItem('stellar_wallet_name')
+								safeLocalStorageRemove('stellar_wallet_address')
+								safeLocalStorageRemove('stellar_wallet_name')
 								return
 							}
 							if (fetchedAddress && fetchedAddress !== storedAddress) {
@@ -134,8 +139,8 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 							// If getAddress fails, clear stored data
 							setAddress(null)
 							setWalletName(null)
-							localStorage.removeItem('stellar_wallet_address')
-							localStorage.removeItem('stellar_wallet_name')
+							safeLocalStorageRemove('stellar_wallet_address')
+							safeLocalStorageRemove('stellar_wallet_name')
 						})
 				}
 
@@ -148,15 +153,15 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 						if (event.payload.address) {
 							if (!isExternalStellarWalletAddress(event.payload.address)) {
 								setAddress(null)
-								localStorage.removeItem('stellar_wallet_address')
+								safeLocalStorageRemove('stellar_wallet_address')
 								return
 							}
 							setAddress(event.payload.address)
-							localStorage.setItem('stellar_wallet_address', event.payload.address)
+							safeLocalStorageSet('stellar_wallet_address', event.payload.address)
 							void syncLinkedWallet(event.payload.address)
 						} else {
 							setAddress(null)
-							localStorage.removeItem('stellar_wallet_address')
+							safeLocalStorageRemove('stellar_wallet_address')
 							void syncLinkedWallet(null)
 						}
 					},
@@ -166,8 +171,8 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 				const unsubscribeDisconnect = StellarWalletsKit.on(KitEventType.DISCONNECT, () => {
 					setAddress(null)
 					setWalletName(null)
-					localStorage.removeItem('stellar_wallet_address')
-					localStorage.removeItem('stellar_wallet_name')
+					safeLocalStorageRemove('stellar_wallet_address')
+					safeLocalStorageRemove('stellar_wallet_name')
 					void syncLinkedWallet(null)
 				})
 
@@ -188,7 +193,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 							}
 							const name = walletIdToName[event.payload.id] || event.payload.id
 							setWalletName(name)
-							localStorage.setItem('stellar_wallet_name', name)
+							safeLocalStorageSet('stellar_wallet_name', name)
 						}
 					},
 				)
@@ -240,7 +245,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 					)
 				}
 				setAddress(newAddress)
-				localStorage.setItem('stellar_wallet_address', newAddress)
+				safeLocalStorageSet('stellar_wallet_address', newAddress)
 				void syncLinkedWallet(newAddress)
 				// Try to get wallet name from the selected wallet
 				// This might need adjustment based on actual API behavior
@@ -262,8 +267,8 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 			StellarWalletsKit.disconnect()
 			setAddress(null)
 			setWalletName(null)
-			localStorage.removeItem('stellar_wallet_address')
-			localStorage.removeItem('stellar_wallet_name')
+			safeLocalStorageRemove('stellar_wallet_address')
+			safeLocalStorageRemove('stellar_wallet_name')
 			void syncLinkedWallet(null)
 		} catch (error) {
 			logger.error('Failed to disconnect wallet:', error)

--- a/apps/web/hooks/passkey/use-smart-account-auth.ts
+++ b/apps/web/hooks/passkey/use-smart-account-auth.ts
@@ -10,6 +10,7 @@ import { toast } from 'sonner'
 import { logger } from '@/lib/logger'
 import { createSessionAction } from '~/app/actions/auth'
 import { ErrorCode, InAppError } from '~/lib/passkey/errors'
+import { safeSessionStorageSet } from '~/lib/utils/safe-storage'
 
 const mapPasskeyApiError = (errorMessage: string): InAppError => {
 	if (errorMessage === 'User not found') {
@@ -154,7 +155,8 @@ export const useSmartAccountAuth = (identifier: string) => {
 			setAuthSuccess(message)
 			toast.success(message)
 
-			sessionStorage.setItem('kindfi_new_session', 'true')
+			// Best-effort only — blocked sessionStorage must not fail login (common on iOS Safari).
+			safeSessionStorageSet('kindfi_new_session', 'true')
 
 			await router.refresh()
 			router.push('/profile')

--- a/apps/web/hooks/stellar/use-stellar.ts
+++ b/apps/web/hooks/stellar/use-stellar.ts
@@ -8,33 +8,34 @@ import { updateDeviceWithDeployee } from '~/app/actions/auth'
 import { logger } from '~/lib/logger'
 import { getPublicKeys } from '~/lib/passkey/stellar'
 import type { PresignResponse, SignParams } from '~/lib/types'
+import {
+	safeLocalStorageGet,
+	safeLocalStorageRemove,
+	safeLocalStorageSet,
+} from '~/lib/utils/safe-storage'
 
-const getStoredDeployee = () => {
-	return localStorage.getItem('sp:deployee')
-}
+const getStoredDeployee = () => safeLocalStorageGet('sp:deployee')
 
 const removeStoredDeployee = () => {
-	localStorage.removeItem('sp:deployee')
+	safeLocalStorageRemove('sp:deployee')
 }
 
-const getStoredBundler = () => {
-	return localStorage.getItem('sp:bundler')
-}
+const getStoredBundler = () => safeLocalStorageGet('sp:bundler')
 
 const setStoredBundler = (bundler: string) => {
-	localStorage.setItem('sp:bundler', bundler)
+	safeLocalStorageSet('sp:bundler', bundler)
 }
 
 const removeStoredBundler = () => {
-	localStorage.removeItem('sp:bundler')
+	safeLocalStorageRemove('sp:bundler')
 }
 
 const setStoredCredentialId = (credentials: string) => {
-	localStorage.setItem('sp:id', credentials)
+	safeLocalStorageSet('sp:id', credentials)
 }
 
 const removeStoredCredentialId = () => {
-	localStorage.removeItem('sp:id')
+	safeLocalStorageRemove('sp:id')
 }
 
 export const useStellar = () => {

--- a/apps/web/hooks/use-etherfuse-user-onboarding.ts
+++ b/apps/web/hooks/use-etherfuse-user-onboarding.ts
@@ -2,6 +2,11 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import type { EtherfuseOnboardingStatus } from '~/lib/etherfuse/resolve-order-context'
+import {
+	safeLocalStorageGet,
+	safeLocalStorageRemove,
+	safeLocalStorageSet,
+} from '~/lib/utils/safe-storage'
 
 export type EtherfuseUserOnboarding = {
 	customerId: string
@@ -22,20 +27,20 @@ const readStoredOnboarding = (
 	}
 
 	try {
-		const raw = localStorage.getItem(storageKey(userId))
+		const raw = safeLocalStorageGet(storageKey(userId))
 		if (!raw) {
 			return null
 		}
 
 		const parsed = JSON.parse(raw) as EtherfuseUserOnboarding
 		if (parsed.walletPublicKey !== walletAddress) {
-			localStorage.removeItem(storageKey(userId))
+			safeLocalStorageRemove(storageKey(userId))
 			return null
 		}
 
 		return parsed
 	} catch {
-		localStorage.removeItem(storageKey(userId))
+		safeLocalStorageRemove(storageKey(userId))
 		return null
 	}
 }
@@ -52,14 +57,14 @@ export const useEtherfuseUserOnboarding = (userId: string, walletAddress: string
 
 	const persistOnboarding = useCallback(
 		(record: EtherfuseUserOnboarding) => {
-			localStorage.setItem(storageKey(userId), JSON.stringify(record))
+			safeLocalStorageSet(storageKey(userId), JSON.stringify(record))
 			setOnboarding(record)
 		},
 		[userId],
 	)
 
 	const clearOnboarding = useCallback(() => {
-		localStorage.removeItem(storageKey(userId))
+		safeLocalStorageRemove(storageKey(userId))
 		setOnboarding(null)
 		setStatus(null)
 	}, [userId])

--- a/apps/web/lib/i18n/context.tsx
+++ b/apps/web/lib/i18n/context.tsx
@@ -2,6 +2,7 @@
 
 import type React from 'react'
 import { createContext, useContext, useEffect, useState } from 'react'
+import { safeLocalStorageGet, safeLocalStorageSet } from '~/lib/utils/safe-storage'
 import { loadLocaleBundle } from './load-locale'
 import { en } from './translations/en'
 
@@ -49,7 +50,7 @@ export function I18nProvider({ children }: I18nProviderProps) {
 
 	// Load language from localStorage on mount
 	useEffect(() => {
-		const savedLanguage = localStorage.getItem('language') as Language
+		const savedLanguage = safeLocalStorageGet('language') as Language
 		if (savedLanguage && (savedLanguage === 'en' || savedLanguage === 'es')) {
 			const timer = setTimeout(() => {
 				setLanguageState(savedLanguage)
@@ -76,7 +77,7 @@ export function I18nProvider({ children }: I18nProviderProps) {
 
 	const setLanguage = (lang: Language) => {
 		setLanguageState(lang)
-		localStorage.setItem('language', lang)
+		safeLocalStorageSet('language', lang)
 		document.documentElement.lang = lang
 	}
 

--- a/apps/web/lib/schemas/stellar.schemas.ts
+++ b/apps/web/lib/schemas/stellar.schemas.ts
@@ -1,7 +1,6 @@
 import {
 	isSmartAccountPlaceholder,
 	isValidStellarWalletAddress,
-	STELLAR_G_ADDRESS_REGEX,
 } from '@packages/lib/utils/wallet-address'
 import { z } from 'zod'
 

--- a/apps/web/lib/utils/color-utils.ts
+++ b/apps/web/lib/utils/color-utils.ts
@@ -1,10 +1,37 @@
 import getContrast from 'get-contrast'
 
+const DEFAULT_HEX_COLOR = '#61646B'
+
 const MAXIMUM_COLOR_RANGE = 0xffffff
 function randomHexColor(): string {
 	return `#${`${Math.floor(Math.random() * MAXIMUM_COLOR_RANGE)
 		.toString(16)
 		.padStart(6, '0')}`}`
+}
+
+/** Normalize user/database colors to 6-char hex; fall back when invalid. */
+export function normalizeHexColor(
+	color: string | null | undefined,
+	fallback = DEFAULT_HEX_COLOR,
+): string {
+	if (!color || typeof color !== 'string') return fallback
+
+	let hex = color.trim()
+	if (!hex.startsWith('#')) hex = `#${hex}`
+	hex = hex.replace('#', '')
+
+	if (/^[0-9A-Fa-f]{3}$/.test(hex)) {
+		hex = hex
+			.split('')
+			.map((char) => char + char)
+			.join('')
+	}
+
+	if (/^[0-9A-Fa-f]{6}$/.test(hex)) {
+		return `#${hex}`
+	}
+
+	return fallback
 }
 
 export function getA11yColorMatch(color: string): [string, string] {
@@ -32,11 +59,7 @@ export function getA11yColorMatch(color: string): [string, string] {
  */
 export function getContrastRatio(color1: string, color2: string): number {
 	const getLuminance = (color: string): number => {
-		// Convert hex to RGB
-		const hex = color.replace('#', '')
-		if (!/^[0-9A-Fa-f]{6}$/.test(hex)) {
-			throw new Error(`Invalid hex color format: ${color}`)
-		}
+		const hex = normalizeHexColor(color).replace('#', '')
 		const r = Number.parseInt(hex.slice(0, 2), 16) / 255
 		const g = Number.parseInt(hex.slice(2, 4), 16) / 255
 		const b = Number.parseInt(hex.slice(4, 6), 16) / 255
@@ -72,9 +95,10 @@ export function getContrastRatio(color1: string, color2: string): number {
 export function getContrastTextColor(
 	backgroundColor: string,
 ): 'text-black' | 'text-white' | 'text-muted-foreground' {
-	const contrastWithWhite = getContrastRatio(backgroundColor, '#FFFFFF')
-	const contrastWithBlack = getContrastRatio(backgroundColor, '#000000')
-	const contrastWithGray = getContrastRatio(backgroundColor, '#61646B') // text-muted-foreground
+	const background = normalizeHexColor(backgroundColor)
+	const contrastWithWhite = getContrastRatio(background, '#FFFFFF')
+	const contrastWithBlack = getContrastRatio(background, '#000000')
+	const contrastWithGray = getContrastRatio(background, '#61646B') // text-muted-foreground
 
 	const maxContrast = Math.max(contrastWithWhite, contrastWithBlack, contrastWithGray)
 

--- a/apps/web/lib/utils/escrow/build-update-escrow-payload.test.ts
+++ b/apps/web/lib/utils/escrow/build-update-escrow-payload.test.ts
@@ -37,12 +37,9 @@ const baseEscrowData: GetEscrowsFromIndexerResponse = {
 
 describe('buildUpdateEscrowPayload', () => {
 	test('appends a new single-release milestone', () => {
-		const payload = buildUpdateEscrowPayload(
-			baseEscrowData,
-			'single-release',
-			platformAddress,
-			{ description: 'Phase 2' },
-		)
+		const payload = buildUpdateEscrowPayload(baseEscrowData, 'single-release', platformAddress, {
+			description: 'Phase 2',
+		})
 
 		expect(payload.signer).toBe(platformAddress)
 		expect(payload.escrow.milestones).toHaveLength(2)
@@ -63,16 +60,11 @@ describe('buildUpdateEscrowPayload', () => {
 			],
 		}
 
-		const payload = buildUpdateEscrowPayload(
-			multiEscrow,
-			'multi-release',
-			platformAddress,
-			{
-				description: 'Build',
-				amount: 1500,
-				receiver: 'GReceiver1234567890123456789012345678901',
-			},
-		)
+		const payload = buildUpdateEscrowPayload(multiEscrow, 'multi-release', platformAddress, {
+			description: 'Build',
+			amount: 1500,
+			receiver: 'GReceiver1234567890123456789012345678901',
+		})
 
 		if ('amount' in payload.escrow.milestones[1]) {
 			expect(payload.escrow.milestones[1].amount).toBe(1500)
@@ -83,9 +75,14 @@ describe('buildUpdateEscrowPayload', () => {
 
 	test('rejects non-platform signer', () => {
 		expect(() =>
-			buildUpdateEscrowPayload(baseEscrowData, 'single-release', 'GOther123456789012345678901234567890123', {
-				description: 'Phase 2',
-			}),
+			buildUpdateEscrowPayload(
+				baseEscrowData,
+				'single-release',
+				'GOther123456789012345678901234567890123',
+				{
+					description: 'Phase 2',
+				},
+			),
 		).toThrow('Only the platform address can add releases')
 	})
 })

--- a/apps/web/lib/utils/escrow/build-update-escrow-payload.ts
+++ b/apps/web/lib/utils/escrow/build-update-escrow-payload.ts
@@ -75,8 +75,7 @@ export function buildUpdateEscrowPayload(
 
 	const trustline = {
 		symbol:
-			'symbol' in escrowData.trustline &&
-			typeof escrowData.trustline.symbol === 'string'
+			'symbol' in escrowData.trustline && typeof escrowData.trustline.symbol === 'string'
 				? escrowData.trustline.symbol
 				: 'USDC',
 		address: escrowData.trustline.address,

--- a/apps/web/lib/utils/safe-storage.ts
+++ b/apps/web/lib/utils/safe-storage.ts
@@ -1,0 +1,48 @@
+/**
+ * Browser storage helpers that never throw when access is blocked
+ * (e.g. iOS Safari private browsing, strict privacy settings, in-app browsers).
+ */
+
+const canUseStorage = (): boolean => {
+	if (typeof window === 'undefined') return false
+	try {
+		const storage = window.localStorage
+		const probeKey = '__kindfi_storage_probe__'
+		storage.setItem(probeKey, '1')
+		storage.removeItem(probeKey)
+		return true
+	} catch {
+		return false
+	}
+}
+
+export const safeLocalStorageGet = (key: string): string | null => {
+	if (!canUseStorage()) return null
+	try {
+		return window.localStorage.getItem(key)
+	} catch {
+		return null
+	}
+}
+
+export const safeLocalStorageSet = (key: string, value: string): boolean => {
+	if (!canUseStorage()) return false
+	try {
+		window.localStorage.setItem(key, value)
+		return true
+	} catch {
+		return false
+	}
+}
+
+export const safeLocalStorageRemove = (key: string): boolean => {
+	if (!canUseStorage()) return false
+	try {
+		window.localStorage.removeItem(key)
+		return true
+	} catch {
+		return false
+	}
+}
+
+export const isLocalStorageAvailable = (): boolean => canUseStorage()

--- a/apps/web/lib/utils/safe-storage.ts
+++ b/apps/web/lib/utils/safe-storage.ts
@@ -3,46 +3,71 @@
  * (e.g. iOS Safari private browsing, strict privacy settings, in-app browsers).
  */
 
-const canUseStorage = (): boolean => {
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+const probeStorage = (storage: StorageLike): boolean => {
+	const probeKey = '__kindfi_storage_probe__'
+	storage.setItem(probeKey, '1')
+	storage.removeItem(probeKey)
+	return true
+}
+
+const canUseStorage = (type: 'local' | 'session'): boolean => {
 	if (typeof window === 'undefined') return false
 	try {
-		const storage = window.localStorage
-		const probeKey = '__kindfi_storage_probe__'
-		storage.setItem(probeKey, '1')
-		storage.removeItem(probeKey)
-		return true
+		const storage = type === 'local' ? window.localStorage : window.sessionStorage
+		return probeStorage(storage)
 	} catch {
 		return false
 	}
 }
 
-export const safeLocalStorageGet = (key: string): string | null => {
-	if (!canUseStorage()) return null
+const safeStorageGet = (type: 'local' | 'session', key: string): string | null => {
+	if (!canUseStorage(type)) return null
 	try {
-		return window.localStorage.getItem(key)
+		const storage = type === 'local' ? window.localStorage : window.sessionStorage
+		return storage.getItem(key)
 	} catch {
 		return null
 	}
 }
 
-export const safeLocalStorageSet = (key: string, value: string): boolean => {
-	if (!canUseStorage()) return false
+const safeStorageSet = (type: 'local' | 'session', key: string, value: string): boolean => {
+	if (!canUseStorage(type)) return false
 	try {
-		window.localStorage.setItem(key, value)
+		const storage = type === 'local' ? window.localStorage : window.sessionStorage
+		storage.setItem(key, value)
 		return true
 	} catch {
 		return false
 	}
 }
 
-export const safeLocalStorageRemove = (key: string): boolean => {
-	if (!canUseStorage()) return false
+const safeStorageRemove = (type: 'local' | 'session', key: string): boolean => {
+	if (!canUseStorage(type)) return false
 	try {
-		window.localStorage.removeItem(key)
+		const storage = type === 'local' ? window.localStorage : window.sessionStorage
+		storage.removeItem(key)
 		return true
 	} catch {
 		return false
 	}
 }
 
-export const isLocalStorageAvailable = (): boolean => canUseStorage()
+export const safeLocalStorageGet = (key: string): string | null => safeStorageGet('local', key)
+
+export const safeLocalStorageSet = (key: string, value: string): boolean =>
+	safeStorageSet('local', key, value)
+
+export const safeLocalStorageRemove = (key: string): boolean => safeStorageRemove('local', key)
+
+export const isLocalStorageAvailable = (): boolean => canUseStorage('local')
+
+export const safeSessionStorageGet = (key: string): string | null => safeStorageGet('session', key)
+
+export const safeSessionStorageSet = (key: string, value: string): boolean =>
+	safeStorageSet('session', key, value)
+
+export const safeSessionStorageRemove = (key: string): boolean => safeStorageRemove('session', key)
+
+export const isSessionStorageAvailable = (): boolean => canUseStorage('session')

--- a/packages/lib/src/config/app-env.config.ts
+++ b/packages/lib/src/config/app-env.config.ts
@@ -3,7 +3,11 @@ import { logger } from '../logger'
 import type { AppEnvInterface, AppName, ValidatedEnvInput } from '../types'
 
 // Transform function with explicit type annotation
-function parseJsonStringArray(value: string | undefined, fallback: string): string[] {
+function parseJsonStringArray(value: string | string[] | undefined, fallback: string): string[] {
+	if (Array.isArray(value)) {
+		return value.map(String)
+	}
+
 	const source = value || fallback
 	try {
 		const parsed: unknown = JSON.parse(source)
@@ -104,8 +108,8 @@ export function transformEnv(): AppEnvInterface {
 			rpId: parseJsonStringArray(data.RP_ID, '["localhost"]'),
 			rpName: parseJsonStringArray(data.RP_NAME, '["App"]'),
 			expectedOrigin: parseJsonStringArray(data.EXPECTED_ORIGIN, '["http://localhost:3000"]'),
-			challengeTtlSeconds: data.CHALLENGE_TTL_SECONDS || 60,
-			challengeTtlMs: (data.CHALLENGE_TTL_SECONDS || 60) * 1000,
+			challengeTtlSeconds: Number(data.CHALLENGE_TTL_SECONDS) || 60,
+			challengeTtlMs: (Number(data.CHALLENGE_TTL_SECONDS) || 60) * 1000,
 		},
 		redis: {
 			// REST API credentials (@upstash/redis). Prefer UPSTASH_*; fall back to Vercel KV names.

--- a/packages/lib/src/config/app-env.config.ts
+++ b/packages/lib/src/config/app-env.config.ts
@@ -3,6 +3,16 @@ import { logger } from '../logger'
 import type { AppEnvInterface, AppName, ValidatedEnvInput } from '../types'
 
 // Transform function with explicit type annotation
+function parseJsonStringArray(value: string | undefined, fallback: string): string[] {
+	const source = value || fallback
+	try {
+		const parsed: unknown = JSON.parse(source)
+		return Array.isArray(parsed) ? parsed.map(String) : JSON.parse(fallback)
+	} catch {
+		return JSON.parse(fallback)
+	}
+}
+
 export function transformEnv(): AppEnvInterface {
 	const data = process.env as ValidatedEnvInput
 	return {
@@ -91,9 +101,9 @@ export function transformEnv(): AppEnvInterface {
 			redis: {
 				url: data.REDIS_URL || '',
 			},
-			rpId: JSON.parse(`${data.RP_ID || '["localhost"]'}`),
-			rpName: JSON.parse(`${data.RP_NAME || '["App"]'}`),
-			expectedOrigin: JSON.parse(`${data.EXPECTED_ORIGIN || '["http://localhost:3000"]'}`),
+			rpId: parseJsonStringArray(data.RP_ID, '["localhost"]'),
+			rpName: parseJsonStringArray(data.RP_NAME, '["App"]'),
+			expectedOrigin: parseJsonStringArray(data.EXPECTED_ORIGIN, '["http://localhost:3000"]'),
 			challengeTtlSeconds: data.CHALLENGE_TTL_SECONDS || 60,
 			challengeTtlMs: (data.CHALLENGE_TTL_SECONDS || 60) * 1000,
 		},

--- a/packages/lib/src/utils/wallet-address.ts
+++ b/packages/lib/src/utils/wallet-address.ts
@@ -20,7 +20,7 @@ export const resolveSmartAccountAddress = (address: string | null | undefined): 
 		return null
 	}
 
-	return address
+	return isSmartAccountContractAddress(address) ? address : null
 }
 
 export const isExternalStellarWalletAddress = (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the client-side crash on **iPhone Safari** after passkey login (`Application error: a client-side exception has occurred`).

On iOS Safari (especially private browsing or strict privacy settings), `localStorage` and `sessionStorage` can throw `SecurityError`. Several client paths accessed storage synchronously on mount or immediately after authentication, which crashed the entire React tree.

## Root cause

`WalletProvider` was mounted at the app root (PR #926) so wallet disconnect works outside Web3 routes. That made synchronous `localStorage` reads run on every page — including the post-login redirect to `/profile`.

After passkey sign-in, the flow also touched `sessionStorage` (`kindfi_new_session`) and profile `localStorage` (`kindfi_role_chosen`), any of which could throw on blocked storage.

## Changes

- Add `safe-storage.ts` helpers for both `localStorage` and `sessionStorage` (probe + try/catch, never throw)
- Route all `WalletProvider` storage access through safe helpers
- Harden post-login paths:
  - `use-smart-account-auth.ts` — safe `sessionStorage` after sign-in
  - `passkey-registration.tsx` — same for registration finalize
  - `profile-dashboard.tsx` — safe role-selection persistence
  - `use-stellar.ts` — legacy Stellar hook storage helpers
  - `use-etherfuse-user-onboarding.ts` — safe localStorage
- `resolveSmartAccountAddress` only returns valid C-addresses (avoids invalid on-chain lookups)
- Harden `color-utils`, `button.tsx` env access, and `appEnvConfig` JSON parsing
- Add `app/error.tsx` and `app/global-error.tsx` for graceful recovery
- **CI fixes:** Biome formatting for escrow files; TypeScript fix for `parseJsonStringArray` accepting `ValidatedEnvInput` union types

## Test plan

- [x] Biome lint passes
- [x] Vercel preview deployment passes
- [ ] Sign in with passkey on iPhone Safari (normal + private browsing)
- [ ] Confirm redirect to `/profile` without client crash
- [ ] Confirm wallet connect/disconnect still works when storage is available
- [ ] Confirm app remains usable (degraded, not crashed) when storage is blocked

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1bc5-2c36-7672-83ac-048b28d29382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1bc5-2c36-7672-83ac-048b28d29382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-friendly fallback screens for route and app-wide loading errors, with “Try again” and return-home options.

* **Bug Fixes**
  * Improved reliability for login, passkey, wallet, onboarding, and language persistence by using best-effort browser storage (avoids failures when storage is blocked).
  * Improved handling of invalid/partial color inputs by normalizing hex values and choosing readable contrast text.
  * Tightened smart-account address validation to avoid accepting unsupported values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->