### PR TITLE
Release: develop → main

### DIFF
--- a/apps/web/app/(routes)/foundations/[slug]/manage/layout.tsx
+++ b/apps/web/app/(routes)/foundations/[slug]/manage/layout.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react'
 import { FoundationManageCommandCenter } from '~/components/sections/foundations/manage/foundation-manage-command-center'
 import { Web3Providers } from '~/components/shared/layout/web3-providers'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { canUserManageFoundation } from '~/lib/queries/foundations/can-user-manage-foundation'
 import { getFoundationManageMeta } from '~/lib/queries/foundations/get-foundation-manage-meta'
 
 export default async function FoundationManageLayout({
@@ -26,7 +27,13 @@ export default async function FoundationManageLayout({
 	}
 
 	const userId = session?.user?.id
-	if (!userId || foundationMeta.founderId !== userId) {
+	const canManage = await canUserManageFoundation(
+		foundationMeta.id,
+		foundationMeta.founderId,
+		userId,
+	)
+
+	if (!canManage) {
 		redirect(`/foundations/${slug}`)
 	}
 

--- a/apps/web/app/(routes)/foundations/[slug]/manage/members/page.tsx
+++ b/apps/web/app/(routes)/foundations/[slug]/manage/members/page.tsx
@@ -2,6 +2,7 @@ import { prefetchSupabaseQuery } from '@packages/lib/supabase-server'
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query'
 import { FoundationMembersWrapper } from '~/components/sections/foundations/manage/foundation-members-wrapper'
 import { getFoundationBySlug } from '~/lib/queries/foundations/get-foundation-by-slug'
+import { getFoundationTeamBySlug } from '~/lib/queries/foundations/get-foundation-team-by-slug'
 
 export default async function FoundationMembersPage({
 	params,
@@ -11,13 +12,20 @@ export default async function FoundationMembersPage({
 	const { slug } = await params
 	const queryClient = new QueryClient()
 
-	// Prefetch foundation data
-	await prefetchSupabaseQuery(
-		queryClient,
-		'foundation',
-		(client) => getFoundationBySlug(client, slug),
-		[slug],
-	)
+	await Promise.all([
+		prefetchSupabaseQuery(
+			queryClient,
+			'foundation',
+			(client) => getFoundationBySlug(client, slug),
+			[slug],
+		),
+		prefetchSupabaseQuery(
+			queryClient,
+			'foundation-team',
+			(client) => getFoundationTeamBySlug(client, slug),
+			[slug],
+		),
+	])
 
 	const dehydratedState = dehydrate(queryClient)
 

--- a/apps/web/app/api/foundations/[slug]/campaigns/route.ts
+++ b/apps/web/app/api/foundations/[slug]/campaigns/route.ts
@@ -3,6 +3,7 @@ import { createSupabaseServerClient } from '@packages/lib/supabase-server'
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
+import { authorizeFoundationManage } from '~/lib/api/authorize-foundation-manage'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { getFoundationBySlug } from '~/lib/queries/foundations/get-foundation-by-slug'
 import { foundationCampaignsSchema } from '~/lib/schemas/foundation.schemas'
@@ -30,9 +31,9 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ slug: 
 			return NextResponse.json({ error: 'Foundation not found' }, { status: 404 })
 		}
 
-		// Verify user is the founder
-		if (foundation.founderId !== session.user.id) {
-			return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+		const auth = await authorizeFoundationManage(session.user.id, foundation.id)
+		if (!auth.ok) {
+			return NextResponse.json({ error: 'Forbidden' }, { status: auth.status })
 		}
 
 		const body = await req.json()

--- a/apps/web/app/api/foundations/[slug]/milestones/route.ts
+++ b/apps/web/app/api/foundations/[slug]/milestones/route.ts
@@ -2,6 +2,7 @@ import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
+import { authorizeFoundationManage } from '~/lib/api/authorize-foundation-manage'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import {
 	foundationMilestoneCreateSchema,
@@ -40,8 +41,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ slug: s
 			return NextResponse.json({ error: 'Foundation not found' }, { status: 404 })
 		}
 
-		if (foundation.founder_id !== session.user.id) {
-			return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+		const auth = await authorizeFoundationManage(session.user.id, foundation.id)
+		if (!auth.ok) {
+			return NextResponse.json({ error: 'Forbidden' }, { status: auth.status })
 		}
 
 		const { error: insertError } = await supabase.from('foundation_milestones').insert({

--- a/apps/web/app/api/foundations/[slug]/route.ts
+++ b/apps/web/app/api/foundations/[slug]/route.ts
@@ -2,6 +2,7 @@ import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
+import { authorizeFoundationManage } from '~/lib/api/authorize-foundation-manage'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import {
 	foundationSlugParamSchema,
@@ -44,8 +45,9 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ slug: 
 			return NextResponse.json({ error: 'Foundation not found' }, { status: 404 })
 		}
 
-		if (foundation.founder_id !== userId) {
-			return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+		const auth = await authorizeFoundationManage(userId, foundation.id)
+		if (!auth.ok) {
+			return NextResponse.json({ error: 'Forbidden' }, { status: auth.status })
 		}
 
 		const formData = await req.formData()

--- a/apps/web/app/api/foundations/[slug]/team/route.ts
+++ b/apps/web/app/api/foundations/[slug]/team/route.ts
@@ -1,0 +1,136 @@
+import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { logger } from '@/lib/logger'
+import { authorizeFoundationManage } from '~/lib/api/authorize-foundation-manage'
+import { createTeamMemberRecord, deleteTeamMemberRecord } from '~/lib/api/team-member-service'
+import { nextAuthOption } from '~/lib/auth/auth-options'
+import {
+	foundationSlugParamSchema,
+	foundationTeamMemberCreateSchema,
+	foundationTeamMemberDeleteQuerySchema,
+} from '~/lib/schemas/foundation.schemas'
+import { validateRequest } from '~/lib/utils/validation'
+
+export async function POST(req: Request, { params }: { params: Promise<{ slug: string }> }) {
+	try {
+		const session = await getServerSession(nextAuthOption)
+		const userId = session?.user?.id
+		if (!userId) {
+			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+		}
+
+		const { slug } = await params
+		const slugValidation = validateRequest(foundationSlugParamSchema, { slug })
+		if (!slugValidation.success) return slugValidation.response
+
+		const body = await req.json()
+		const validation = validateRequest(foundationTeamMemberCreateSchema, body)
+		if (!validation.success) return validation.response
+
+		const auth = await authorizeFoundationManage(userId, validation.data.foundationId)
+		if (!auth.ok) {
+			return NextResponse.json({ error: 'Forbidden' }, { status: auth.status })
+		}
+
+		const { data: foundation, error: foundationError } = await supabaseServiceRole
+			.from('foundations')
+			.select('founder_id')
+			.eq('id', validation.data.foundationId)
+			.single()
+
+		if (foundationError || !foundation) {
+			return NextResponse.json({ error: 'Foundation not found' }, { status: 404 })
+		}
+
+		const result = await createTeamMemberRecord({
+			entityId: validation.data.foundationId,
+			entityColumn: 'foundation_id',
+			teamTable: 'foundation_team',
+			membersTable: 'foundation_members',
+			ownerUserId: foundation.founder_id,
+			type: validation.data.type,
+			fullName: validation.data.type === 'manual' ? validation.data.fullName : undefined,
+			roleTitle: validation.data.roleTitle,
+			bio: validation.data.bio,
+			photoUrl: validation.data.type === 'manual' ? validation.data.photoUrl : undefined,
+			yearsInvolved: validation.data.type === 'manual' ? validation.data.yearsInvolved : undefined,
+			userId: validation.data.type === 'registered' ? validation.data.userId : undefined,
+		})
+
+		if ('error' in result) {
+			return NextResponse.json({ error: result.error }, { status: result.status })
+		}
+
+		return NextResponse.json(
+			{
+				message: 'Team member added successfully',
+				member: {
+					id: result.member.id,
+					foundationId: result.member.entityId,
+					userId: result.member.userId,
+					fullName: result.member.fullName,
+					roleTitle: result.member.roleTitle,
+					bio: result.member.bio,
+					photoUrl: result.member.photoUrl,
+					yearsInvolved: result.member.yearsInvolved,
+					orderIndex: result.member.orderIndex,
+					isManager: result.member.isManager,
+					createdAt: result.member.createdAt,
+					updatedAt: result.member.updatedAt,
+				},
+			},
+			{ status: result.status },
+		)
+	} catch (err) {
+		logger.error(err)
+		return NextResponse.json(
+			{ error: err instanceof Error ? err.message : 'Unknown error' },
+			{ status: 500 },
+		)
+	}
+}
+
+export async function DELETE(req: Request, { params }: { params: Promise<{ slug: string }> }) {
+	try {
+		const session = await getServerSession(nextAuthOption)
+		const userId = session?.user?.id
+		if (!userId) {
+			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+		}
+
+		const { slug: _slug } = await params
+		const { searchParams } = new URL(req.url)
+		const validation = validateRequest(foundationTeamMemberDeleteQuerySchema, {
+			foundationId: searchParams.get('foundationId'),
+			memberId: searchParams.get('memberId'),
+		})
+		if (!validation.success) return validation.response
+		const { foundationId, memberId } = validation.data
+
+		const auth = await authorizeFoundationManage(userId, foundationId)
+		if (!auth.ok) {
+			return NextResponse.json({ error: 'Forbidden' }, { status: auth.status })
+		}
+
+		const result = await deleteTeamMemberRecord({
+			entityId: foundationId,
+			entityColumn: 'foundation_id',
+			teamTable: 'foundation_team',
+			membersTable: 'foundation_members',
+			memberId,
+		})
+
+		if ('error' in result) {
+			return NextResponse.json({ error: result.error }, { status: result.status })
+		}
+
+		return NextResponse.json({ message: 'Team member removed successfully' })
+	} catch (err) {
+		logger.error(err)
+		return NextResponse.json(
+			{ error: err instanceof Error ? err.message : 'Unknown error' },
+			{ status: 500 },
+		)
+	}
+}

--- a/apps/web/app/api/projects/[slug]/team/route.ts
+++ b/apps/web/app/api/projects/[slug]/team/route.ts
@@ -1,8 +1,9 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
-import type { TablesInsert, TablesUpdate } from '@services/supabase'
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
+import { authorizeProjectManage } from '~/lib/api/authorize-project-manage'
+import { createTeamMemberRecord, deleteTeamMemberRecord } from '~/lib/api/team-member-service'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import {
 	teamMemberCreateSchema,
@@ -23,86 +24,61 @@ export async function POST(req: Request, { params }: { params: Promise<{ slug: s
 		const body = await req.json()
 		const validation = validateRequest(teamMemberCreateSchema, body)
 		if (!validation.success) return validation.response
-		const { projectId, fullName, roleTitle, bio, photoUrl, yearsInvolved } = validation.data
 
-		// Verify user has permission and get max order_index in parallel
-		const [projectResult, memberResult, existingTeamResult] = await Promise.all([
-			supabaseServiceRole.from('projects').select('id, kindler_id').eq('id', projectId).single(),
-			supabaseServiceRole
-				.from('project_members')
-				.select('role')
-				.eq('project_id', projectId)
-				.eq('user_id', userId)
-				.in('role', ['core', 'admin', 'editor'])
-				.single(),
-			supabaseServiceRole
-				.from('project_team')
-				.select('order_index')
-				.eq('project_id', projectId)
-				.order('order_index', { ascending: false })
-				.limit(1)
-				.single(),
-		])
+		const auth = await authorizeProjectManage(userId, validation.data.projectId)
+		if (!auth.ok) {
+			return NextResponse.json({ error: 'Forbidden' }, { status: auth.status })
+		}
 
-		const { data: project, error: projectError } = projectResult
-		const { data: memberData } = memberResult
-		const { data: existingTeam } = existingTeamResult
+		const { data: project, error: projectError } = await supabaseServiceRole
+			.from('projects')
+			.select('kindler_id')
+			.eq('id', validation.data.projectId)
+			.single()
 
 		if (projectError || !project) {
 			return NextResponse.json({ error: 'Project not found' }, { status: 404 })
 		}
 
-		const isOwner = project.kindler_id === userId
-		const hasEditorRole = !!memberData
-
-		if (!isOwner && !hasEditorRole) {
-			return NextResponse.json(
-				{
-					error: 'Forbidden: You do not have permission to manage this project team',
-				},
-				{ status: 403 },
-			)
-		}
-
-		const nextOrderIndex = existingTeam?.order_index ? existingTeam.order_index + 1 : 0
-
-		// Insert new team member
-		const insertData: TablesInsert<'project_team'> = {
-			project_id: projectId,
-			full_name: fullName,
-			role_title: roleTitle,
-			bio: bio?.trim() || null,
-			photo_url: photoUrl?.trim() || null,
-			years_involved: yearsInvolved || null,
-			order_index: nextOrderIndex,
-		}
-
-		const { data: newMember, error: insertError } = await supabaseServiceRole
-			.from('project_team')
-			.insert(insertData)
-			.select()
-			.single()
-
-		if (insertError) {
-			logger.error(insertError)
-			return NextResponse.json({ error: insertError.message }, { status: 500 })
-		}
-
-		return NextResponse.json({
-			message: 'Team member added successfully',
-			member: {
-				id: newMember.id,
-				projectId: newMember.project_id,
-				fullName: newMember.full_name,
-				roleTitle: newMember.role_title,
-				bio: newMember.bio,
-				photoUrl: newMember.photo_url,
-				yearsInvolved: newMember.years_involved,
-				orderIndex: newMember.order_index,
-				createdAt: newMember.created_at,
-				updatedAt: newMember.updated_at,
-			},
+		const result = await createTeamMemberRecord({
+			entityId: validation.data.projectId,
+			entityColumn: 'project_id',
+			teamTable: 'project_team',
+			membersTable: 'project_members',
+			ownerUserId: project.kindler_id,
+			type: validation.data.type,
+			fullName: validation.data.type === 'manual' ? validation.data.fullName : undefined,
+			roleTitle: validation.data.roleTitle,
+			bio: validation.data.bio,
+			photoUrl: validation.data.type === 'manual' ? validation.data.photoUrl : undefined,
+			yearsInvolved: validation.data.type === 'manual' ? validation.data.yearsInvolved : undefined,
+			userId: validation.data.type === 'registered' ? validation.data.userId : undefined,
 		})
+
+		if ('error' in result) {
+			return NextResponse.json({ error: result.error }, { status: result.status })
+		}
+
+		return NextResponse.json(
+			{
+				message: 'Team member added successfully',
+				member: {
+					id: result.member.id,
+					projectId: result.member.entityId,
+					userId: result.member.userId,
+					fullName: result.member.fullName,
+					roleTitle: result.member.roleTitle,
+					bio: result.member.bio,
+					photoUrl: result.member.photoUrl,
+					yearsInvolved: result.member.yearsInvolved,
+					orderIndex: result.member.orderIndex,
+					isManager: result.member.isManager,
+					createdAt: result.member.createdAt,
+					updatedAt: result.member.updatedAt,
+				},
+			},
+			{ status: result.status },
+		)
 	} catch (err) {
 		logger.error(err)
 		return NextResponse.json(
@@ -127,43 +103,12 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ slug: 
 		const { projectId, memberId, fullName, roleTitle, bio, photoUrl, yearsInvolved, orderIndex } =
 			validation.data
 
-		// Verify user has permission in parallel
-		const [projectResult, memberResult] = await Promise.all([
-			supabaseServiceRole.from('projects').select('id, kindler_id').eq('id', projectId).single(),
-			supabaseServiceRole
-				.from('project_members')
-				.select('role')
-				.eq('project_id', projectId)
-				.eq('user_id', userId)
-				.in('role', ['core', 'admin', 'editor'])
-				.single(),
-		])
-
-		const { data: project, error: projectError } = projectResult
-		const { data: memberData, error: memberError } = memberResult
-
-		if (projectError || !project) {
-			return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+		const auth = await authorizeProjectManage(userId, projectId)
+		if (!auth.ok) {
+			return NextResponse.json({ error: 'Forbidden' }, { status: auth.status })
 		}
 
-		if (memberError && memberError.code !== 'PGRST116') {
-			logger.error('Error checking user permissions:', memberError)
-		}
-
-		const isOwner = project.kindler_id === userId
-		const hasEditorRole = !!memberData
-
-		if (!isOwner && !hasEditorRole) {
-			return NextResponse.json(
-				{
-					error: 'Forbidden: You do not have permission to manage this project team',
-				},
-				{ status: 403 },
-			)
-		}
-
-		// Build update data
-		const updateData: TablesUpdate<'project_team'> = {}
+		const updateData: Record<string, unknown> = {}
 		if (fullName !== undefined) updateData.full_name = fullName?.trim() ?? null
 		if (roleTitle !== undefined) updateData.role_title = roleTitle?.trim() ?? null
 		if (bio !== undefined) updateData.bio = bio?.trim() || null
@@ -189,12 +134,14 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ slug: 
 			member: {
 				id: updatedMember.id,
 				projectId: updatedMember.project_id,
+				userId: updatedMember.user_id,
 				fullName: updatedMember.full_name,
 				roleTitle: updatedMember.role_title,
 				bio: updatedMember.bio,
 				photoUrl: updatedMember.photo_url,
 				yearsInvolved: updatedMember.years_involved,
 				orderIndex: updatedMember.order_index,
+				isManager: Boolean(updatedMember.user_id),
 				createdAt: updatedMember.created_at,
 				updatedAt: updatedMember.updated_at,
 			},
@@ -218,63 +165,31 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ slug:
 
 		const { slug: _projectSlug } = await params
 		const { searchParams } = new URL(req.url)
-		const queryData = {
+		const validation = validateRequest(teamMemberDeleteQuerySchema, {
 			projectId: searchParams.get('projectId'),
 			memberId: searchParams.get('memberId'),
-		}
-		const validation = validateRequest(teamMemberDeleteQuerySchema, queryData)
+		})
 		if (!validation.success) return validation.response
 		const { projectId, memberId } = validation.data
 
-		// Verify user has permission in parallel
-		const [projectResult, memberResult] = await Promise.all([
-			supabaseServiceRole.from('projects').select('id, kindler_id').eq('id', projectId).single(),
-			supabaseServiceRole
-				.from('project_members')
-				.select('role')
-				.eq('project_id', projectId)
-				.eq('user_id', userId)
-				.in('role', ['core', 'admin', 'editor'])
-				.single(),
-		])
-
-		const { data: project, error: projectError } = projectResult
-		const { data: memberData, error: memberError } = memberResult
-
-		if (projectError || !project) {
-			return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+		const auth = await authorizeProjectManage(userId, projectId)
+		if (!auth.ok) {
+			return NextResponse.json({ error: 'Forbidden' }, { status: auth.status })
 		}
 
-		if (memberError && memberError.code !== 'PGRST116') {
-			logger.error('Error checking user permissions:', memberError)
-		}
-
-		const isOwner = project.kindler_id === userId
-		const hasEditorRole = !!memberData
-
-		if (!isOwner && !hasEditorRole) {
-			return NextResponse.json(
-				{
-					error: 'Forbidden: You do not have permission to manage this project team',
-				},
-				{ status: 403 },
-			)
-		}
-
-		const { error: deleteError } = await supabaseServiceRole
-			.from('project_team')
-			.delete()
-			.eq('id', memberId)
-			.eq('project_id', projectId)
-
-		if (deleteError) {
-			logger.error(deleteError)
-			return NextResponse.json({ error: deleteError.message }, { status: 500 })
-		}
-
-		return NextResponse.json({
-			message: 'Team member removed successfully',
+		const result = await deleteTeamMemberRecord({
+			entityId: projectId,
+			entityColumn: 'project_id',
+			teamTable: 'project_team',
+			membersTable: 'project_members',
+			memberId,
 		})
+
+		if ('error' in result) {
+			return NextResponse.json({ error: result.error }, { status: result.status })
+		}
+
+		return NextResponse.json({ message: 'Team member removed successfully' })
 	} catch (err) {
 		logger.error(err)
 		return NextResponse.json(

--- a/apps/web/app/api/users/search/route.ts
+++ b/apps/web/app/api/users/search/route.ts
@@ -6,6 +6,9 @@ import { nextAuthOption } from '~/lib/auth/auth-options'
 import { userSearchQuerySchema } from '~/lib/schemas/user.schemas'
 import { validateRequest } from '~/lib/utils/validation'
 
+const escapeFilterValue = (value: string): string =>
+	value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+
 export async function GET(req: Request) {
 	try {
 		const session = await getServerSession(nextAuthOption)
@@ -20,13 +23,13 @@ export async function GET(req: Request) {
 		if (!validation.success) return validation.response
 
 		const { q } = validation.data
-		const pattern = `%${q}%`
+		const pattern = `%${escapeFilterValue(q)}%`
 
 		const { data: users, error } = await supabaseServiceRole
 			.from('profiles')
 			.select('id, display_name, email, image_url, slug')
-			.or(`display_name.ilike.${pattern},email.ilike.${pattern},slug.ilike.${pattern}`)
-			.order('display_name', { ascending: true })
+			.or(`display_name.ilike."${pattern}",email.ilike."${pattern}",slug.ilike."${pattern}"`)
+			.order('display_name', { ascending: true, nullsFirst: false })
 			.limit(10)
 
 		if (error) {

--- a/apps/web/app/api/users/search/route.ts
+++ b/apps/web/app/api/users/search/route.ts
@@ -1,0 +1,54 @@
+import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { logger } from '@/lib/logger'
+import { nextAuthOption } from '~/lib/auth/auth-options'
+import { userSearchQuerySchema } from '~/lib/schemas/user.schemas'
+import { validateRequest } from '~/lib/utils/validation'
+
+export async function GET(req: Request) {
+	try {
+		const session = await getServerSession(nextAuthOption)
+		if (!session?.user?.id) {
+			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+		}
+
+		const { searchParams } = new URL(req.url)
+		const validation = validateRequest(userSearchQuerySchema, {
+			q: searchParams.get('q'),
+		})
+		if (!validation.success) return validation.response
+
+		const { q } = validation.data
+		const pattern = `%${q}%`
+
+		const { data: users, error } = await supabaseServiceRole
+			.from('profiles')
+			.select('id, display_name, email, image_url, slug')
+			.or(`display_name.ilike.${pattern},email.ilike.${pattern},slug.ilike.${pattern}`)
+			.order('display_name', { ascending: true })
+			.limit(10)
+
+		if (error) {
+			logger.error('User search error:', error)
+			return NextResponse.json({ error: error.message }, { status: 500 })
+		}
+
+		return NextResponse.json({
+			users:
+				users?.map((user) => ({
+					id: user.id,
+					displayName: user.display_name,
+					email: user.email,
+					imageUrl: user.image_url,
+					slug: user.slug,
+				})) ?? [],
+		})
+	} catch (err) {
+		logger.error(err)
+		return NextResponse.json(
+			{ error: err instanceof Error ? err.message : 'Unknown error' },
+			{ status: 500 },
+		)
+	}
+}

--- a/apps/web/components/sections/admin/admin-projects-list.tsx
+++ b/apps/web/components/sections/admin/admin-projects-list.tsx
@@ -38,7 +38,7 @@ export function AdminProjectsList() {
 		queryFn: fetchAdminProjects,
 	})
 
-	const { getDisplayRaised } = useProjectsFundingBalances(projects ?? [])
+	const { getDisplayRaised } = useProjectsFundingBalances(projects)
 
 	if (isLoading) {
 		return (

--- a/apps/web/components/sections/foundations/manage/foundation-members-wrapper.tsx
+++ b/apps/web/components/sections/foundations/manage/foundation-members-wrapper.tsx
@@ -9,7 +9,12 @@ import { notFound } from 'next/navigation'
 import { IoPeopleOutline } from 'react-icons/io5'
 import { Badge } from '~/components/base/badge'
 import { Card, CardContent } from '~/components/base/card'
+import { AddTeamMemberForm } from '~/components/sections/projects/members/add-team-member-form'
+import { TeamMemberList } from '~/components/sections/projects/members/team-member-list'
+import { useFoundationTeamMutation } from '~/hooks/foundations/use-foundation-team-mutation'
 import { getFoundationBySlug } from '~/lib/queries/foundations/get-foundation-by-slug'
+import { getFoundationTeamBySlug } from '~/lib/queries/foundations/get-foundation-team-by-slug'
+import type { CreateTeamMemberData } from '~/lib/types/project/project-team.types'
 import { ManagePageShell, ManageSectionHeader } from './shared'
 
 interface FoundationMembersWrapperProps {
@@ -18,16 +23,53 @@ interface FoundationMembersWrapperProps {
 
 export function FoundationMembersWrapper({ foundationSlug }: FoundationMembersWrapperProps) {
 	const prefersReducedMotion = useReducedMotion()
+	const { createMember, deleteMember } = useFoundationTeamMutation()
+
 	const {
 		data: foundation,
-		error,
-		isLoading,
+		error: foundationError,
+		isLoading: isFoundationLoading,
 	} = useSupabaseQuery('foundation', (client) => getFoundationBySlug(client, foundationSlug), {
 		additionalKeyValues: [foundationSlug],
 	})
 
-	if (error ?? !foundation) {
+	const {
+		data: teamData,
+		isLoading: isTeamLoading,
+		error: teamError,
+	} = useSupabaseQuery(
+		'foundation-team',
+		(client) => getFoundationTeamBySlug(client, foundationSlug),
+		{
+			additionalKeyValues: [foundationSlug],
+		},
+	)
+
+	if (foundationError ?? teamError ?? !foundation) {
 		notFound()
+	}
+
+	const isLoading = isFoundationLoading || isTeamLoading
+	const teamMembers = teamData?.team ?? []
+
+	const handleAddMember = async (data: CreateTeamMemberData) => {
+		if (!teamData) return
+
+		await createMember.mutateAsync({
+			foundationId: teamData.foundationId,
+			foundationSlug,
+			...data,
+		})
+	}
+
+	const handleDeleteMember = async (memberId: string) => {
+		if (!teamData) return
+
+		await deleteMember.mutateAsync({
+			foundationId: teamData.foundationId,
+			foundationSlug,
+			memberId,
+		})
 	}
 
 	if (isLoading) {
@@ -49,7 +91,7 @@ export function FoundationMembersWrapper({ foundationSlug }: FoundationMembersWr
 			<ManageSectionHeader
 				icon={<IoPeopleOutline size={24} className="relative z-10" aria-hidden="true" />}
 				title="Foundation Team"
-				description={`View the people behind ${foundation.name}`}
+				description={`Manage the people behind ${foundation.name}`}
 			/>
 
 			<motion.div
@@ -59,7 +101,7 @@ export function FoundationMembersWrapper({ foundationSlug }: FoundationMembersWr
 					delay: prefersReducedMotion ? 0 : 0.2,
 					duration: prefersReducedMotion ? 0 : 0.3,
 				}}
-				className="space-y-6"
+				className="space-y-8"
 			>
 				<div>
 					<h2 className="text-2xl font-bold mb-4 flex items-center gap-2">
@@ -126,20 +168,18 @@ export function FoundationMembersWrapper({ foundationSlug }: FoundationMembersWr
 					)}
 				</div>
 
-				<div className="mt-8">
-					<Card className="border-0 bg-muted/30">
-						<CardContent className="p-8 text-center">
-							<IoPeopleOutline
-								className="h-12 w-12 text-muted-foreground mx-auto mb-4"
-								aria-hidden="true"
-							/>
-							<h3 className="text-lg font-semibold mb-2">Team Members</h3>
-							<p className="text-muted-foreground text-sm">
-								Foundation team member management coming soon. For now, only the founder is
-								displayed.
-							</p>
-						</CardContent>
-					</Card>
+				<div className="space-y-8">
+					<AddTeamMemberForm
+						onAdd={handleAddMember}
+						entityLabel="foundation"
+						excludeUserIds={[
+							foundation.founder?.id,
+							...teamMembers
+								.filter((member) => member.userId)
+								.map((member) => member.userId as string),
+						].filter((id): id is string => Boolean(id))}
+					/>
+					<TeamMemberList members={teamMembers} onDelete={handleDeleteMember} />
 				</div>
 			</motion.div>
 		</ManagePageShell>

--- a/apps/web/components/sections/profile/views/creator-profile/use-creator-profile-data.ts
+++ b/apps/web/components/sections/profile/views/creator-profile/use-creator-profile-data.ts
@@ -18,7 +18,7 @@ async function fetchProfileProjects(): Promise<CreatorProjectWithBalance[]> {
 export function useCreatorProfileData(userId: string) {
 	const { status } = useSession()
 	const {
-		data: projects = [],
+		data: projects,
 		isLoading,
 		error,
 	} = useQuery({
@@ -30,7 +30,7 @@ export function useCreatorProfileData(userId: string) {
 	const { getDisplayRaised, isLoadingBalances } = useProjectsFundingBalances(projects)
 
 	const projectsWithBalances = useMemo((): CreatorProjectWithBalance[] => {
-		return projects.map((project) => {
+		return (projects ?? []).map((project) => {
 			const raised = getDisplayRaised(project)
 			const percentageComplete =
 				calculateFundingProgressPercent(raised, project.goal) ?? project.percentageComplete
@@ -61,7 +61,7 @@ export function useCreatorProfileData(userId: string) {
 		}).format(amount)
 
 	return {
-		projects,
+		projects: projects ?? [],
 		projectsWithBalances,
 		activeProjects,
 		totalRaised,

--- a/apps/web/components/sections/profile/views/donor-profile/use-donor-profile-data.ts
+++ b/apps/web/components/sections/profile/views/donor-profile/use-donor-profile-data.ts
@@ -15,7 +15,7 @@ export function useDonorProfileData(userId: string) {
 	const queryEnabled = status === 'authenticated' && Boolean(userId) && !isSupabaseUserLoading
 
 	const {
-		data: supportedProjects = [],
+		data: supportedProjects,
 		isLoading,
 		error,
 	} = useSupabaseQuery(
@@ -27,7 +27,7 @@ export function useDonorProfileData(userId: string) {
 	const { getDisplayRaised, isLoadingBalances } = useProjectsFundingBalances(supportedProjects)
 
 	const projectsWithBalances = useMemo((): DonorProjectWithBalance[] => {
-		return supportedProjects.map((project) => {
+		return (supportedProjects ?? []).map((project) => {
 			const raised = getDisplayRaised(project)
 			const percentageComplete =
 				calculateFundingProgressPercent(raised, project.goal) ?? project.percentageComplete
@@ -50,7 +50,7 @@ export function useDonorProfileData(userId: string) {
 	}, [projectsWithBalances])
 
 	return {
-		supportedProjects,
+		supportedProjects: supportedProjects ?? [],
 		projectsWithBalances,
 		stats,
 		isLoading: isLoading || isLoadingBalances,

--- a/apps/web/components/sections/projects/members/add-team-member-form.tsx
+++ b/apps/web/components/sections/projects/members/add-team-member-form.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { Loader2, UserPlus } from 'lucide-react'
+import { Loader2, UserPlus, Users } from 'lucide-react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -17,16 +17,21 @@ import {
 	FormMessage,
 } from '~/components/base/form'
 import { Input } from '~/components/base/input'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/base/tabs'
 import { Textarea } from '~/components/base/textarea'
+import { UserSearchPicker } from '~/components/shared/user-search-picker'
 import { zodResolver } from '~/lib/form/zod-resolver'
+import type { SearchableUser } from '~/lib/schemas/user.schemas'
 import type { CreateTeamMemberData } from '~/lib/types/project/project-team.types'
 
 interface AddTeamMemberFormProps {
 	onAdd: (data: CreateTeamMemberData) => Promise<void>
+	excludeUserIds?: string[]
+	entityLabel?: 'campaign' | 'foundation'
 	className?: string
 }
 
-const teamMemberSchema = z.object({
+const manualTeamMemberSchema = z.object({
 	fullName: z.string().trim().min(1, 'Full name is required').max(100, 'Full name is too long'),
 	roleTitle: z.string().trim().min(1, 'Role/title is required').max(100, 'Role/title is too long'),
 	bio: z.string().trim().max(300, 'Bio must be 2-3 lines (max 300 characters)').optional(),
@@ -39,13 +44,25 @@ const teamMemberSchema = z.object({
 		.optional(),
 })
 
-type TeamMemberFormData = z.infer<typeof teamMemberSchema>
+const registeredTeamMemberSchema = z.object({
+	roleTitle: z.string().trim().min(1, 'Role/title is required').max(100, 'Role/title is too long'),
+	bio: z.string().trim().max(300, 'Bio must be 2-3 lines (max 300 characters)').optional(),
+})
 
-export function AddTeamMemberForm({ onAdd, className }: AddTeamMemberFormProps) {
+type ManualTeamMemberFormData = z.infer<typeof manualTeamMemberSchema>
+type RegisteredTeamMemberFormData = z.infer<typeof registeredTeamMemberSchema>
+
+export function AddTeamMemberForm({
+	onAdd,
+	excludeUserIds = [],
+	entityLabel = 'campaign',
+	className,
+}: AddTeamMemberFormProps) {
 	const [isSubmitting, setIsSubmitting] = useState(false)
+	const [selectedUser, setSelectedUser] = useState<SearchableUser | null>(null)
 
-	const form = useForm<TeamMemberFormData>({
-		resolver: zodResolver(teamMemberSchema),
+	const manualForm = useForm<ManualTeamMemberFormData>({
+		resolver: zodResolver(manualTeamMemberSchema),
 		defaultValues: {
 			fullName: '',
 			roleTitle: '',
@@ -55,19 +72,53 @@ export function AddTeamMemberForm({ onAdd, className }: AddTeamMemberFormProps) 
 		},
 	})
 
-	const handleSubmit = async (data: TeamMemberFormData) => {
+	const registeredForm = useForm<RegisteredTeamMemberFormData>({
+		resolver: zodResolver(registeredTeamMemberSchema),
+		defaultValues: {
+			roleTitle: '',
+			bio: '',
+		},
+	})
+
+	const handleManualSubmit = async (data: ManualTeamMemberFormData) => {
 		try {
 			setIsSubmitting(true)
 			await onAdd({
+				type: 'manual',
 				fullName: data.fullName,
 				roleTitle: data.roleTitle,
 				bio: data.bio || undefined,
 				photoUrl: data.photoUrl || undefined,
 				yearsInvolved: data.yearsInvolved,
 			})
-			form.reset()
+			manualForm.reset()
 		} catch (error) {
 			logger.error('Failed to add team member:', error)
+		} finally {
+			setIsSubmitting(false)
+		}
+	}
+
+	const handleRegisteredSubmit = async (data: RegisteredTeamMemberFormData) => {
+		if (!selectedUser) {
+			registeredForm.setError('roleTitle', {
+				message: 'Please select a registered user',
+			})
+			return
+		}
+
+		try {
+			setIsSubmitting(true)
+			await onAdd({
+				type: 'registered',
+				userId: selectedUser.id,
+				roleTitle: data.roleTitle,
+				bio: data.bio || undefined,
+			})
+			registeredForm.reset()
+			setSelectedUser(null)
+		} catch (error) {
+			logger.error('Failed to add registered team member:', error)
 		} finally {
 			setIsSubmitting(false)
 		}
@@ -87,146 +138,254 @@ export function AddTeamMemberForm({ onAdd, className }: AddTeamMemberFormProps) 
 						Add Team Member
 					</CardTitle>
 					<CardDescription>
-						Add someone who&apos;s behind this project. No account required.
+						Add someone manually for display, or select a registered user to grant {entityLabel}{' '}
+						management access.
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
-					<Form {...form}>
-						<form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
-							<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-								<FormField
-									control={form.control}
-									name="fullName"
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>
-												Full Name <span className="text-destructive">*</span>
-											</FormLabel>
-											<FormControl>
-												<Input placeholder="John Doe" disabled={isSubmitting} {...field} />
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
+					<Tabs defaultValue="registered">
+						<TabsList className="grid w-full grid-cols-2 mb-6">
+							<TabsTrigger value="registered" className="flex items-center gap-2">
+								<Users className="h-4 w-4" aria-hidden="true" />
+								Registered User
+							</TabsTrigger>
+							<TabsTrigger value="manual" className="flex items-center gap-2">
+								<UserPlus className="h-4 w-4" aria-hidden="true" />
+								Manual Entry
+							</TabsTrigger>
+						</TabsList>
 
-								<FormField
-									control={form.control}
-									name="roleTitle"
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>
-												Role / Title <span className="text-destructive">*</span>
-											</FormLabel>
-											<FormControl>
-												<Input
-													placeholder="e.g., Project Lead, Designer"
-													disabled={isSubmitting}
-													{...field}
-												/>
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-							</div>
-
-							<FormField
-								control={form.control}
-								name="bio"
-								render={({ field }) => (
+						<TabsContent value="registered">
+							<Form {...registeredForm}>
+								<form
+									onSubmit={registeredForm.handleSubmit(handleRegisteredSubmit)}
+									className="space-y-4"
+								>
 									<FormItem>
 										<FormLabel>
-											Short Bio{' '}
-											<span className="text-muted-foreground text-xs">(optional, 2-3 lines)</span>
+											Platform User <span className="text-destructive">*</span>
 										</FormLabel>
 										<FormControl>
-											<Textarea
-												placeholder="Brief description of their role and contribution..."
-												rows={3}
+											<UserSearchPicker
+												selectedUser={selectedUser}
+												onSelect={setSelectedUser}
 												disabled={isSubmitting}
-												{...field}
+												excludeUserIds={excludeUserIds}
 											/>
 										</FormControl>
-										<FormMessage />
+										<p className="text-xs text-muted-foreground mt-1">
+											Registered users are granted permission to manage this {entityLabel}.
+										</p>
 									</FormItem>
-								)}
-							/>
 
-							<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-								<FormField
-									control={form.control}
-									name="photoUrl"
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>
-												Photo URL <span className="text-muted-foreground text-xs">(optional)</span>
-											</FormLabel>
-											<FormControl>
-												<Input
-													placeholder="https://example.com/photo.jpg"
-													type="url"
-													disabled={isSubmitting}
-													{...field}
-												/>
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
+									<FormField
+										control={registeredForm.control}
+										name="roleTitle"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>
+													Role / Title <span className="text-destructive">*</span>
+												</FormLabel>
+												<FormControl>
+													<Input
+														placeholder="e.g., Campaign Manager, Co-founder"
+														disabled={isSubmitting}
+														{...field}
+													/>
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
 
-								<FormField
-									control={form.control}
-									name="yearsInvolved"
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>
-												Years Involved{' '}
-												<span className="text-muted-foreground text-xs">(optional)</span>
-											</FormLabel>
-											<FormControl>
-												<Input
-													placeholder="e.g., 3"
-													type="number"
-													min={0}
-													max={100}
-													disabled={isSubmitting}
-													{...field}
-													onChange={(e) =>
-														field.onChange(
-															e.target.value ? parseInt(e.target.value, 10) : undefined,
-														)
-													}
-												/>
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-							</div>
+									<FormField
+										control={registeredForm.control}
+										name="bio"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>
+													Short Bio{' '}
+													<span className="text-muted-foreground text-xs">(optional)</span>
+												</FormLabel>
+												<FormControl>
+													<Textarea
+														placeholder="Override the user's profile bio for this team listing…"
+														rows={3}
+														disabled={isSubmitting}
+														{...field}
+													/>
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
 
-							<div className="flex justify-end">
-								<Button
-									type="submit"
-									disabled={isSubmitting}
-									variant="primary-gradient"
-									className="flex items-center gap-2"
-								>
-									{isSubmitting ? (
-										<>
-											<Loader2 className="h-4 w-4 animate-spin" />
-											Adding...
-										</>
-									) : (
-										<>
-											<UserPlus className="h-4 w-4" />
-											Add Team Member
-										</>
-									)}
-								</Button>
-							</div>
-						</form>
-					</Form>
+									<div className="flex justify-end">
+										<Button
+											type="submit"
+											disabled={isSubmitting || !selectedUser}
+											variant="primary-gradient"
+											className="flex items-center gap-2"
+										>
+											{isSubmitting ? (
+												<>
+													<Loader2 className="h-4 w-4 animate-spin" />
+													Adding...
+												</>
+											) : (
+												<>
+													<Users className="h-4 w-4" />
+													Add & Grant Access
+												</>
+											)}
+										</Button>
+									</div>
+								</form>
+							</Form>
+						</TabsContent>
+
+						<TabsContent value="manual">
+							<Form {...manualForm}>
+								<form onSubmit={manualForm.handleSubmit(handleManualSubmit)} className="space-y-4">
+									<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+										<FormField
+											control={manualForm.control}
+											name="fullName"
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel>
+														Full Name <span className="text-destructive">*</span>
+													</FormLabel>
+													<FormControl>
+														<Input placeholder="John Doe" disabled={isSubmitting} {...field} />
+													</FormControl>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+
+										<FormField
+											control={manualForm.control}
+											name="roleTitle"
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel>
+														Role / Title <span className="text-destructive">*</span>
+													</FormLabel>
+													<FormControl>
+														<Input
+															placeholder="e.g., Project Lead, Designer"
+															disabled={isSubmitting}
+															{...field}
+														/>
+													</FormControl>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+									</div>
+
+									<FormField
+										control={manualForm.control}
+										name="bio"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>
+													Short Bio{' '}
+													<span className="text-muted-foreground text-xs">
+														(optional, 2-3 lines)
+													</span>
+												</FormLabel>
+												<FormControl>
+													<Textarea
+														placeholder="Brief description of their role and contribution..."
+														rows={3}
+														disabled={isSubmitting}
+														{...field}
+													/>
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+
+									<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+										<FormField
+											control={manualForm.control}
+											name="photoUrl"
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel>
+														Photo URL{' '}
+														<span className="text-muted-foreground text-xs">(optional)</span>
+													</FormLabel>
+													<FormControl>
+														<Input
+															placeholder="https://example.com/photo.jpg"
+															type="url"
+															disabled={isSubmitting}
+															{...field}
+														/>
+													</FormControl>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+
+										<FormField
+											control={manualForm.control}
+											name="yearsInvolved"
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel>
+														Years Involved{' '}
+														<span className="text-muted-foreground text-xs">(optional)</span>
+													</FormLabel>
+													<FormControl>
+														<Input
+															placeholder="e.g., 3"
+															type="number"
+															min={0}
+															max={100}
+															disabled={isSubmitting}
+															{...field}
+															onChange={(e) =>
+																field.onChange(
+																	e.target.value ? parseInt(e.target.value, 10) : undefined,
+																)
+															}
+														/>
+													</FormControl>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+									</div>
+
+									<div className="flex justify-end">
+										<Button
+											type="submit"
+											disabled={isSubmitting}
+											variant="primary-gradient"
+											className="flex items-center gap-2"
+										>
+											{isSubmitting ? (
+												<>
+													<Loader2 className="h-4 w-4 animate-spin" />
+													Adding...
+												</>
+											) : (
+												<>
+													<UserPlus className="h-4 w-4" />
+													Add Team Member
+												</>
+											)}
+										</Button>
+									</div>
+								</form>
+							</Form>
+						</TabsContent>
+					</Tabs>
 				</CardContent>
 			</Card>
 		</motion.div>

--- a/apps/web/components/sections/projects/members/add-team-member-form.tsx
+++ b/apps/web/components/sections/projects/members/add-team-member-form.tsx
@@ -17,6 +17,7 @@ import {
 	FormMessage,
 } from '~/components/base/form'
 import { Input } from '~/components/base/input'
+import { Label } from '~/components/base/label'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/base/tabs'
 import { Textarea } from '~/components/base/textarea'
 import { UserSearchPicker } from '~/components/shared/user-search-picker'
@@ -161,22 +162,20 @@ export function AddTeamMemberForm({
 									onSubmit={registeredForm.handleSubmit(handleRegisteredSubmit)}
 									className="space-y-4"
 								>
-									<FormItem>
-										<FormLabel>
+									<div className="space-y-2">
+										<Label>
 											Platform User <span className="text-destructive">*</span>
-										</FormLabel>
-										<FormControl>
-											<UserSearchPicker
-												selectedUser={selectedUser}
-												onSelect={setSelectedUser}
-												disabled={isSubmitting}
-												excludeUserIds={excludeUserIds}
-											/>
-										</FormControl>
-										<p className="text-xs text-muted-foreground mt-1">
+										</Label>
+										<UserSearchPicker
+											selectedUser={selectedUser}
+											onSelect={setSelectedUser}
+											disabled={isSubmitting}
+											excludeUserIds={excludeUserIds}
+										/>
+										<p className="text-xs text-muted-foreground">
 											Registered users are granted permission to manage this {entityLabel}.
 										</p>
-									</FormItem>
+									</div>
 
 									<FormField
 										control={registeredForm.control}

--- a/apps/web/components/sections/projects/members/project-members-wrapper.tsx
+++ b/apps/web/components/sections/projects/members/project-members-wrapper.tsx
@@ -102,7 +102,14 @@ export function ProjectMembersWrapper({ projectSlug }: ProjectMembersWrapperProp
 					className="space-y-8 max-w-4xl mx-auto"
 				>
 					{/* Add Team Member Form */}
-					{!isLoading ? <AddTeamMemberForm onAdd={handleAddMember} /> : null}
+					{!isLoading ? (
+						<AddTeamMemberForm
+							onAdd={handleAddMember}
+							excludeUserIds={teamMembers
+								.filter((member) => member.userId)
+								.map((member) => member.userId as string)}
+						/>
+					) : null}
 
 					{/* Team Members List */}
 					<TeamMemberList members={teamMembers} onDelete={handleDeleteMember} />

--- a/apps/web/components/sections/projects/members/team-member-card.tsx
+++ b/apps/web/components/sections/projects/members/team-member-card.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { Edit2, Trash2 } from 'lucide-react'
+import { Edit2, Shield, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
+import { Badge } from '~/components/base/badge'
 import { Button } from '~/components/base/button'
 import { Card, CardContent, CardHeader } from '~/components/base/card'
 import {
@@ -45,7 +46,15 @@ export function TeamMemberCard({ member, index, onEdit, onDelete }: TeamMemberCa
 								</AvatarFallback>
 							</Avatar>
 							<div className="flex-1 min-w-0">
-								<h3 className="font-semibold text-lg truncate">{member.fullName}</h3>
+								<div className="flex items-center gap-2">
+									<h3 className="font-semibold text-lg truncate">{member.fullName}</h3>
+									{member.isManager ? (
+										<Badge variant="secondary" className="shrink-0 gap-1 text-xs">
+											<Shield className="h-3 w-3" aria-hidden="true" />
+											Manager
+										</Badge>
+									) : null}
+								</div>
 								<p className="text-sm text-muted-foreground truncate">{member.roleTitle}</p>
 							</div>
 						</div>

--- a/apps/web/components/shared/user-search-picker.tsx
+++ b/apps/web/components/shared/user-search-picker.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { Check, ChevronsUpDown, Loader2, User } from 'lucide-react'
+import Image from 'next/image'
+import { useEffect, useState } from 'react'
+import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from '~/components/base/command'
+import { Popover, PopoverContent, PopoverTrigger } from '~/components/base/popover'
+import type { SearchableUser } from '~/lib/schemas/user.schemas'
+import { cn, getAvatarFallback } from '~/lib/utils'
+import type { UserSearchPickerProps } from './user-search-picker.types'
+
+export function UserSearchPicker({
+	selectedUser,
+	onSelect,
+	disabled = false,
+	excludeUserIds = [],
+}: UserSearchPickerProps) {
+	const [open, setOpen] = useState(false)
+	const [query, setQuery] = useState('')
+	const [users, setUsers] = useState<SearchableUser[]>([])
+	const [isSearching, setIsSearching] = useState(false)
+
+	useEffect(() => {
+		if (query.trim().length < 2) {
+			setUsers([])
+			return
+		}
+
+		const controller = new AbortController()
+		const timeoutId = setTimeout(async () => {
+			setIsSearching(true)
+			try {
+				const res = await fetch(`/api/users/search?q=${encodeURIComponent(query.trim())}`, {
+					signal: controller.signal,
+				})
+				if (!res.ok) return
+				const data = (await res.json()) as { users: SearchableUser[] }
+				setUsers(data.users.filter((user) => !excludeUserIds.includes(user.id)))
+			} catch {
+				// Ignore aborted requests
+			} finally {
+				setIsSearching(false)
+			}
+		}, 300)
+
+		return () => {
+			clearTimeout(timeoutId)
+			controller.abort()
+		}
+	}, [query, excludeUserIds])
+
+	const displayLabel = selectedUser
+		? selectedUser.displayName || selectedUser.email || 'Selected user'
+		: 'Search by name or email…'
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					disabled={disabled}
+					className={cn(
+						'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm ring-offset-background',
+						'hover:bg-accent/40 focus:outline-none focus:ring-1 focus:ring-ring',
+						'disabled:cursor-not-allowed disabled:opacity-50',
+						!selectedUser && 'text-muted-foreground',
+					)}
+				>
+					<span className="flex items-center gap-2 truncate">
+						{selectedUser ? (
+							<Avatar className="h-6 w-6">
+								<AvatarImage src={selectedUser.imageUrl ?? undefined} alt="" />
+								<AvatarFallback className="text-xs">
+									{getAvatarFallback(selectedUser.displayName || selectedUser.email || '')}
+								</AvatarFallback>
+							</Avatar>
+						) : (
+							<User className="h-4 w-4 shrink-0" aria-hidden="true" />
+						)}
+						<span className="truncate">{displayLabel}</span>
+					</span>
+					<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+				</button>
+			</PopoverTrigger>
+			<PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+				<Command shouldFilter={false}>
+					<CommandInput
+						placeholder="Search users…"
+						className="h-9"
+						value={query}
+						onValueChange={setQuery}
+					/>
+					<CommandList>
+						{isSearching ? (
+							<div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+								<Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+								Searching…
+							</div>
+						) : query.trim().length < 2 ? (
+							<CommandEmpty>Type at least 2 characters to search.</CommandEmpty>
+						) : users.length === 0 ? (
+							<CommandEmpty>No users found.</CommandEmpty>
+						) : (
+							<CommandGroup>
+								{users.map((user) => {
+									const label = user.displayName || user.email || 'Anonymous'
+									return (
+										<CommandItem
+											key={user.id}
+											value={`${label} ${user.email ?? ''}`}
+											onSelect={() => {
+												onSelect(user)
+												setOpen(false)
+											}}
+											className="gap-2"
+										>
+											{user.imageUrl ? (
+												<Image
+													src={user.imageUrl}
+													alt=""
+													width={24}
+													height={24}
+													className="h-6 w-6 rounded-full object-cover shrink-0"
+												/>
+											) : (
+												<div className="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-xs font-medium shrink-0">
+													{getAvatarFallback(label)}
+												</div>
+											)}
+											<div className="flex-1 min-w-0">
+												<span className="block truncate font-medium">{label}</span>
+												{user.email ? (
+													<span className="block text-xs text-muted-foreground truncate">
+														{user.email}
+													</span>
+												) : null}
+											</div>
+											{selectedUser?.id === user.id ? (
+												<Check className="h-4 w-4 shrink-0 text-primary" />
+											) : null}
+										</CommandItem>
+									)
+								})}
+							</CommandGroup>
+						)}
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	)
+}

--- a/apps/web/components/shared/user-search-picker.tsx
+++ b/apps/web/components/shared/user-search-picker.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { Check, ChevronsUpDown, Loader2, User } from 'lucide-react'
-import Image from 'next/image'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Avatar, AvatarFallback, AvatarImage } from '~/components/base/avatar'
 import {
 	Command,
@@ -27,25 +26,47 @@ export function UserSearchPicker({
 	const [query, setQuery] = useState('')
 	const [users, setUsers] = useState<SearchableUser[]>([])
 	const [isSearching, setIsSearching] = useState(false)
+	const [searchError, setSearchError] = useState<string | null>(null)
+	const excludedIdsKey = useMemo(() => excludeUserIds.join(','), [excludeUserIds])
 
 	useEffect(() => {
 		if (query.trim().length < 2) {
 			setUsers([])
+			setSearchError(null)
 			return
 		}
 
 		const controller = new AbortController()
 		const timeoutId = setTimeout(async () => {
 			setIsSearching(true)
+			setSearchError(null)
 			try {
 				const res = await fetch(`/api/users/search?q=${encodeURIComponent(query.trim())}`, {
 					signal: controller.signal,
 				})
-				if (!res.ok) return
+
+				if (!res.ok) {
+					let message = 'Failed to search users'
+					try {
+						const body = (await res.json()) as { error?: string }
+						message = body.error ?? message
+					} catch {
+						// ignore parse errors
+					}
+					setUsers([])
+					setSearchError(message)
+					return
+				}
+
 				const data = (await res.json()) as { users: SearchableUser[] }
-				setUsers(data.users.filter((user) => !excludeUserIds.includes(user.id)))
-			} catch {
-				// Ignore aborted requests
+				const excluded = new Set(excludedIdsKey.split(',').filter(Boolean))
+				setUsers(data.users.filter((user) => !excluded.has(user.id)))
+			} catch (error) {
+				if (error instanceof DOMException && error.name === 'AbortError') {
+					return
+				}
+				setUsers([])
+				setSearchError('Failed to search users')
 			} finally {
 				setIsSearching(false)
 			}
@@ -55,7 +76,7 @@ export function UserSearchPicker({
 			clearTimeout(timeoutId)
 			controller.abort()
 		}
-	}, [query, excludeUserIds])
+	}, [query, excludedIdsKey])
 
 	const displayLabel = selectedUser
 		? selectedUser.displayName || selectedUser.email || 'Selected user'
@@ -104,6 +125,8 @@ export function UserSearchPicker({
 								<Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
 								Searching…
 							</div>
+						) : searchError ? (
+							<CommandEmpty>{searchError}</CommandEmpty>
 						) : query.trim().length < 2 ? (
 							<CommandEmpty>Type at least 2 characters to search.</CommandEmpty>
 						) : users.length === 0 ? (
@@ -122,19 +145,12 @@ export function UserSearchPicker({
 											}}
 											className="gap-2"
 										>
-											{user.imageUrl ? (
-												<Image
-													src={user.imageUrl}
-													alt=""
-													width={24}
-													height={24}
-													className="h-6 w-6 rounded-full object-cover shrink-0"
-												/>
-											) : (
-												<div className="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-xs font-medium shrink-0">
+											<Avatar className="h-6 w-6 shrink-0">
+												<AvatarImage src={user.imageUrl ?? undefined} alt="" />
+												<AvatarFallback className="text-xs">
 													{getAvatarFallback(label)}
-												</div>
-											)}
+												</AvatarFallback>
+											</Avatar>
 											<div className="flex-1 min-w-0">
 												<span className="block truncate font-medium">{label}</span>
 												{user.email ? (

--- a/apps/web/components/shared/user-search-picker.types.ts
+++ b/apps/web/components/shared/user-search-picker.types.ts
@@ -1,0 +1,8 @@
+import type { SearchableUser } from '~/lib/schemas/user.schemas'
+
+export interface UserSearchPickerProps {
+	selectedUser: SearchableUser | null
+	onSelect: (user: SearchableUser | null) => void
+	disabled?: boolean
+	excludeUserIds?: string[]
+}

--- a/apps/web/hooks/foundations/use-foundation-team-mutation.ts
+++ b/apps/web/hooks/foundations/use-foundation-team-mutation.ts
@@ -2,25 +2,16 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import type {
-	CreateTeamMemberData,
-	UpdateTeamMemberData,
-} from '~/lib/types/project/project-team.types'
+import type { CreateTeamMemberData } from '~/lib/types/project/project-team.types'
 
-type CreateTeamMemberRequest = CreateTeamMemberData & {
-	projectId: string
-	projectSlug: string
+type CreateFoundationTeamMemberRequest = CreateTeamMemberData & {
+	foundationId: string
+	foundationSlug: string
 }
 
-type UpdateTeamMemberRequest = UpdateTeamMemberData & {
-	projectId: string
-	projectSlug: string
-	memberId: string
-}
-
-type DeleteTeamMemberRequest = {
-	projectId: string
-	projectSlug: string
+type DeleteFoundationTeamMemberRequest = {
+	foundationId: string
+	foundationSlug: string
 	memberId: string
 }
 
@@ -28,28 +19,29 @@ type TeamMemberResponse = {
 	message: string
 	member?: {
 		id: string
-		projectId: string
+		foundationId: string
 		fullName: string
 		roleTitle: string
 		bio?: string | null
 		photoUrl?: string | null
 		yearsInvolved?: number | null
 		orderIndex: number
+		isManager?: boolean
 		createdAt: string
 		updatedAt: string
 	}
 }
 
-export function useTeamMutation() {
+export function useFoundationTeamMutation() {
 	const queryClient = useQueryClient()
 
-	const createMember = useMutation<TeamMemberResponse, Error, CreateTeamMemberRequest>({
+	const createMember = useMutation<TeamMemberResponse, Error, CreateFoundationTeamMemberRequest>({
 		mutationFn: async (data) => {
 			const body =
 				data.type === 'manual'
 					? {
 							type: 'manual' as const,
-							projectId: data.projectId,
+							foundationId: data.foundationId,
 							fullName: data.fullName,
 							roleTitle: data.roleTitle,
 							bio: data.bio,
@@ -58,13 +50,13 @@ export function useTeamMutation() {
 						}
 					: {
 							type: 'registered' as const,
-							projectId: data.projectId,
+							foundationId: data.foundationId,
 							userId: data.userId,
 							roleTitle: data.roleTitle,
 							bio: data.bio,
 						}
 
-			const res = await fetch(`/api/projects/${data.projectSlug}/team`, {
+			const res = await fetch(`/api/foundations/${data.foundationSlug}/team`, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
@@ -97,7 +89,7 @@ export function useTeamMutation() {
 		onSuccess: (_data, variables) => {
 			toast.success('Team member added successfully! 🎉')
 			queryClient.invalidateQueries({
-				queryKey: ['supabase', 'project-team', variables.projectSlug],
+				queryKey: ['supabase', 'foundation-team', variables.foundationSlug],
 			})
 		},
 		onError: (error: Error) => {
@@ -107,64 +99,10 @@ export function useTeamMutation() {
 		},
 	})
 
-	const updateMember = useMutation<TeamMemberResponse, Error, UpdateTeamMemberRequest>({
-		mutationFn: async (data) => {
-			const res = await fetch(`/api/projects/${data.projectSlug}/team`, {
-				method: 'PATCH',
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify({
-					projectId: data.projectId,
-					memberId: data.memberId,
-					fullName: data.fullName,
-					roleTitle: data.roleTitle,
-					bio: data.bio,
-					photoUrl: data.photoUrl,
-					yearsInvolved: data.yearsInvolved,
-					orderIndex: data.orderIndex,
-				}),
-			})
-
-			if (!res.ok) {
-				const clonedRes = res.clone()
-				let errorMessage = 'Failed to update team member'
-
-				try {
-					const contentType = clonedRes.headers.get('content-type')
-					if (contentType?.includes('application/json')) {
-						const error = await clonedRes.json()
-						errorMessage = error?.error || errorMessage
-					} else {
-						const text = await clonedRes.text()
-						errorMessage = text || errorMessage
-					}
-				} catch {
-					// If reading fails, use default message
-				}
-
-				throw new Error(errorMessage)
-			}
-
-			return res.json()
-		},
-		onSuccess: (_data, variables) => {
-			toast.success('Team member updated successfully! ✨')
-			queryClient.invalidateQueries({
-				queryKey: ['supabase', 'project-team', variables.projectSlug],
-			})
-		},
-		onError: (error: Error) => {
-			toast.error('Failed to update team member', {
-				description: error.message,
-			})
-		},
-	})
-
-	const deleteMember = useMutation<{ message: string }, Error, DeleteTeamMemberRequest>({
+	const deleteMember = useMutation<{ message: string }, Error, DeleteFoundationTeamMemberRequest>({
 		mutationFn: async (data) => {
 			const res = await fetch(
-				`/api/projects/${data.projectSlug}/team?projectId=${data.projectId}&memberId=${data.memberId}`,
+				`/api/foundations/${data.foundationSlug}/team?foundationId=${data.foundationId}&memberId=${data.memberId}`,
 				{
 					method: 'DELETE',
 				},
@@ -195,7 +133,7 @@ export function useTeamMutation() {
 		onSuccess: (_data, variables) => {
 			toast.success('Team member removed successfully')
 			queryClient.invalidateQueries({
-				queryKey: ['supabase', 'project-team', variables.projectSlug],
+				queryKey: ['supabase', 'foundation-team', variables.foundationSlug],
 			})
 		},
 		onError: (error: Error) => {
@@ -207,7 +145,6 @@ export function useTeamMutation() {
 
 	return {
 		createMember,
-		updateMember,
 		deleteMember,
 	}
 }

--- a/apps/web/hooks/projects/use-projects-funding-balances.ts
+++ b/apps/web/hooks/projects/use-projects-funding-balances.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import type { EscrowType } from '@trustless-work/escrow'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { logger } from '@/lib/logger'
 import { useOptionalEscrow } from '~/hooks/contexts/use-escrow.context'
 import {
@@ -12,20 +12,32 @@ import {
 	resolveEscrowBalanceFromMap,
 } from '~/lib/utils/projects/project-funding'
 
-export function useProjectsFundingBalances(projects: ProjectFundingSource[]) {
+const EMPTY_PROJECTS: ProjectFundingSource[] = []
+
+const buildProjectsEscrowKey = (projects: ProjectFundingSource[]): string =>
+	projects
+		.filter((project) => Boolean(project.escrowContractAddress))
+		.map((project) => `${project.escrowContractAddress as string}|${getProjectEscrowType(project)}`)
+		.sort()
+		.join(',')
+
+export function useProjectsFundingBalances(projects: ProjectFundingSource[] = EMPTY_PROJECTS) {
 	const escrow = useOptionalEscrow()
 	const getMultipleBalances = escrow?.getMultipleBalances
 	const [escrowBalances, setEscrowBalances] = useState<Record<string, number>>({})
 	const [isLoadingBalances, setIsLoadingBalances] = useState(false)
+	const projectsRef = useRef(projects)
+	projectsRef.current = projects
 
-	const projectsWithEscrow = useMemo(
-		() => projects.filter((project) => Boolean(project.escrowContractAddress)),
-		[projects],
-	)
+	const projectsEscrowKey = useMemo(() => buildProjectsEscrowKey(projects), [projects])
 
 	const fetchBalances = useCallback(async () => {
+		const projectsWithEscrow = projectsRef.current.filter((project) =>
+			Boolean(project.escrowContractAddress),
+		)
+
 		if (projectsWithEscrow.length === 0 || !getMultipleBalances) {
-			setEscrowBalances({})
+			setEscrowBalances((prev) => (Object.keys(prev).length === 0 ? prev : {}))
 			return
 		}
 
@@ -62,7 +74,7 @@ export function useProjectsFundingBalances(projects: ProjectFundingSource[]) {
 		} finally {
 			setIsLoadingBalances(false)
 		}
-	}, [getMultipleBalances, projectsWithEscrow])
+	}, [getMultipleBalances, projectsEscrowKey])
 
 	useEffect(() => {
 		void fetchBalances()

--- a/apps/web/lib/api/authorize-foundation-manage.ts
+++ b/apps/web/lib/api/authorize-foundation-manage.ts
@@ -1,0 +1,60 @@
+import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+
+const MANAGE_MEMBER_ROLES = ['core', 'admin', 'editor'] as const
+
+export type FoundationManageAccess = {
+	userId: string
+	foundationId: string
+	isFounder: boolean
+	isPlatformAdmin: boolean
+}
+
+export async function getFoundationIdBySlug(slug: string): Promise<string | null> {
+	const { data, error } = await supabaseServiceRole
+		.from('foundations')
+		.select('id')
+		.eq('slug', slug)
+		.maybeSingle()
+
+	if (error || !data) return null
+	return data.id
+}
+
+export async function authorizeFoundationManage(
+	userId: string,
+	foundationId: string,
+): Promise<{ ok: true; access: FoundationManageAccess } | { ok: false; status: 403 | 404 }> {
+	const [foundationResult, memberResult, profileResult] = await Promise.all([
+		supabaseServiceRole
+			.from('foundations')
+			.select('id, founder_id')
+			.eq('id', foundationId)
+			.single(),
+		supabaseServiceRole
+			.from('foundation_members')
+			.select('role')
+			.eq('foundation_id', foundationId)
+			.eq('user_id', userId)
+			.in('role', [...MANAGE_MEMBER_ROLES])
+			.maybeSingle(),
+		supabaseServiceRole.from('profiles').select('role').eq('id', userId).maybeSingle(),
+	])
+
+	const { data: foundation, error: foundationError } = foundationResult
+	if (foundationError || !foundation) {
+		return { ok: false, status: 404 }
+	}
+
+	const isFounder = foundation.founder_id === userId
+	const isPlatformAdmin = profileResult.data?.role === 'admin'
+	const hasEditorRole = !!memberResult.data
+
+	if (!isFounder && !hasEditorRole && !isPlatformAdmin) {
+		return { ok: false, status: 403 }
+	}
+
+	return {
+		ok: true,
+		access: { userId, foundationId: foundation.id, isFounder, isPlatformAdmin },
+	}
+}

--- a/apps/web/lib/api/team-member-service.ts
+++ b/apps/web/lib/api/team-member-service.ts
@@ -1,0 +1,208 @@
+import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import type { TablesInsert } from '@services/supabase'
+
+type ProfileRow = {
+	id: string
+	display_name: string | null
+	bio: string | null
+	image_url: string | null
+	email: string | null
+}
+
+type TeamInsertInput = {
+	entityId: string
+	entityColumn: 'project_id' | 'foundation_id'
+	teamTable: 'project_team' | 'foundation_team'
+	membersTable: 'project_members' | 'foundation_members'
+	ownerUserId: string
+	type: 'manual' | 'registered'
+	fullName?: string
+	roleTitle: string
+	bio?: string
+	photoUrl?: string
+	yearsInvolved?: number
+	userId?: string
+}
+
+const mapTeamMember = (member: {
+	id: string
+	project_id?: string
+	foundation_id?: string
+	user_id: string | null
+	full_name: string
+	role_title: string
+	bio: string | null
+	photo_url: string | null
+	years_involved: number | null
+	order_index: number
+	created_at: string
+	updated_at: string
+}) => ({
+	id: member.id,
+	entityId: member.project_id ?? member.foundation_id ?? '',
+	userId: member.user_id,
+	fullName: member.full_name,
+	roleTitle: member.role_title,
+	bio: member.bio,
+	photoUrl: member.photo_url,
+	yearsInvolved: member.years_involved,
+	orderIndex: member.order_index,
+	createdAt: member.created_at,
+	updatedAt: member.updated_at,
+	isManager: Boolean(member.user_id),
+})
+
+export async function createTeamMemberRecord(input: TeamInsertInput) {
+	const {
+		entityId,
+		entityColumn,
+		teamTable,
+		membersTable,
+		ownerUserId,
+		type,
+		roleTitle,
+		bio,
+		photoUrl,
+		yearsInvolved,
+		userId,
+		fullName,
+	} = input
+
+	let profile: ProfileRow | null = null
+	if (type === 'registered') {
+		if (!userId) {
+			return { error: 'User ID is required for registered team members', status: 400 as const }
+		}
+		if (userId === ownerUserId) {
+			return { error: 'The owner is already a team member', status: 400 as const }
+		}
+
+		const { data: profileData, error: profileError } = await supabaseServiceRole
+			.from('profiles')
+			.select('id, display_name, bio, image_url, email')
+			.eq('id', userId)
+			.maybeSingle()
+
+		if (profileError || !profileData) {
+			return { error: 'Registered user not found', status: 404 as const }
+		}
+		profile = profileData
+	}
+
+	const existingTeamQuery = supabaseServiceRole
+		.from(teamTable)
+		.select('id, user_id')
+		.eq(entityColumn, entityId)
+
+	if (type === 'registered' && userId) {
+		existingTeamQuery.eq('user_id', userId)
+	}
+
+	const [existingTeamResult, orderResult] = await Promise.all([
+		type === 'registered' && userId
+			? existingTeamQuery.maybeSingle()
+			: Promise.resolve({ data: null, error: null }),
+		supabaseServiceRole
+			.from(teamTable)
+			.select('order_index')
+			.eq(entityColumn, entityId)
+			.order('order_index', { ascending: false })
+			.limit(1)
+			.maybeSingle(),
+	])
+
+	if (existingTeamResult.data) {
+		return { error: 'This user is already on the team', status: 409 as const }
+	}
+
+	const nextOrderIndex =
+		orderResult.data?.order_index != null ? orderResult.data.order_index + 1 : 0
+
+	const resolvedFullName =
+		type === 'registered'
+			? profile?.display_name?.trim() || profile?.email || 'Team Member'
+			: (fullName?.trim() ?? '')
+
+	const insertData: TablesInsert<'project_team'> | TablesInsert<'foundation_team'> = {
+		[entityColumn]: entityId,
+		full_name: resolvedFullName,
+		role_title: roleTitle,
+		bio: bio?.trim() || (type === 'registered' ? profile?.bio?.trim() || null : null),
+		photo_url:
+			photoUrl?.trim() || (type === 'registered' ? profile?.image_url?.trim() || null : null),
+		years_involved: yearsInvolved ?? null,
+		order_index: nextOrderIndex,
+		user_id: type === 'registered' ? (userId ?? null) : null,
+	}
+
+	const { data: newMember, error: insertError } = await supabaseServiceRole
+		.from(teamTable)
+		.insert(insertData)
+		.select()
+		.single()
+
+	if (insertError) {
+		return { error: insertError.message, status: 500 as const }
+	}
+
+	if (type === 'registered' && userId) {
+		const memberInsert: TablesInsert<'project_members'> | TablesInsert<'foundation_members'> = {
+			[entityColumn]: entityId,
+			user_id: userId,
+			role: 'admin',
+			title: roleTitle,
+		}
+
+		const { error: memberError } = await supabaseServiceRole
+			.from(membersTable)
+			.upsert(memberInsert, {
+				onConflict: `${entityColumn},user_id`,
+			})
+
+		if (memberError) {
+			await supabaseServiceRole.from(teamTable).delete().eq('id', newMember.id)
+			return { error: memberError.message, status: 500 as const }
+		}
+	}
+
+	return { member: mapTeamMember(newMember), status: 201 as const }
+}
+
+export async function deleteTeamMemberRecord(input: {
+	entityId: string
+	entityColumn: 'project_id' | 'foundation_id'
+	teamTable: 'project_team' | 'foundation_team'
+	membersTable: 'project_members' | 'foundation_members'
+	memberId: string
+}) {
+	const { data: teamMember, error: fetchError } = await supabaseServiceRole
+		.from(input.teamTable)
+		.select('id, user_id')
+		.eq('id', input.memberId)
+		.eq(input.entityColumn, input.entityId)
+		.maybeSingle()
+
+	if (fetchError || !teamMember) {
+		return { error: 'Team member not found', status: 404 as const }
+	}
+
+	const { error: deleteError } = await supabaseServiceRole
+		.from(input.teamTable)
+		.delete()
+		.eq('id', input.memberId)
+		.eq(input.entityColumn, input.entityId)
+
+	if (deleteError) {
+		return { error: deleteError.message, status: 500 as const }
+	}
+
+	if (teamMember.user_id) {
+		await supabaseServiceRole
+			.from(input.membersTable)
+			.delete()
+			.eq(input.entityColumn, input.entityId)
+			.eq('user_id', teamMember.user_id)
+	}
+
+	return { status: 200 as const }
+}

--- a/apps/web/lib/api/team-member-service.ts
+++ b/apps/web/lib/api/team-member-service.ts
@@ -123,8 +123,7 @@ export async function createTeamMemberRecord(input: TeamInsertInput) {
 			? profile?.display_name?.trim() || profile?.email || 'Team Member'
 			: (fullName?.trim() ?? '')
 
-	const insertData: TablesInsert<'project_team'> | TablesInsert<'foundation_team'> = {
-		[entityColumn]: entityId,
+	const sharedInsert = {
 		full_name: resolvedFullName,
 		role_title: roleTitle,
 		bio: bio?.trim() || (type === 'registered' ? profile?.bio?.trim() || null : null),
@@ -134,6 +133,17 @@ export async function createTeamMemberRecord(input: TeamInsertInput) {
 		order_index: nextOrderIndex,
 		user_id: type === 'registered' ? (userId ?? null) : null,
 	}
+
+	const insertData =
+		entityColumn === 'project_id'
+			? ({
+					...sharedInsert,
+					project_id: entityId,
+				} satisfies TablesInsert<'project_team'>)
+			: ({
+					...sharedInsert,
+					foundation_id: entityId,
+				} satisfies TablesInsert<'foundation_team'>)
 
 	const { data: newMember, error: insertError } = await supabaseServiceRole
 		.from(teamTable)
@@ -146,12 +156,20 @@ export async function createTeamMemberRecord(input: TeamInsertInput) {
 	}
 
 	if (type === 'registered' && userId) {
-		const memberInsert: TablesInsert<'project_members'> | TablesInsert<'foundation_members'> = {
-			[entityColumn]: entityId,
-			user_id: userId,
-			role: 'admin',
-			title: roleTitle,
-		}
+		const memberInsert =
+			entityColumn === 'project_id'
+				? ({
+						project_id: entityId,
+						user_id: userId,
+						role: 'admin',
+						title: roleTitle,
+					} satisfies TablesInsert<'project_members'>)
+				: ({
+						foundation_id: entityId,
+						user_id: userId,
+						role: 'admin',
+						title: roleTitle,
+					} satisfies TablesInsert<'foundation_members'>)
 
 		const { error: memberError } = await supabaseServiceRole
 			.from(membersTable)

--- a/apps/web/lib/queries/foundations/can-user-manage-foundation.ts
+++ b/apps/web/lib/queries/foundations/can-user-manage-foundation.ts
@@ -1,0 +1,41 @@
+import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+
+const MANAGE_MEMBER_ROLES = ['core', 'admin', 'editor'] as const
+
+/**
+ * Returns true when the user may access foundation manage routes:
+ * foundation founder or team member with edit access.
+ */
+export async function canUserManageFoundation(
+	foundationId: string,
+	founderId: string | null,
+	userId: string | undefined,
+): Promise<boolean> {
+	if (!userId) {
+		return false
+	}
+
+	if (founderId === userId) {
+		return true
+	}
+
+	const { data: profile } = await supabaseServiceRole
+		.from('profiles')
+		.select('role')
+		.eq('id', userId)
+		.maybeSingle()
+
+	if (profile?.role === 'admin') {
+		return true
+	}
+
+	const { data: member } = await supabaseServiceRole
+		.from('foundation_members')
+		.select('role')
+		.eq('foundation_id', foundationId)
+		.eq('user_id', userId)
+		.in('role', [...MANAGE_MEMBER_ROLES])
+		.maybeSingle()
+
+	return Boolean(member)
+}

--- a/apps/web/lib/queries/foundations/get-foundation-team-by-slug.ts
+++ b/apps/web/lib/queries/foundations/get-foundation-team-by-slug.ts
@@ -2,38 +2,35 @@ import type { TypedSupabaseClient } from '@packages/lib/types'
 import { logger } from '@/lib/logger'
 import type { ProjectTeamMember } from '~/lib/types/project/project-team.types'
 
-export async function getProjectTeamBySlug(
+export async function getFoundationTeamBySlug(
 	client: TypedSupabaseClient,
-	projectSlug: string,
-): Promise<{ projectId: string; team: ProjectTeamMember[] } | null> {
-	const { data: project, error: projectError } = await client
-		.from('projects')
+	foundationSlug: string,
+): Promise<{ foundationId: string; team: ProjectTeamMember[] } | null> {
+	const { data: foundation, error: foundationError } = await client
+		.from('foundations')
 		.select('id')
-		.eq('slug', projectSlug)
+		.eq('slug', foundationSlug)
 		.single()
 
-	if (projectError) throw projectError
-	if (!project) return null
+	if (foundationError) throw foundationError
+	if (!foundation) return null
 
 	const { data: team, error: teamError } = await client
-		.from('project_team')
+		.from('foundation_team')
 		.select('*')
-		.eq('project_id', project.id)
+		.eq('foundation_id', foundation.id)
 		.order('order_index', { ascending: true })
 		.order('created_at', { ascending: true })
 
-	// If table doesn't exist yet (migration not run), return empty team
-	// This prevents 404 errors before the migration is applied
 	if (teamError) {
-		// Check if it's a "relation does not exist" error
 		if (
 			teamError.message?.includes('does not exist') ||
 			teamError.message?.includes('relation') ||
 			teamError.code === '42P01'
 		) {
-			logger.warn('project_team table does not exist yet. Please run the migration.')
+			logger.warn('foundation_team table does not exist yet. Please run the migration.')
 			return {
-				projectId: project.id,
+				foundationId: foundation.id,
 				team: [],
 			}
 		}
@@ -41,11 +38,11 @@ export async function getProjectTeamBySlug(
 	}
 
 	return {
-		projectId: project.id,
+		foundationId: foundation.id,
 		team:
 			team?.map((member) => ({
 				id: member.id,
-				projectId: member.project_id,
+				projectId: member.foundation_id,
 				userId: member.user_id ?? null,
 				fullName: member.full_name,
 				roleTitle: member.role_title,

--- a/apps/web/lib/schemas/foundation.schemas.ts
+++ b/apps/web/lib/schemas/foundation.schemas.ts
@@ -23,6 +23,46 @@ export const foundationMilestoneCreateSchema = z.object({
 	impactMetric: z.string().nullable().optional(),
 })
 
+const foundationTeamRoleTitleSchema = z
+	.string()
+	.min(1, 'Role title is required')
+	.transform((s) => s.trim())
+
+const foundationTeamBioSchema = z
+	.string()
+	.optional()
+	.transform((s) => s?.trim() || undefined)
+
+export const foundationTeamMemberCreateSchema = z.discriminatedUnion('type', [
+	z.object({
+		type: z.literal('manual'),
+		foundationId: z.string().uuid('Foundation ID is required'),
+		fullName: z
+			.string()
+			.min(1, 'Full name is required')
+			.transform((s) => s.trim()),
+		roleTitle: foundationTeamRoleTitleSchema,
+		bio: foundationTeamBioSchema,
+		photoUrl: z
+			.string()
+			.optional()
+			.transform((s) => s?.trim() || undefined),
+		yearsInvolved: z.number().optional(),
+	}),
+	z.object({
+		type: z.literal('registered'),
+		foundationId: z.string().uuid('Foundation ID is required'),
+		userId: z.string().uuid('User ID is required'),
+		roleTitle: foundationTeamRoleTitleSchema,
+		bio: foundationTeamBioSchema,
+	}),
+])
+
+export const foundationTeamMemberDeleteQuerySchema = z.object({
+	foundationId: z.string().uuid('Foundation ID is required'),
+	memberId: z.string().uuid('Member ID is required'),
+})
+
 export const foundationUpdateFormSchema = z.object({
 	name: z.string().min(1, 'Name is required'),
 	description: z.string().min(1, 'Description is required'),

--- a/apps/web/lib/schemas/project.schemas.ts
+++ b/apps/web/lib/schemas/project.schemas.ts
@@ -60,26 +60,40 @@ export const projectSlugParamSchema = z.object({
 	slug: z.string().min(1, 'Slug is required'),
 })
 
-export const teamMemberCreateSchema = z.object({
-	projectId: z.string().uuid('Project ID is required'),
-	fullName: z
-		.string()
-		.min(1, 'Full name is required')
-		.transform((s) => s.trim()),
-	roleTitle: z
-		.string()
-		.min(1, 'Role title is required')
-		.transform((s) => s.trim()),
-	bio: z
-		.string()
-		.optional()
-		.transform((s) => s?.trim() || undefined),
-	photoUrl: z
-		.string()
-		.optional()
-		.transform((s) => s?.trim() || undefined),
-	yearsInvolved: z.number().optional(),
-})
+const teamMemberRoleTitleSchema = z
+	.string()
+	.min(1, 'Role title is required')
+	.transform((s) => s.trim())
+
+const teamMemberBioSchema = z
+	.string()
+	.optional()
+	.transform((s) => s?.trim() || undefined)
+
+export const teamMemberCreateSchema = z.discriminatedUnion('type', [
+	z.object({
+		type: z.literal('manual'),
+		projectId: z.string().uuid('Project ID is required'),
+		fullName: z
+			.string()
+			.min(1, 'Full name is required')
+			.transform((s) => s.trim()),
+		roleTitle: teamMemberRoleTitleSchema,
+		bio: teamMemberBioSchema,
+		photoUrl: z
+			.string()
+			.optional()
+			.transform((s) => s?.trim() || undefined),
+		yearsInvolved: z.number().optional(),
+	}),
+	z.object({
+		type: z.literal('registered'),
+		projectId: z.string().uuid('Project ID is required'),
+		userId: z.string().uuid('User ID is required'),
+		roleTitle: teamMemberRoleTitleSchema,
+		bio: teamMemberBioSchema,
+	}),
+])
 
 export const teamMemberUpdateSchema = z.object({
 	projectId: z.string().uuid('Project ID is required'),

--- a/apps/web/lib/schemas/user.schemas.ts
+++ b/apps/web/lib/schemas/user.schemas.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+export const userSearchQuerySchema = z.object({
+	q: z
+		.string()
+		.min(2, 'Search query must be at least 2 characters')
+		.max(100, 'Search query is too long')
+		.transform((s) => s.trim()),
+})
+
+export type SearchableUser = {
+	id: string
+	displayName: string | null
+	email: string | null
+	imageUrl: string | null
+	slug: string | null
+}

--- a/apps/web/lib/types/project/project-team.types.ts
+++ b/apps/web/lib/types/project/project-team.types.ts
@@ -1,23 +1,35 @@
 export interface ProjectTeamMember {
 	id: string
 	projectId: string
+	userId?: string | null
 	fullName: string
 	roleTitle: string
 	bio?: string | null
 	photoUrl?: string | null
 	yearsInvolved?: number | null
 	orderIndex: number
+	isManager?: boolean
 	createdAt: string
 	updatedAt: string
 }
 
-export interface CreateTeamMemberData {
+export interface CreateManualTeamMemberData {
+	type: 'manual'
 	fullName: string
 	roleTitle: string
 	bio?: string
 	photoUrl?: string
 	yearsInvolved?: number
 }
+
+export interface CreateRegisteredTeamMemberData {
+	type: 'registered'
+	userId: string
+	roleTitle: string
+	bio?: string
+}
+
+export type CreateTeamMemberData = CreateManualTeamMemberData | CreateRegisteredTeamMemberData
 
 export interface UpdateTeamMemberData {
 	fullName?: string

--- a/services/supabase/migrations/20260703120000_add_team_member_user_link_and_foundation_team.sql
+++ b/services/supabase/migrations/20260703120000_add_team_member_user_link_and_foundation_team.sql
@@ -1,0 +1,229 @@
+-- Link project_team to registered users and add foundation team/member tables
+-- Enables selecting platform users as team members with manage permissions
+
+-- 1. Add optional user_id to project_team (links registered users)
+ALTER TABLE public.project_team
+ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_project_team_user_id ON public.project_team(user_id);
+
+-- Prevent duplicate registered users on the same project team
+CREATE UNIQUE INDEX IF NOT EXISTS project_team_project_id_user_id_key
+ON public.project_team(project_id, user_id)
+WHERE user_id IS NOT NULL;
+
+-- 2. Foundation members (access control, mirrors project_members)
+CREATE TABLE IF NOT EXISTS public.foundation_members (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    foundation_id UUID NOT NULL REFERENCES public.foundations(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    role public.project_member_role NOT NULL DEFAULT 'admin',
+    title TEXT NOT NULL DEFAULT '',
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (foundation_id, user_id)
+);
+
+ALTER TABLE public.foundation_members ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_foundation_members_foundation_id
+ON public.foundation_members(foundation_id);
+
+CREATE INDEX IF NOT EXISTS idx_foundation_members_user_id
+ON public.foundation_members(user_id);
+
+CREATE POLICY "Foundation members are viewable by everyone"
+ON public.foundation_members
+FOR SELECT
+USING (true);
+
+CREATE POLICY "Foundation founders and admins can insert members"
+ON public.foundation_members
+FOR INSERT
+TO authenticated
+WITH CHECK (
+    EXISTS (
+        SELECT 1 FROM public.foundations f
+        WHERE f.id = foundation_members.foundation_id
+        AND (
+            f.founder_id = public.current_auth_user_id()
+            OR EXISTS (
+                SELECT 1 FROM public.foundation_members fm
+                WHERE fm.foundation_id = f.id
+                AND fm.user_id = public.current_auth_user_id()
+                AND fm.role IN ('core', 'admin', 'editor')
+            )
+        )
+    )
+);
+
+CREATE POLICY "Foundation founders and admins can update members"
+ON public.foundation_members
+FOR UPDATE
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.foundations f
+        WHERE f.id = foundation_members.foundation_id
+        AND (
+            f.founder_id = public.current_auth_user_id()
+            OR EXISTS (
+                SELECT 1 FROM public.foundation_members fm
+                WHERE fm.foundation_id = f.id
+                AND fm.user_id = public.current_auth_user_id()
+                AND fm.role IN ('core', 'admin', 'editor')
+            )
+        )
+    )
+);
+
+CREATE POLICY "Foundation founders and admins can delete members"
+ON public.foundation_members
+FOR DELETE
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.foundations f
+        WHERE f.id = foundation_members.foundation_id
+        AND (
+            f.founder_id = public.current_auth_user_id()
+            OR EXISTS (
+                SELECT 1 FROM public.foundation_members fm
+                WHERE fm.foundation_id = f.id
+                AND fm.user_id = public.current_auth_user_id()
+                AND fm.role IN ('core', 'admin', 'editor')
+            )
+        )
+    )
+    OR user_id = public.current_auth_user_id()
+);
+
+CREATE OR REPLACE FUNCTION public.set_foundation_member_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_foundation_member_timestamp
+BEFORE UPDATE ON public.foundation_members
+FOR EACH ROW
+EXECUTE FUNCTION public.set_foundation_member_updated_at();
+
+GRANT ALL ON public.foundation_members TO authenticated;
+GRANT SELECT ON public.foundation_members TO anon;
+
+-- 3. Foundation team (display, mirrors project_team)
+CREATE TABLE IF NOT EXISTS public.foundation_team (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    foundation_id UUID NOT NULL REFERENCES public.foundations(id) ON DELETE CASCADE,
+    user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+    full_name TEXT NOT NULL,
+    role_title TEXT NOT NULL,
+    bio TEXT,
+    photo_url TEXT,
+    years_involved INTEGER,
+    order_index INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT foundation_team_full_name_check CHECK (char_length(trim(full_name)) > 0),
+    CONSTRAINT foundation_team_role_title_check CHECK (char_length(trim(role_title)) > 0),
+    CONSTRAINT foundation_team_years_involved_check CHECK (years_involved IS NULL OR years_involved >= 0)
+);
+
+ALTER TABLE public.foundation_team ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_foundation_team_foundation_id
+ON public.foundation_team(foundation_id);
+
+CREATE INDEX IF NOT EXISTS idx_foundation_team_order_index
+ON public.foundation_team(foundation_id, order_index);
+
+CREATE INDEX IF NOT EXISTS idx_foundation_team_user_id
+ON public.foundation_team(user_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS foundation_team_foundation_id_user_id_key
+ON public.foundation_team(foundation_id, user_id)
+WHERE user_id IS NOT NULL;
+
+CREATE POLICY "Foundation team members are viewable by everyone"
+ON public.foundation_team
+FOR SELECT
+USING (true);
+
+CREATE POLICY "Foundation founders and admins can insert team members"
+ON public.foundation_team
+FOR INSERT
+TO authenticated
+WITH CHECK (
+    EXISTS (
+        SELECT 1 FROM public.foundations f
+        WHERE f.id = foundation_team.foundation_id
+        AND (
+            f.founder_id = public.current_auth_user_id()
+            OR EXISTS (
+                SELECT 1 FROM public.foundation_members fm
+                WHERE fm.foundation_id = f.id
+                AND fm.user_id = public.current_auth_user_id()
+                AND fm.role IN ('core', 'admin', 'editor')
+            )
+        )
+    )
+);
+
+CREATE POLICY "Foundation founders and admins can update team members"
+ON public.foundation_team
+FOR UPDATE
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.foundations f
+        WHERE f.id = foundation_team.foundation_id
+        AND (
+            f.founder_id = public.current_auth_user_id()
+            OR EXISTS (
+                SELECT 1 FROM public.foundation_members fm
+                WHERE fm.foundation_id = f.id
+                AND fm.user_id = public.current_auth_user_id()
+                AND fm.role IN ('core', 'admin', 'editor')
+            )
+        )
+    )
+);
+
+CREATE POLICY "Foundation founders and admins can delete team members"
+ON public.foundation_team
+FOR DELETE
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.foundations f
+        WHERE f.id = foundation_team.foundation_id
+        AND (
+            f.founder_id = public.current_auth_user_id()
+            OR EXISTS (
+                SELECT 1 FROM public.foundation_members fm
+                WHERE fm.foundation_id = f.id
+                AND fm.user_id = public.current_auth_user_id()
+                AND fm.role IN ('core', 'admin', 'editor')
+            )
+        )
+    )
+);
+
+CREATE OR REPLACE FUNCTION public.set_foundation_team_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_foundation_team_timestamp
+BEFORE UPDATE ON public.foundation_team
+FOR EACH ROW
+EXECUTE FUNCTION public.set_foundation_team_updated_at();
+
+GRANT ALL ON public.foundation_team TO authenticated;
+GRANT SELECT ON public.foundation_team TO anon;

--- a/services/supabase/src/database.types.ts
+++ b/services/supabase/src/database.types.ts
@@ -596,6 +596,94 @@ export type Database = {
           },
         ]
       }
+      foundation_members: {
+        Row: {
+          foundation_id: string
+          id: string
+          joined_at: string
+          role: Database["public"]["Enums"]["project_member_role"]
+          title: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          foundation_id: string
+          id?: string
+          joined_at?: string
+          role?: Database["public"]["Enums"]["project_member_role"]
+          title?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          foundation_id?: string
+          id?: string
+          joined_at?: string
+          role?: Database["public"]["Enums"]["project_member_role"]
+          title?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "foundation_members_foundation_id_fkey"
+            columns: ["foundation_id"]
+            isOneToOne: false
+            referencedRelation: "foundations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      foundation_team: {
+        Row: {
+          bio: string | null
+          created_at: string
+          foundation_id: string
+          full_name: string
+          id: string
+          order_index: number
+          photo_url: string | null
+          role_title: string
+          updated_at: string
+          user_id: string | null
+          years_involved: number | null
+        }
+        Insert: {
+          bio?: string | null
+          created_at?: string
+          foundation_id: string
+          full_name: string
+          id?: string
+          order_index?: number
+          photo_url?: string | null
+          role_title: string
+          updated_at?: string
+          user_id?: string | null
+          years_involved?: number | null
+        }
+        Update: {
+          bio?: string | null
+          created_at?: string
+          foundation_id?: string
+          full_name?: string
+          id?: string
+          order_index?: number
+          photo_url?: string | null
+          role_title?: string
+          updated_at?: string
+          user_id?: string | null
+          years_involved?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "foundation_team_foundation_id_fkey"
+            columns: ["foundation_id"]
+            isOneToOne: false
+            referencedRelation: "foundations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       foundations: {
         Row: {
           cover_image_url: string | null
@@ -1291,6 +1379,7 @@ export type Database = {
           project_id: string
           role_title: string
           updated_at: string
+          user_id: string | null
           years_involved: number | null
         }
         Insert: {
@@ -1303,6 +1392,7 @@ export type Database = {
           project_id: string
           role_title: string
           updated_at?: string
+          user_id?: string | null
           years_involved?: number | null
         }
         Update: {
@@ -1315,6 +1405,7 @@ export type Database = {
           project_id?: string
           role_title?: string
           updated_at?: string
+          user_id?: string | null
           years_involved?: number | null
         }
         Relationships: [


### PR DESCRIPTION
## Summary
- Add registered-user team members for projects and foundations, granting campaign/foundation manage access while keeping manual display-only members
- Introduce `foundation_team` / `foundation_members` tables and user search API for selecting platform users
- Fix user search picker crashes, funding balance re-render loops, manage layout JWT handling, and related TypeScript build errors

## Test plan
- [ ] Add a registered user as a project team member and confirm they can access `/projects/[slug]/manage`
- [ ] Add manual team members on project and foundation manage pages (display only, no manage access)
- [ ] Search users by name/email on the Registered User tab without page crash
- [ ] Verify foundation team management at `/foundations/[slug]/manage/members`
- [ ] Confirm admin projects list and profile pages load without funding balance errors
- [ ] Run `bun run build` in `apps/web`


Made with [Cursor](https://cursor.com)