### PR TITLE
feat: add /tutorials documentation hub with step-by-step workflow guides

### DIFF
--- a/apps/web/app/(routes)/tutorials/page.tsx
+++ b/apps/web/app/(routes)/tutorials/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next'
+import { TutorialsContainer } from '~/components/sections/tutorials/tutorials-container'
+import { JsonLd } from '~/components/shared/json-ld'
+import { getBreadcrumbSchema } from '~/lib/seo/structured-data'
+
+export const metadata: Metadata = {
+	title: 'Tutorials | KindFi',
+	description:
+		'Step-by-step guides for KindFi — learn how to register, create campaigns, submit milestones, donate, and understand the full milestone-based funding lifecycle.',
+	openGraph: {
+		title: 'Tutorials & Guides | KindFi',
+		description:
+			'Practical, concise guides for every KindFi workflow: account setup, campaign creation, milestone submission, donation flow, and more.',
+		type: 'website',
+		url: '/tutorials',
+	},
+	twitter: {
+		card: 'summary',
+		title: 'Tutorials | KindFi',
+		description:
+			'Step-by-step guides for registering, creating campaigns, submitting milestones, and understanding donations on KindFi.',
+	},
+	alternates: {
+		canonical: '/tutorials',
+	},
+}
+
+export default function TutorialsPage() {
+	return (
+		<>
+			<JsonLd
+				data={getBreadcrumbSchema([
+					{ name: 'Home', url: '/' },
+					{ name: 'Tutorials', url: '/tutorials' },
+				])}
+			/>
+			<main className="flex w-full flex-col bg-white" aria-label="KindFi Tutorials">
+				<TutorialsContainer />
+			</main>
+		</>
+	)
+}

--- a/apps/web/components/sections/tutorials/tutorial-card.tsx
+++ b/apps/web/components/sections/tutorials/tutorial-card.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { motion, useReducedMotion } from 'framer-motion'
+import type { LucideIcon } from 'lucide-react'
+import { Card, CardContent, CardHeader } from '~/components/base/card'
+
+interface TutorialCardProps {
+	icon: LucideIcon
+	title: string
+	description: string
+	steps: string[]
+	index: number
+}
+
+export function TutorialCard({ icon: Icon, title, description, steps, index }: TutorialCardProps) {
+	const reducedMotion = useReducedMotion()
+
+	return (
+		<motion.div
+			initial={reducedMotion ? false : { opacity: 0, y: 20 }}
+			whileInView={reducedMotion ? false : { opacity: 1, y: 0 }}
+			transition={
+				reducedMotion
+					? { duration: 0 }
+					: { duration: 0.4, delay: index * 0.07, ease: [0.22, 1, 0.36, 1] }
+			}
+			viewport={{ once: true }}
+		>
+			<Card className="h-full border border-slate-200/80 bg-white shadow-sm transition-shadow duration-300 hover:shadow-md">
+				<CardHeader className="pb-3">
+					<div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-50">
+						<Icon className="h-5 w-5 text-emerald-700" aria-hidden="true" />
+					</div>
+					<h3 className="text-base font-semibold leading-snug text-slate-900 sm:text-lg">
+						{title}
+					</h3>
+					<p className="text-sm leading-relaxed text-muted-foreground">{description}</p>
+				</CardHeader>
+
+				<CardContent>
+					<ol className="space-y-2.5" aria-label={`Steps for ${title}`}>
+						{steps.map((step, i) => (
+							<li key={step} className="flex gap-3">
+								<span
+									className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-[11px] font-semibold text-emerald-800"
+									aria-hidden="true"
+								>
+									{i + 1}
+								</span>
+								<span className="text-sm leading-relaxed text-slate-700">{step}</span>
+							</li>
+						))}
+					</ol>
+				</CardContent>
+			</Card>
+		</motion.div>
+	)
+}

--- a/apps/web/components/sections/tutorials/tutorials-container.tsx
+++ b/apps/web/components/sections/tutorials/tutorials-container.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { SectionContainer } from '~/components/shared/section-container'
+import { useI18n } from '~/lib/i18n'
+import { TutorialsCta } from './tutorials-cta'
+import { TutorialsGrid } from './tutorials-grid'
+import { TutorialsHero } from './tutorials-hero'
+
+export function TutorialsContainer() {
+	const { t } = useI18n()
+
+	return (
+		<>
+			<TutorialsHero />
+
+			<section
+				className="w-full bg-white py-16 sm:py-20 lg:py-24"
+				aria-label={t('tutorials.sections.gettingStarted')}
+			>
+				<SectionContainer maxWidth="7xl">
+					<TutorialsGrid />
+				</SectionContainer>
+			</section>
+
+			<TutorialsCta />
+		</>
+	)
+}

--- a/apps/web/components/sections/tutorials/tutorials-cta.tsx
+++ b/apps/web/components/sections/tutorials/tutorials-cta.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { motion, useReducedMotion } from 'framer-motion'
+import Link from 'next/link'
+import { Button } from '~/components/base/button'
+import { SectionContainer } from '~/components/shared/section-container'
+import { useI18n } from '~/lib/i18n'
+
+export function TutorialsCta() {
+	const { t } = useI18n()
+	const reducedMotion = useReducedMotion()
+
+	return (
+		<section
+			className="relative overflow-hidden border-t border-slate-200/60 bg-white py-16 sm:py-20"
+			aria-labelledby="tutorials-cta-heading"
+		>
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute -right-24 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full bg-emerald-100/40 blur-3xl" />
+				<div className="absolute -left-24 top-1/2 h-56 w-56 -translate-y-1/2 rounded-full bg-indigo-100/30 blur-3xl" />
+			</div>
+
+			<SectionContainer maxWidth="4xl" className="relative text-center">
+				<motion.h2
+					id="tutorials-cta-heading"
+					className="text-balance text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl"
+					initial={reducedMotion ? false : { opacity: 0, y: 20 }}
+					whileInView={reducedMotion ? false : { opacity: 1, y: 0 }}
+					transition={reducedMotion ? { duration: 0 } : { duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+					viewport={{ once: true }}
+				>
+					<span className="gradient-text">{t('tutorials.cta.title')}</span>
+				</motion.h2>
+
+				<motion.p
+					className="mx-auto mt-5 max-w-xl text-base leading-relaxed text-muted-foreground sm:mt-6 sm:text-lg"
+					initial={reducedMotion ? false : { opacity: 0, y: 12 }}
+					whileInView={reducedMotion ? false : { opacity: 1, y: 0 }}
+					transition={
+						reducedMotion
+							? { duration: 0 }
+							: { duration: 0.45, delay: 0.1, ease: [0.22, 1, 0.36, 1] }
+					}
+					viewport={{ once: true }}
+				>
+					{t('tutorials.cta.subtitle')}
+				</motion.p>
+
+				<motion.div
+					className="mt-8 flex flex-col justify-center gap-4 sm:flex-row"
+					initial={reducedMotion ? false : { opacity: 0, y: 12 }}
+					whileInView={reducedMotion ? false : { opacity: 1, y: 0 }}
+					transition={
+						reducedMotion
+							? { duration: 0 }
+							: { duration: 0.45, delay: 0.15, ease: [0.22, 1, 0.36, 1] }
+					}
+					viewport={{ once: true }}
+				>
+					<Link href="/faqs">
+						<Button size="lg" className="gradient-btn text-white shadow-sm hover:shadow-md">
+							{t('tutorials.cta.faqs')}
+						</Button>
+					</Link>
+					<Link href="/governance">
+						<Button
+							size="lg"
+							variant="outline"
+							className="gradient-border-btn bg-white transition-all duration-300"
+						>
+							{t('tutorials.cta.community')}
+						</Button>
+					</Link>
+				</motion.div>
+			</SectionContainer>
+		</section>
+	)
+}

--- a/apps/web/components/sections/tutorials/tutorials-grid.tsx
+++ b/apps/web/components/sections/tutorials/tutorials-grid.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { BookOpen, Building2, CheckCircle2, GitMerge, Landmark, UserPlus } from 'lucide-react'
+import { useI18n } from '~/lib/i18n'
+import { TutorialCard } from './tutorial-card'
+
+export function TutorialsGrid() {
+	const { t } = useI18n()
+
+	const cards = [
+		{
+			icon: UserPlus,
+			title: t('tutorials.cards.register.title'),
+			description: t('tutorials.cards.register.description'),
+			steps: t('tutorials.cards.register.steps') as unknown as string[],
+		},
+		{
+			icon: BookOpen,
+			title: t('tutorials.cards.createCampaign.title'),
+			description: t('tutorials.cards.createCampaign.description'),
+			steps: t('tutorials.cards.createCampaign.steps') as unknown as string[],
+		},
+		{
+			icon: CheckCircle2,
+			title: t('tutorials.cards.milestones.title'),
+			description: t('tutorials.cards.milestones.description'),
+			steps: t('tutorials.cards.milestones.steps') as unknown as string[],
+		},
+		{
+			icon: GitMerge,
+			title: t('tutorials.cards.readyForReview.title'),
+			description: t('tutorials.cards.readyForReview.description'),
+			steps: t('tutorials.cards.readyForReview.steps') as unknown as string[],
+		},
+		{
+			icon: Landmark,
+			title: t('tutorials.cards.donationFlow.title'),
+			description: t('tutorials.cards.donationFlow.description'),
+			steps: t('tutorials.cards.donationFlow.steps') as unknown as string[],
+		},
+		{
+			icon: Building2,
+			title: t('tutorials.cards.createFoundation.title'),
+			description: t('tutorials.cards.createFoundation.description'),
+			steps: t('tutorials.cards.createFoundation.steps') as unknown as string[],
+		},
+	]
+
+	return (
+		<div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+			{cards.map((card, index) => (
+				<TutorialCard key={card.title} index={index} {...card} />
+			))}
+		</div>
+	)
+}

--- a/apps/web/components/sections/tutorials/tutorials-hero.tsx
+++ b/apps/web/components/sections/tutorials/tutorials-hero.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { motion, useReducedMotion } from 'framer-motion'
+import { BookOpen } from 'lucide-react'
+import { SectionContainer } from '~/components/shared/section-container'
+import { useI18n } from '~/lib/i18n'
+
+export function TutorialsHero() {
+	const { t } = useI18n()
+	const reducedMotion = useReducedMotion()
+
+	return (
+		<section
+			className="relative isolate w-full overflow-hidden bg-[#fafbfc] pt-14 pb-16 sm:pt-16 sm:pb-20 md:pt-20 md:pb-24"
+			aria-labelledby="tutorials-hero-title"
+		>
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute inset-0 bg-grid-slate-100/60 [mask-image:radial-gradient(ellipse_at_center,white,transparent_72%)]" />
+				<div className="absolute -right-32 top-0 h-96 w-96 rounded-full bg-emerald-200/35 blur-3xl" />
+				<div className="absolute -left-32 top-12 h-80 w-80 rounded-full bg-indigo-200/25 blur-3xl" />
+			</div>
+
+			<SectionContainer maxWidth="6xl" className="relative">
+				<motion.div
+					className="mx-auto max-w-4xl text-center"
+					initial={reducedMotion ? false : { opacity: 0, y: 16 }}
+					animate={reducedMotion ? false : { opacity: 1, y: 0 }}
+					transition={
+						reducedMotion ? { duration: 0 } : { duration: 0.45, ease: [0.22, 1, 0.36, 1] }
+					}
+				>
+					<p className="mb-4 inline-flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.2em] text-emerald-700/80">
+						<BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
+						{t('tutorials.badge')}
+					</p>
+
+					<h1
+						id="tutorials-hero-title"
+						className="text-balance text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl"
+					>
+						{t('tutorials.title')}{' '}
+						<span className="gradient-text">{t('tutorials.titleHighlight')}</span>
+					</h1>
+
+					<p className="mx-auto mt-5 max-w-2xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+						{t('tutorials.subtitle')}
+					</p>
+				</motion.div>
+			</SectionContainer>
+
+			<div className="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-b from-transparent to-white" />
+		</section>
+	)
+}

--- a/apps/web/lib/i18n/translations/en/index.ts
+++ b/apps/web/lib/i18n/translations/en/index.ts
@@ -13,6 +13,7 @@ import { nav } from './nav'
 import { news } from './news'
 import { profile } from './profile'
 import { projects } from './projects'
+import { tutorials } from './tutorials'
 import { user } from './user'
 import { waitlist } from './waitlist'
 
@@ -32,6 +33,7 @@ export const en = {
 	profile,
 	about,
 	news,
+	tutorials,
 	waitlist,
 	footer,
 }

--- a/apps/web/lib/i18n/translations/en/tutorials.ts
+++ b/apps/web/lib/i18n/translations/en/tutorials.ts
@@ -1,0 +1,94 @@
+export const tutorials = {
+	badge: 'Help Center',
+	title: 'Tutorials &',
+	titleHighlight: 'Guides',
+	subtitle:
+		'Step-by-step guides to help you get the most out of KindFi — from creating your account to managing campaigns and understanding how funds are released.',
+	sections: {
+		gettingStarted: 'Getting Started',
+		campaigns: 'Campaigns',
+		donations: 'Donations & Milestones',
+	},
+	cards: {
+		register: {
+			title: 'Register & Create an Account',
+			description: 'Set up your KindFi account and get ready to support or launch campaigns.',
+			steps: [
+				'Go to kindfi.org and click Sign Up.',
+				'Enter your email address and create a secure password.',
+				'Verify your email using the link sent to your inbox.',
+				'Complete passkey registration for added security.',
+				'Fill in your profile details (name, bio, avatar).',
+				'Your account is ready — explore projects or start a campaign.',
+			],
+		},
+		createCampaign: {
+			title: 'Create a Campaign',
+			description: 'Launch a milestone-based crowdfunding campaign on the Stellar blockchain.',
+			steps: [
+				'Sign in and navigate to Create Campaign from the header.',
+				'Choose a category and fill in your campaign title and description.',
+				'Set your funding goal and target end date.',
+				'Define at least one milestone with a clear deliverable and amount.',
+				'Upload a cover image and any supporting media.',
+				'Submit your campaign for AI-assisted review.',
+				'Once approved, your campaign goes live and is visible to supporters.',
+			],
+		},
+		milestones: {
+			title: 'Complete & Submit Milestones',
+			description: 'Provide evidence of progress to unlock the next tranche of funds.',
+			steps: [
+				'Open your campaign dashboard and select the active milestone.',
+				'Click Submit Evidence and upload proof of completion (docs, photos, links).',
+				'Add a written update describing what was accomplished.',
+				'Submit the milestone for review.',
+				'The KindFi team or community validators will verify your submission.',
+				'Once approved, the milestone funds are released to your wallet.',
+			],
+		},
+		readyForReview: {
+			title: 'Mark Project as Ready for Review',
+			description: 'Signal that your project is complete and ready for final evaluation.',
+			steps: [
+				'Ensure all milestones have been submitted and verified.',
+				'Open your campaign dashboard and click Mark as Ready for Review.',
+				'Add a final summary update for your backers.',
+				'The platform team will schedule a final review.',
+				'Once approved, the project is marked complete and remaining funds released.',
+			],
+		},
+		donationFlow: {
+			title: 'Understand the Donation & Milestone Flow',
+			description: 'Learn how funds move from donor to campaign creator through trustless escrow.',
+			steps: [
+				'A donor finds a campaign and clicks Donate.',
+				'Funds are transferred to a Trustless Work escrow contract on Stellar.',
+				'The campaign creator completes a milestone and submits evidence.',
+				'Validators review and approve the milestone submission.',
+				'The approved amount is released from escrow to the campaign creator.',
+				'Donors can track every step on-chain via the campaign dashboard.',
+				'If a milestone is rejected, funds remain locked until resubmission or refund.',
+			],
+		},
+		createFoundation: {
+			title: 'Create a Foundation',
+			description:
+				'Set up an organizational entity to manage multiple campaigns under one umbrella.',
+			steps: [
+				'Sign in and navigate to Create Foundation from the header menu.',
+				'Provide your foundation name, mission statement, and category.',
+				'Upload a logo and fill in contact details.',
+				'Submit for verification — the KindFi team reviews your application.',
+				'Once verified, you can link campaigns to your foundation profile.',
+				'Your foundation page becomes a hub for all related initiatives.',
+			],
+		},
+	},
+	cta: {
+		title: 'Still Have Questions?',
+		subtitle: 'Check our FAQs for quick answers or join the community for real-time support.',
+		faqs: 'Browse FAQs',
+		community: 'Join the Community',
+	},
+}

--- a/apps/web/lib/i18n/translations/es/index.ts
+++ b/apps/web/lib/i18n/translations/es/index.ts
@@ -13,6 +13,7 @@ import { nav } from './nav'
 import { news } from './news'
 import { profile } from './profile'
 import { projects } from './projects'
+import { tutorials } from './tutorials'
 import { user } from './user'
 import { waitlist } from './waitlist'
 
@@ -32,6 +33,7 @@ export const es = {
 	profile,
 	about,
 	news,
+	tutorials,
 	waitlist,
 	footer,
 }

--- a/apps/web/lib/i18n/translations/es/tutorials.ts
+++ b/apps/web/lib/i18n/translations/es/tutorials.ts
@@ -1,0 +1,97 @@
+export const tutorials = {
+	badge: 'Centro de Ayuda',
+	title: 'Tutoriales y',
+	titleHighlight: 'Guías',
+	subtitle:
+		'Guías paso a paso para ayudarte a sacar el máximo provecho de KindFi — desde crear tu cuenta hasta gestionar campañas y entender cómo se liberan los fondos.',
+	sections: {
+		gettingStarted: 'Primeros Pasos',
+		campaigns: 'Campañas',
+		donations: 'Donaciones y Hitos',
+	},
+	cards: {
+		register: {
+			title: 'Regístrate y Crea una Cuenta',
+			description: 'Configura tu cuenta en KindFi y prepárate para apoyar o lanzar campañas.',
+			steps: [
+				'Ve a kindfi.org y haz clic en Registrarse.',
+				'Ingresa tu correo electrónico y crea una contraseña segura.',
+				'Verifica tu correo usando el enlace enviado a tu bandeja de entrada.',
+				'Completa el registro con passkey para mayor seguridad.',
+				'Completa tu perfil (nombre, bio, avatar).',
+				'Tu cuenta está lista — explora proyectos o inicia una campaña.',
+			],
+		},
+		createCampaign: {
+			title: 'Crear una Campaña',
+			description: 'Lanza una campaña de crowdfunding basada en hitos en la blockchain de Stellar.',
+			steps: [
+				'Inicia sesión y navega a Crear Campaña desde el encabezado.',
+				'Elige una categoría y completa el título y descripción de tu campaña.',
+				'Establece tu meta de financiamiento y fecha límite.',
+				'Define al menos un hito con un entregable claro y monto asignado.',
+				'Sube una imagen de portada y contenido multimedia de apoyo.',
+				'Envía tu campaña para revisión asistida por IA.',
+				'Una vez aprobada, tu campaña se publica y es visible para los colaboradores.',
+			],
+		},
+		milestones: {
+			title: 'Completar y Enviar Hitos',
+			description:
+				'Proporciona evidencia de tu progreso para desbloquear el siguiente tramo de fondos.',
+			steps: [
+				'Abre el panel de tu campaña y selecciona el hito activo.',
+				'Haz clic en Enviar Evidencia y sube pruebas de cumplimiento (documentos, fotos, enlaces).',
+				'Agrega una actualización escrita describiendo lo que se logró.',
+				'Envía el hito para revisión.',
+				'El equipo de KindFi o los validadores de la comunidad verificarán tu envío.',
+				'Una vez aprobado, los fondos del hito se liberan a tu billetera.',
+			],
+		},
+		readyForReview: {
+			title: 'Marcar Proyecto como Listo para Revisión',
+			description: 'Indica que tu proyecto está completo y listo para evaluación final.',
+			steps: [
+				'Asegúrate de que todos los hitos hayan sido enviados y verificados.',
+				'Abre el panel de tu campaña y haz clic en Marcar como Listo para Revisión.',
+				'Agrega una actualización final de resumen para tus patrocinadores.',
+				'El equipo de la plataforma programará una revisión final.',
+				'Una vez aprobado, el proyecto se marca como completo y se liberan los fondos restantes.',
+			],
+		},
+		donationFlow: {
+			title: 'Entender el Flujo de Donaciones e Hitos',
+			description:
+				'Aprende cómo se mueven los fondos del donante al creador de campaña mediante escrow sin confianza.',
+			steps: [
+				'Un donante encuentra una campaña y hace clic en Donar.',
+				'Los fondos se transfieren a un contrato de escrow de Trustless Work en Stellar.',
+				'El creador de la campaña completa un hito y envía evidencia.',
+				'Los validadores revisan y aprueban el envío del hito.',
+				'El monto aprobado se libera del escrow al creador de la campaña.',
+				'Los donantes pueden rastrear cada paso on-chain desde el panel de campaña.',
+				'Si se rechaza un hito, los fondos permanecen bloqueados hasta reenvío o reembolso.',
+			],
+		},
+		createFoundation: {
+			title: 'Crear una Fundación',
+			description:
+				'Crea una entidad organizacional para gestionar múltiples campañas bajo un mismo paraguas.',
+			steps: [
+				'Inicia sesión y navega a Crear Fundación desde el menú del encabezado.',
+				'Proporciona el nombre, misión y categoría de tu fundación.',
+				'Sube un logo y completa los datos de contacto.',
+				'Envía para verificación — el equipo de KindFi revisará tu solicitud.',
+				'Una vez verificada, puedes vincular campañas al perfil de tu fundación.',
+				'Tu página de fundación se convierte en un hub para todas las iniciativas relacionadas.',
+			],
+		},
+	},
+	cta: {
+		title: '¿Aún Tienes Preguntas?',
+		subtitle:
+			'Consulta nuestras Preguntas Frecuentes para respuestas rápidas o únete a la comunidad para soporte en tiempo real.',
+		faqs: 'Ver FAQs',
+		community: 'Unirse a la Comunidad',
+	},
+}


### PR DESCRIPTION
 Closes #970 

  Implements the /tutorials route as KindFi's user-facing documentation hub:

  - Page: app/(routes)/tutorials/page.tsx with SEO metadata and breadcrumb JSON-LD
  - Hero section with gradient background and Framer Motion animation
  - Responsive card grid (1→2→3 columns) with step-by-step guides for:
    - Registering and creating an account
    - Creating a campaign
    - Completing and submitting milestones
    - Marking a project as ready for review
    - Understanding the donation and milestone flow
    - Creating a foundation
  - CTA section linking to /faqs and /governance
  - Full i18n support (EN + ES) via new tutorials translation namespace
  - Follows existing design system: Card, SectionContainer, gradient-text, gradient-btn, useReducedMotion
