### PR TITLE
refactor: split StellarPasskeyService into focused modules

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -62,6 +62,9 @@
 	},
 	"main": "./src/index.ts",
 	"types": "./src/index.ts",
+	"scripts": {
+		"test": "bun test"
+	},
 	"license": "MIT",
 	"dependencies": {
 		"@openzeppelin/relayer-plugin-channels": "^0.5.0",

--- a/packages/lib/src/stellar/passkey-signature.utils.ts
+++ b/packages/lib/src/stellar/passkey-signature.utils.ts
@@ -1,0 +1,138 @@
+import { Buffer } from 'node:buffer'
+import { createHash, createPublicKey, createVerify } from 'node:crypto'
+import { db, devices } from '@packages/drizzle'
+import { eq } from 'drizzle-orm'
+import { logger } from '../logger'
+
+/**
+ * Converts uncompressed public key to DER format for crypto verification.
+ * This is the standard ASN.1 DER encoding for P-256 public keys.
+ */
+export function convertUncompressedToDER(uncompressedKey: Buffer): Buffer {
+	const derPrefix = Buffer.from([
+		0x30,
+		0x59, // SEQUENCE, length
+		0x30,
+		0x13, // SEQUENCE, length
+		0x06,
+		0x07,
+		0x2a,
+		0x86,
+		0x48,
+		0xce,
+		0x3d,
+		0x02,
+		0x01, // OID for EC public key
+		0x06,
+		0x08,
+		0x2a,
+		0x86,
+		0x48,
+		0xce,
+		0x3d,
+		0x03,
+		0x01,
+		0x07, // OID for P-256 curve
+		0x03,
+		0x42,
+		0x00, // BIT STRING, length, unused bits
+	])
+
+	return Buffer.concat([derPrefix, uncompressedKey])
+}
+
+/**
+ * Verifies SECP256R1 signature using Node.js crypto
+ */
+export async function verifySECP256R1Signature(
+	authenticatorData: string,
+	clientDataJSON: string,
+	signature: string,
+	publicKey: Buffer,
+): Promise<boolean> {
+	try {
+		// Create the signed data (authenticator data + client data hash)
+		const authDataBuffer = Buffer.from(authenticatorData, 'base64')
+		const clientDataBuffer = Buffer.from(clientDataJSON, 'base64')
+		const clientDataHash = createHash('sha256').update(clientDataBuffer).digest()
+
+		const signedData = Buffer.concat([authDataBuffer, clientDataHash])
+		const signatureBuffer = Buffer.from(signature, 'base64')
+
+		// Convert uncompressed public key to DER format for verification
+		const publicKeyDER = convertUncompressedToDER(publicKey)
+
+		// Create public key object
+		const publicKeyObj = createPublicKey({
+			key: publicKeyDER,
+			format: 'der',
+			type: 'spki',
+		})
+
+		// Verify signature
+		const verify = createVerify('SHA256')
+		verify.update(signedData)
+		const isValid = verify.verify(publicKeyObj, signatureBuffer)
+
+		return isValid
+	} catch (error) {
+		logger.error(
+			'SECP256R1 verification failed',
+			error instanceof Error ? error : new Error(String(error)),
+		)
+		return false
+	}
+}
+
+/**
+ * Gets the public key for a contract from the devices table
+ */
+export async function getPublicKeyForContract(contractId: string): Promise<Buffer | null> {
+	try {
+		// Query database for device record with this contract address
+		const deviceRecord = await db
+			.select({
+				publicKey: devices.publicKey,
+				deviceName: devices.deviceName,
+				credentialId: devices.credentialId,
+			})
+			.from(devices)
+			.where(eq(devices.address, contractId))
+			.limit(1)
+
+		if (deviceRecord.length === 0) {
+			return null
+		}
+
+		const device = deviceRecord[0]
+
+		// The publicKey field should contain the CBOR-encoded public key
+		if (!device.publicKey) {
+			return null
+		}
+
+		// Check if the public key is already a hex string or base64
+		let publicKeyBuffer: Buffer
+		try {
+			// Try to decode as base64 first (most common format)
+			publicKeyBuffer = Buffer.from(device.publicKey, 'base64')
+		} catch {
+			try {
+				// Try as hex string
+				publicKeyBuffer = Buffer.from(device.publicKey, 'hex')
+			} catch {
+				// Assume it's already a raw string
+				publicKeyBuffer = Buffer.from(device.publicKey, 'utf8')
+			}
+		}
+
+		return publicKeyBuffer
+	} catch (error) {
+		logger.error(
+			'Error retrieving public key from database',
+			error instanceof Error ? error : new Error(String(error)),
+			{ contractId },
+		)
+		return null
+	}
+}

--- a/packages/lib/src/stellar/passkey-transaction.utils.ts
+++ b/packages/lib/src/stellar/passkey-transaction.utils.ts
@@ -1,0 +1,259 @@
+import { Buffer } from 'node:buffer'
+import {
+	Account,
+	type Keypair,
+	Operation,
+	type Transaction,
+	TransactionBuilder,
+	xdr,
+} from '@stellar/stellar-sdk'
+import { Api, assembleTransaction, type Server } from '@stellar/stellar-sdk/rpc'
+
+/**
+ * Runtime dependencies a passkey transaction needs, supplied by the caller
+ * (the StellarPasskeyService) instead of being read from instance state.
+ */
+export interface PasskeyTxContext {
+	server: Server
+	fundingKeypair: Keypair
+	networkPassphrase: string
+	fee: string
+}
+
+export interface AddDeviceOperation {
+	type: 'add_device'
+	deviceId: string
+	publicKey: string
+	isAdmin?: boolean
+	challenge?: string
+}
+
+export interface RemoveDeviceOperation {
+	type: 'remove_device'
+	deviceId: string
+	challenge?: string
+}
+
+export interface ContractInvocationOperation {
+	type: 'invoke_contract'
+	contractAddress?: string
+	functionName: string
+	args?: unknown[]
+	challenge?: string
+}
+
+export type PasskeyOperation =
+	| AddDeviceOperation
+	| RemoveDeviceOperation
+	| ContractInvocationOperation
+
+/**
+ * Converts JS arguments to Soroban ScVal format.
+ * Strings, numbers and booleans map to their native ScVal; everything else
+ * is JSON-encoded into bytes.
+ */
+export function argsToScVals(args: unknown[]): xdr.ScVal[] {
+	return args.map((arg: unknown) => {
+		if (typeof arg === 'string') {
+			return xdr.ScVal.scvString(arg)
+		}
+		if (typeof arg === 'number') {
+			return xdr.ScVal.scvU64(xdr.Uint64.fromString(arg.toString()))
+		}
+		if (typeof arg === 'boolean') {
+			return xdr.ScVal.scvBool(arg)
+		}
+		// Default to bytes for complex types
+		return xdr.ScVal.scvBytes(Buffer.from(JSON.stringify(arg), 'utf-8'))
+	})
+}
+
+/**
+ * Submits a built transaction with simulation, authorization assembly, signing,
+ * and confirmation polling via Soroban RPC.
+ */
+export async function submitTransaction(
+	ctx: PasskeyTxContext,
+	builtTransaction: Transaction,
+): Promise<string> {
+	if (!ctx.fundingKeypair) {
+		throw new Error('Funding keypair required for transaction submission')
+	}
+	const { server, fundingKeypair } = ctx
+
+	// Simulate transaction to get authorization requirements
+	const simulation = await server.simulateTransaction(builtTransaction)
+
+	if (Api.isSimulationError(simulation)) {
+		throw new Error(`Simulation failed: ${simulation.error || 'unknown error'}`)
+	}
+
+	if (Api.isSimulationRestore(simulation)) {
+		throw new Error('Transaction requires restore operation')
+	}
+
+	// Assemble transaction with authorization entries from simulation
+	const assembledTransaction = assembleTransaction(builtTransaction, simulation).build()
+
+	// Sign the transaction with our funding account
+	// The assembleTransaction function handles authorization entries automatically
+	assembledTransaction.sign(fundingKeypair)
+
+	// Submit transaction to Soroban RPC (NOT Horizon)
+	// Soroban transactions with authorization entries must use sendTransaction
+	const sendResult = await server.sendTransaction(assembledTransaction)
+
+	if (sendResult.status === 'ERROR') {
+		throw new Error('Transaction submission failed')
+	}
+
+	if (sendResult.status === 'PENDING') {
+		// Wait for transaction to be included in a ledger
+		let attempts = 0
+		const maxAttempts = 120 // 2 minutes for complex auth transactions
+
+		while (attempts < maxAttempts) {
+			await new Promise((resolve) => setTimeout(resolve, 10000))
+			attempts++
+
+			try {
+				const txResult = await server.getTransaction(sendResult.hash)
+
+				if (txResult.status === Api.GetTransactionStatus.SUCCESS) {
+					return sendResult.hash
+				}
+
+				if (txResult.status === Api.GetTransactionStatus.FAILED) {
+					throw new Error('Transaction failed')
+				}
+
+				if (txResult.status === Api.GetTransactionStatus.NOT_FOUND) {
+				}
+
+				// Still pending, continue waiting
+			} catch (_error) {}
+		}
+
+		throw new Error('Transaction timed out waiting for confirmation')
+	}
+
+	return sendResult.hash
+}
+
+/**
+ * Executes add device operation on the passkey contract
+ */
+export async function executeAddDevice(
+	ctx: PasskeyTxContext,
+	address: string,
+	operationData: AddDeviceOperation,
+): Promise<string> {
+	if (!ctx.fundingKeypair) {
+		throw new Error('Funding keypair required for add device operation')
+	}
+	const { server, fundingKeypair, networkPassphrase, fee } = ctx
+	const { deviceId, publicKey, isAdmin = false } = operationData
+
+	// Get funding account
+	const fundingAccount = await server
+		.getAccount(fundingKeypair.publicKey())
+		.then((res) => new Account(res.accountId(), res.sequenceNumber()))
+
+	// Build transaction for adding device
+	const transaction = new TransactionBuilder(fundingAccount, {
+		fee,
+		networkPassphrase,
+	})
+		.addOperation(
+			Operation.invokeContractFunction({
+				contract: address,
+				function: 'add',
+				args: [
+					xdr.ScVal.scvBytes(Buffer.from(deviceId, 'utf-8')),
+					xdr.ScVal.scvBytes(Buffer.from(publicKey, 'base64')),
+					xdr.ScVal.scvBool(isAdmin),
+				],
+			}),
+		)
+		.setTimeout(60)
+		.build()
+
+	return await submitTransaction(ctx, transaction)
+}
+
+/**
+ * Executes remove device operation on the passkey contract
+ */
+export async function executeRemoveDevice(
+	ctx: PasskeyTxContext,
+	address: string,
+	operationData: RemoveDeviceOperation,
+): Promise<string> {
+	if (!ctx.fundingKeypair) {
+		throw new Error('Funding keypair required for remove device operation')
+	}
+	const { server, fundingKeypair, networkPassphrase, fee } = ctx
+	const { deviceId } = operationData
+
+	// Get funding account
+	const fundingAccount = await server
+		.getAccount(fundingKeypair.publicKey())
+		.then((res) => new Account(res.accountId(), res.sequenceNumber()))
+
+	// Build transaction for removing device
+	const transaction = new TransactionBuilder(fundingAccount, {
+		fee,
+		networkPassphrase,
+	})
+		.addOperation(
+			Operation.invokeContractFunction({
+				contract: address,
+				function: 'remove',
+				args: [xdr.ScVal.scvBytes(Buffer.from(deviceId, 'utf-8'))],
+			}),
+		)
+		.setTimeout(60)
+		.build()
+
+	return await submitTransaction(ctx, transaction)
+}
+
+/**
+ * Executes general contract invocation
+ */
+export async function executeContractInvocation(
+	ctx: PasskeyTxContext,
+	contractId: string,
+	operationData: ContractInvocationOperation,
+): Promise<string> {
+	if (!ctx.fundingKeypair) {
+		throw new Error('Funding keypair required for contract invocation')
+	}
+	const { server, fundingKeypair, networkPassphrase, fee } = ctx
+	const { contractAddress, functionName, args = [] } = operationData
+
+	// Get funding account
+	const fundingAccount = await server
+		.getAccount(fundingKeypair.publicKey())
+		.then((res) => new Account(res.accountId(), res.sequenceNumber()))
+
+	// Convert arguments to ScVal format
+	const scArgs = argsToScVals(args)
+
+	// Build transaction for contract invocation
+	const transaction = new TransactionBuilder(fundingAccount, {
+		fee,
+		networkPassphrase,
+	})
+		.addOperation(
+			Operation.invokeContractFunction({
+				contract: contractAddress || contractId,
+				function: functionName,
+				args: scArgs,
+			}),
+		)
+		.setTimeout(60)
+		.build()
+
+	return await submitTransaction(ctx, transaction)
+}

--- a/packages/lib/src/stellar/stellar-passkey.service.ts
+++ b/packages/lib/src/stellar/stellar-passkey.service.ts
@@ -1,19 +1,6 @@
 import { Buffer } from 'node:buffer'
-import { createHash, createPublicKey, createVerify } from 'node:crypto'
-import { db, devices } from '@packages/drizzle'
-import {
-	Account,
-	Address,
-	Contract,
-	hash,
-	Keypair,
-	Operation,
-	type Transaction,
-	TransactionBuilder,
-	xdr,
-} from '@stellar/stellar-sdk'
+import { Address, Contract, hash, Keypair, TransactionBuilder, xdr } from '@stellar/stellar-sdk'
 import { Api, assembleTransaction, Server } from '@stellar/stellar-sdk/rpc'
-import { eq } from 'drizzle-orm'
 import { appEnvConfig } from '../config'
 import { logger } from '../logger'
 import {
@@ -21,6 +8,14 @@ import {
 	convertCoseToUncompressedPublicKey,
 } from '../passkey/webauthn-keys'
 import type { AppEnvInterface } from '../types'
+import { getPublicKeyForContract, verifySECP256R1Signature } from './passkey-signature.utils'
+import {
+	executeAddDevice,
+	executeContractInvocation,
+	executeRemoveDevice,
+	type PasskeyOperation,
+	type PasskeyTxContext,
+} from './passkey-transaction.utils'
 import { type RateLimitConfig, SignatureRateLimiter } from './rate-limiter'
 
 /**
@@ -339,13 +334,13 @@ export class StellarPasskeyService {
 			// Verify origin (optional but recommended)
 
 			// Get the public key for this address
-			const publicKey = await this.getPublicKeyForContract(address)
+			const publicKey = await getPublicKeyForContract(address)
 			if (!publicKey) {
 				throw new Error('Public key not found for address')
 			}
 
 			// Verify the signature using secp256r1
-			const isValid = await this.verifySECP256R1Signature(
+			const isValid = await verifySECP256R1Signature(
 				authenticatorData,
 				clientDataJSON,
 				rawSignature,
@@ -368,141 +363,6 @@ export class StellarPasskeyService {
 	}
 
 	/**
-	 * Verifies SECP256R1 signature using Node.js crypto
-	 */
-	private async verifySECP256R1Signature(
-		authenticatorData: string,
-		clientDataJSON: string,
-		signature: string,
-		publicKey: Buffer,
-	): Promise<boolean> {
-		try {
-			// Create the signed data (authenticator data + client data hash)
-			const authDataBuffer = Buffer.from(authenticatorData, 'base64')
-			const clientDataBuffer = Buffer.from(clientDataJSON, 'base64')
-			const clientDataHash = createHash('sha256').update(clientDataBuffer).digest()
-
-			const signedData = Buffer.concat([authDataBuffer, clientDataHash])
-			const signatureBuffer = Buffer.from(signature, 'base64')
-
-			// Convert uncompressed public key to DER format for verification
-			const publicKeyDER = this.convertUncompressedToDER(publicKey)
-
-			// Create public key object
-			const publicKeyObj = createPublicKey({
-				key: publicKeyDER,
-				format: 'der',
-				type: 'spki',
-			})
-
-			// Verify signature
-			const verify = createVerify('SHA256')
-			verify.update(signedData)
-			const isValid = verify.verify(publicKeyObj, signatureBuffer)
-
-			return isValid
-		} catch (error) {
-			logger.error(
-				'SECP256R1 verification failed',
-				error instanceof Error ? error : new Error(String(error)),
-			)
-			return false
-		}
-	}
-
-	/**
-	 * Converts uncompressed public key to DER format for crypto verification
-	 */
-	private convertUncompressedToDER(uncompressedKey: Buffer): Buffer {
-		// DER format for SECP256R1 public key
-		// This is the standard ASN.1 DER encoding for P-256 public keys
-		const derPrefix = Buffer.from([
-			0x30,
-			0x59, // SEQUENCE, length
-			0x30,
-			0x13, // SEQUENCE, length
-			0x06,
-			0x07,
-			0x2a,
-			0x86,
-			0x48,
-			0xce,
-			0x3d,
-			0x02,
-			0x01, // OID for EC public key
-			0x06,
-			0x08,
-			0x2a,
-			0x86,
-			0x48,
-			0xce,
-			0x3d,
-			0x03,
-			0x01,
-			0x07, // OID for P-256 curve
-			0x03,
-			0x42,
-			0x00, // BIT STRING, length, unused bits
-		])
-
-		return Buffer.concat([derPrefix, uncompressedKey])
-	}
-
-	/**
-	 * Gets the public key for a contract
-	 */
-	private async getPublicKeyForContract(contractId: string): Promise<Buffer | null> {
-		try {
-			// Query database for device record with this contract address
-			const deviceRecord = await db
-				.select({
-					publicKey: devices.publicKey,
-					deviceName: devices.deviceName,
-					credentialId: devices.credentialId,
-				})
-				.from(devices)
-				.where(eq(devices.address, contractId))
-				.limit(1)
-
-			if (deviceRecord.length === 0) {
-				return null
-			}
-
-			const device = deviceRecord[0]
-
-			// The publicKey field should contain the CBOR-encoded public key
-			// Convert from base64 string to Buffer for processing
-			if (!device.publicKey) {
-				return null
-			}
-
-			// Check if the public key is already a hex string or base64
-			let publicKeyBuffer: Buffer
-			try {
-				// Try to decode as base64 first (most common format)
-				publicKeyBuffer = Buffer.from(device.publicKey, 'base64')
-			} catch {
-				try {
-					// Try as hex string
-					publicKeyBuffer = Buffer.from(device.publicKey, 'hex')
-				} catch {
-					// Assume it's already a raw string
-					publicKeyBuffer = Buffer.from(device.publicKey, 'utf8')
-				}
-			}
-
-			return publicKeyBuffer
-		} catch (error) {
-			logger.error(
-				'Error retrieving public key from database',
-				error instanceof Error ? error : new Error(String(error)),
-				{ contractId },
-			)
-			return null
-		}
-	}
-
-	/**
 	 * Executes a passkey transaction on the smart contract
 	 * This handles operations after signature verification
 	 */
@@ -514,6 +374,7 @@ export class StellarPasskeyService {
 		if (!this.fundingKeypair) {
 			throw new Error('Funding keypair required for transaction execution')
 		}
+		const fundingKeypair = this.fundingKeypair
 
 		try {
 			// Parse operation details
@@ -530,14 +391,21 @@ export class StellarPasskeyService {
 				throw new Error('Invalid signature for transaction')
 			}
 
+			const ctx: PasskeyTxContext = {
+				server: this.server,
+				fundingKeypair,
+				networkPassphrase: this.networkPassphrase,
+				fee: this.STANDARD_FEE,
+			}
+
 			// Execute the specific operation
 			switch (operationData.type) {
 				case 'add_device':
-					return await this.executeAddDevice(address, operationData)
+					return await executeAddDevice(ctx, address, operationData)
 				case 'remove_device':
-					return await this.executeRemoveDevice(address, operationData)
+					return await executeRemoveDevice(ctx, address, operationData)
 				case 'invoke_contract':
-					return await this.executeContractInvocation(address, address, operationData)
+					return await executeContractInvocation(ctx, address, operationData)
 				default:
 					throw new Error('Unsupported operation type')
 			}
@@ -549,201 +417,6 @@ export class StellarPasskeyService {
 			)
 			throw new Error(`Transaction execution failed: ${error}`)
 		}
-	}
-
-	/**
-	 * Executes add device operation on the passkey contract
-	 */
-	private async executeAddDevice(
-		address: string,
-		operationData: AddDeviceOperation,
-	): Promise<string> {
-		if (!this.fundingKeypair) {
-			throw new Error('Funding keypair required for add device operation')
-		}
-
-		const { deviceId, publicKey, isAdmin = false } = operationData
-
-		// Get funding account
-		const fundingAccount = await this.server
-			.getAccount(this.fundingKeypair.publicKey())
-			.then((res) => new Account(res.accountId(), res.sequenceNumber()))
-
-		// Build transaction for adding device
-		const transaction = new TransactionBuilder(fundingAccount, {
-			fee: this.STANDARD_FEE,
-			networkPassphrase: this.networkPassphrase,
-		})
-			.addOperation(
-				Operation.invokeContractFunction({
-					contract: address,
-					function: 'add',
-					args: [
-						xdr.ScVal.scvBytes(Buffer.from(deviceId, 'utf-8')),
-						xdr.ScVal.scvBytes(Buffer.from(publicKey, 'base64')),
-						xdr.ScVal.scvBool(isAdmin),
-					],
-				}),
-			)
-			.setTimeout(60)
-			.build()
-
-		return await this.submitTransaction(transaction)
-	}
-
-	/**
-	 * Executes remove device operation on the passkey contract
-	 */
-	private async executeRemoveDevice(
-		address: string,
-		operationData: RemoveDeviceOperation,
-	): Promise<string> {
-		if (!this.fundingKeypair) {
-			throw new Error('Funding keypair required for remove device operation')
-		}
-
-		const { deviceId } = operationData
-
-		// Get funding account
-		const fundingAccount = await this.server
-			.getAccount(this.fundingKeypair.publicKey())
-			.then((res) => new Account(res.accountId(), res.sequenceNumber()))
-
-		// Build transaction for removing device
-		const transaction = new TransactionBuilder(fundingAccount, {
-			fee: this.STANDARD_FEE,
-			networkPassphrase: this.networkPassphrase,
-		})
-			.addOperation(
-				Operation.invokeContractFunction({
-					contract: address,
-					function: 'remove',
-					args: [xdr.ScVal.scvBytes(Buffer.from(deviceId, 'utf-8'))],
-				}),
-			)
-			.setTimeout(60)
-			.build()
-
-		return await this.submitTransaction(transaction)
-	}
-
-	/**
-	 * Executes general contract invocation
-	 */
-	private async executeContractInvocation(
-		_address: string,
-		contractId: string,
-		operationData: ContractInvocationOperation,
-	): Promise<string> {
-		if (!this.fundingKeypair) {
-			throw new Error('Funding keypair required for contract invocation')
-		}
-
-		const { contractAddress, functionName, args = [] } = operationData
-
-		// Get funding account
-		const fundingAccount = await this.server
-			.getAccount(this.fundingKeypair.publicKey())
-			.then((res) => new Account(res.accountId(), res.sequenceNumber()))
-
-		// Convert arguments to ScVal format
-		const scArgs = args.map((arg: unknown) => {
-			if (typeof arg === 'string') {
-				return xdr.ScVal.scvString(arg)
-			}
-			if (typeof arg === 'number') {
-				return xdr.ScVal.scvU64(xdr.Uint64.fromString(arg.toString()))
-			}
-			if (typeof arg === 'boolean') {
-				return xdr.ScVal.scvBool(arg)
-			}
-			// Default to bytes for complex types
-			return xdr.ScVal.scvBytes(Buffer.from(JSON.stringify(arg), 'utf-8'))
-		})
-
-		// Build transaction for contract invocation
-		const transaction = new TransactionBuilder(fundingAccount, {
-			fee: this.STANDARD_FEE,
-			networkPassphrase: this.networkPassphrase,
-		})
-			.addOperation(
-				Operation.invokeContractFunction({
-					contract: contractAddress || contractId,
-					function: functionName,
-					args: scArgs,
-				}),
-			)
-			.setTimeout(60)
-			.build()
-
-		return await this.submitTransaction(transaction)
-	}
-
-	/**
-	 * Helper to submit transactions with proper error handling and authorization
-	 */
-	private async submitTransaction(builtTransaction: Transaction): Promise<string> {
-		if (!this.fundingKeypair) {
-			throw new Error('Funding keypair required for transaction submission')
-		}
-
-		// Simulate transaction to get authorization requirements
-		const simulation = await this.server.simulateTransaction(builtTransaction)
-
-		if (Api.isSimulationError(simulation)) {
-			throw new Error(`Simulation failed: ${simulation.error || 'unknown error'}`)
-		}
-
-		if (Api.isSimulationRestore(simulation)) {
-			throw new Error('Transaction requires restore operation')
-		}
-
-		// Assemble transaction with authorization entries from simulation
-		const assembledTransaction = assembleTransaction(builtTransaction, simulation).build()
-
-		// Sign the transaction with our funding account
-		// The assembleTransaction function handles authorization entries automatically
-		assembledTransaction.sign(this.fundingKeypair)
-
-		// Submit transaction to Soroban RPC (NOT Horizon - this was the bug!)
-		// Soroban transactions with authorization entries must use sendTransaction
-		const sendResult = await this.server.sendTransaction(assembledTransaction)
-
-		if (sendResult.status === 'ERROR') {
-			throw new Error('Transaction submission failed')
-		}
-
-		if (sendResult.status === 'PENDING') {
-			// Wait for transaction to be included in a ledger
-			let attempts = 0
-			const maxAttempts = 120 // 2 minutes for complex auth transactions
-
-			while (attempts < maxAttempts) {
-				await new Promise((resolve) => setTimeout(resolve, 10000)) // Wait 1 second
-				attempts++
-
-				try {
-					const txResult = await this.server.getTransaction(sendResult.hash)
-
-					if (txResult.status === Api.GetTransactionStatus.SUCCESS) {
-						return sendResult.hash
-					}
-
-					if (txResult.status === Api.GetTransactionStatus.FAILED) {
-						throw new Error('Transaction failed')
-					}
-
-					if (txResult.status === Api.GetTransactionStatus.NOT_FOUND) {
-					}
-
-					// Still pending, continue waiting
-				} catch (_error) {}
-			}
-
-			throw new Error('Transaction timed out waiting for confirmation')
-		}
-
-		return sendResult.hash
 	}
 
 	/**
@@ -843,29 +516,9 @@ export interface PasskeyAccountInfo {
 	status: 'active' | 'not_found' | 'inactive'
 }
 
-export interface AddDeviceOperation {
-	type: 'add_device'
-	deviceId: string
-	publicKey: string
-	isAdmin?: boolean
-	challenge?: string
-}
-
-export interface RemoveDeviceOperation {
-	type: 'remove_device'
-	deviceId: string
-	challenge?: string
-}
-
-export interface ContractInvocationOperation {
-	type: 'invoke_contract'
-	contractAddress?: string
-	functionName: string
-	args?: unknown[]
-	challenge?: string
-}
-
-export type PasskeyOperation =
-	| AddDeviceOperation
-	| RemoveDeviceOperation
-	| ContractInvocationOperation
+export type {
+	AddDeviceOperation,
+	ContractInvocationOperation,
+	PasskeyOperation,
+	RemoveDeviceOperation,
+} from './passkey-transaction.utils'

--- a/packages/lib/test/passkey-signature.utils.test.ts
+++ b/packages/lib/test/passkey-signature.utils.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test'
+import { Buffer } from 'node:buffer'
+import { createHash, createSign, generateKeyPairSync } from 'node:crypto'
+import {
+	convertUncompressedToDER,
+	verifySECP256R1Signature,
+} from '../src/stellar/passkey-signature.utils'
+
+describe('convertUncompressedToDER', () => {
+	test('prepends the 26-byte P-256 SPKI prefix and appends the key', () => {
+		const key = Buffer.alloc(65, 0x04)
+		const der = convertUncompressedToDER(key)
+		expect(der.length).toBe(26 + 65)
+		expect(der[0]).toBe(0x30)
+		expect(der[1]).toBe(0x59)
+		expect(der.subarray(26)).toEqual(key)
+	})
+})
+
+describe('verifySECP256R1Signature', () => {
+	const { privateKey, publicKey } = generateKeyPairSync('ec', {
+		namedCurve: 'prime256v1',
+	})
+	// P-256 SPKI DER = 26-byte prefix + 65-byte uncompressed point.
+	const spkiDer = publicKey.export({ type: 'spki', format: 'der' }) as Buffer
+	const uncompressedKey = spkiDer.subarray(spkiDer.length - 65)
+
+	const authenticatorData = Buffer.from('authenticator-data').toString('base64')
+	const clientDataJSON = Buffer.from(
+		JSON.stringify({ challenge: 'abc', origin: 'https://kindfi.org' }),
+	).toString('base64')
+
+	const sign = (auth: string, client: string): string => {
+		const authBuf = Buffer.from(auth, 'base64')
+		const clientHash = createHash('sha256').update(Buffer.from(client, 'base64')).digest()
+		const signedData = Buffer.concat([authBuf, clientHash])
+		const signer = createSign('SHA256')
+		signer.update(signedData)
+		return signer.sign(privateKey).toString('base64')
+	}
+
+	test('returns true for a valid signature', async () => {
+		const signature = sign(authenticatorData, clientDataJSON)
+		const result = await verifySECP256R1Signature(
+			authenticatorData,
+			clientDataJSON,
+			signature,
+			uncompressedKey,
+		)
+		expect(result).toBe(true)
+	})
+
+	test('returns false when the signed client data differs', async () => {
+		const signature = sign(authenticatorData, clientDataJSON)
+		const otherClient = Buffer.from(JSON.stringify({ challenge: 'different' })).toString('base64')
+		const result = await verifySECP256R1Signature(
+			authenticatorData,
+			otherClient,
+			signature,
+			uncompressedKey,
+		)
+		expect(result).toBe(false)
+	})
+
+	test('returns false for a malformed signature', async () => {
+		const result = await verifySECP256R1Signature(
+			authenticatorData,
+			clientDataJSON,
+			Buffer.from('not-a-signature').toString('base64'),
+			uncompressedKey,
+		)
+		expect(result).toBe(false)
+	})
+})

--- a/packages/lib/test/passkey-transaction.utils.test.ts
+++ b/packages/lib/test/passkey-transaction.utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+import { Buffer } from 'node:buffer'
+import { argsToScVals } from '../src/stellar/passkey-transaction.utils'
+
+describe('argsToScVals', () => {
+	test('converts a string to scvString', () => {
+		const [val] = argsToScVals(['hello'])
+		expect(val.switch().name).toBe('scvString')
+		expect(val.str().toString()).toBe('hello')
+	})
+
+	test('converts a number to scvU64', () => {
+		const [val] = argsToScVals([42])
+		expect(val.switch().name).toBe('scvU64')
+		expect(val.u64().toString()).toBe('42')
+	})
+
+	test('converts a boolean to scvBool', () => {
+		const [val] = argsToScVals([true])
+		expect(val.switch().name).toBe('scvBool')
+		expect(val.b()).toBe(true)
+	})
+
+	test('converts an object to scvBytes with JSON payload', () => {
+		const obj = { foo: 'bar' }
+		const [val] = argsToScVals([obj])
+		expect(val.switch().name).toBe('scvBytes')
+		expect(Buffer.from(val.bytes()).toString('utf-8')).toBe(JSON.stringify(obj))
+	})
+
+	test('preserves order and length across mixed args', () => {
+		const vals = argsToScVals(['a', 1, false])
+		expect(vals).toHaveLength(3)
+		expect(vals[0].switch().name).toBe('scvString')
+		expect(vals[1].switch().name).toBe('scvU64')
+		expect(vals[2].switch().name).toBe('scvBool')
+	})
+
+	test('returns an empty array for no args', () => {
+		expect(argsToScVals([])).toEqual([])
+	})
+})

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -23,6 +23,6 @@
 		"strict": true,
 		"target": "ES2017"
 	},
-	"exclude": ["node_modules", "dist"],
+	"exclude": ["node_modules", "dist", "test"],
 	"include": ["**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
## Context

`packages/lib/src/stellar/stellar-passkey.service.ts` was 871 lines, with `StellarPasskeyService` owning 14 methods across three unrelated concerns: account deployment, passkey signature verification, and Soroban transaction submission.

## Changes

- **Extract signature helpers** into `packages/lib/src/stellar/passkey-signature.utils.ts`:
  - `convertUncompressedToDER`, `verifySECP256R1Signature`, `getPublicKeyForContract` (pure functions, no instance state).
- **Extract transaction helpers** into `packages/lib/src/stellar/passkey-transaction.utils.ts`:
  - `submitTransaction`, `executeAddDevice`, `executeRemoveDevice`, `executeContractInvocation`.
  - These receive an explicit `PasskeyTxContext` ({ server, fundingKeypair, networkPassphrase, fee }) instead of reading `this`, and each keeps its original `funding keypair required` guard as defense-in-depth.
  - The ScVal argument mapping is extracted into a pure, exported `argsToScVals` so the module has an independently testable unit.
  - The operation interfaces (`AddDeviceOperation`, `RemoveDeviceOperation`, `ContractInvocationOperation`, `PasskeyOperation`) live here and are **re-exported from the service** to preserve existing import paths.
- **`StellarPasskeyService` is now a thin orchestrator** that delegates to these utilities. Its public API and behavior are unchanged.

## Tests

New co-located unit tests under `packages/lib/test/` (run with `bun test`, added a `test` script to `packages/lib/package.json`):

- `passkey-signature.utils.test.ts` — real P-256 sign/verify round-trip (valid / tampered / malformed) + DER-prefix assertions.
- `passkey-transaction.utils.test.ts` — `argsToScVals` across string / number / boolean / object, order, and empty input.

`10/10` passing.

## Acceptance criteria

- [x] No behavior change; existing consumers of `StellarPasskeyService` keep working unmodified (public API preserved; operation types re-exported).
- [x] New utility modules are independently unit-testable.
- [x] Service class line count meaningfully reduced: **871 → 524 lines**.

> Note on the ~400-line target: the remaining lines are account **deployment** logic (`deployPasskeyAccount`, `deployViaFactory`, `verifyContractExists`) and `queryContractDevices`, which are outside the scope of this issue's proposed extraction. All three signature and four transaction helpers named in the issue were extracted.

## References

Follow-up to the review request by @Bran18 on #953 (Hotfix: Contract Fee).

Closes #954


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passkey signature verification for Stellar transactions.
  * Added support for adding and removing passkey devices.
  * Added execution of arbitrary Stellar contract calls with common argument types.
  * Added transaction simulation, signing, submission, status polling, and timeout handling.

* **Bug Fixes**
  * Improved handling of missing or invalid passkey public keys and signatures.

* **Tests**
  * Added coverage for signature validation and transaction argument conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->