### PR TITLE
refactor: split SmartWalletTransactionService transaction-building logic

### DIFF
--- a/apps/web/lib/stellar/smart-wallet-submission.utils.ts
+++ b/apps/web/lib/stellar/smart-wallet-submission.utils.ts
@@ -1,0 +1,70 @@
+import type { WebAuthnSignatureData } from '@packages/lib/stellar'
+import type { Operation, Transaction } from '@stellar/stellar-sdk'
+import { Api, type Server } from '@stellar/stellar-sdk/rpc'
+import { logger } from '@/lib/logger'
+
+export interface SubmitWithWebAuthnParams {
+	smartWalletAddress: string
+	operation: Operation
+	webAuthnSignature: WebAuthnSignatureData
+	publicKey: Uint8Array
+}
+
+/**
+ * Submit a signed transaction using WebAuthn signature via Channels service.
+ * NOTE: requires Smart Account Kit SDK — currently throws a guiding error.
+ */
+export async function submitTransactionWithWebAuthn(
+	_params: SubmitWithWebAuthnParams,
+): Promise<{ transactionHash: string; status: string }> {
+	logger.warn(
+		'⚠️ submitTransactionWithWebAuthn requires Smart Account Kit SDK. ' +
+			'Use SmartAccountKitService.signAndSubmit() instead, or use legacy submitTransaction() method.',
+	)
+
+	throw new Error(
+		'WebAuthn transaction submission via Channels requires Smart Account Kit SDK. ' +
+			'Install smart-account-kit and use SmartAccountKitService.signAndSubmit() instead.',
+	)
+}
+
+/**
+ * Submit a signed transaction to the network (legacy method).
+ * @returns Transaction hash
+ */
+export async function submitTransaction(
+	server: Server,
+	signedTransaction: Transaction,
+): Promise<string> {
+	const result = await server.sendTransaction(signedTransaction)
+
+	if (result.status === 'ERROR') {
+		throw new Error(`Transaction failed: ${JSON.stringify(result)}`)
+	}
+
+	let attempts = 0
+	const maxAttempts = 120
+
+	while (attempts < maxAttempts) {
+		await new Promise((resolve) => setTimeout(resolve, 1000))
+		attempts++
+
+		try {
+			const txResult = await server.getTransaction(result.hash)
+
+			if (txResult.status === Api.GetTransactionStatus.SUCCESS) {
+				return result.hash
+			}
+
+			if (txResult.status === Api.GetTransactionStatus.FAILED) {
+				throw new Error(`Transaction failed: ${JSON.stringify(txResult)}`)
+			}
+		} catch (error) {
+			if (attempts === maxAttempts) {
+				throw error
+			}
+		}
+	}
+
+	throw new Error('Transaction timeout')
+}

--- a/apps/web/lib/stellar/smart-wallet-transaction-builder.utils.ts
+++ b/apps/web/lib/stellar/smart-wallet-transaction-builder.utils.ts
@@ -1,0 +1,178 @@
+import { Buffer } from 'node:buffer'
+import { deriveSignaturePayload } from '@packages/lib/passkey'
+import {
+	Account,
+	type Keypair,
+	type Transaction,
+	TransactionBuilder,
+	xdr,
+} from '@stellar/stellar-sdk'
+import { Api, assembleTransaction, type Server } from '@stellar/stellar-sdk/rpc'
+import { logger } from '@/lib/logger'
+
+/** Runtime dependencies supplied by SmartWalletTransactionService. */
+export interface SmartWalletTxContext {
+	server: Server
+	networkPassphrase: string
+	fundingKeypair?: Keypair
+	fee: string
+}
+
+export interface BuildTransactionParams {
+	smartWalletAddress: string
+	operations: xdr.Operation[]
+	sponsorFees: boolean
+}
+
+export interface TransactionChallenge {
+	/** Transaction envelope in XDR format */
+	transactionXDR: string
+	/** Base64URL-encoded challenge hash for WebAuthn */
+	challenge: string
+	/** Transaction hash (hex) */
+	hash: string
+}
+
+type DeriveSignaturePayloadParams = Parameters<typeof deriveSignaturePayload>[0]
+
+/** Get funding account for fee sponsorship. */
+export async function getFundingAccount(ctx: SmartWalletTxContext): Promise<Account> {
+	if (!ctx.fundingKeypair) {
+		throw new Error('Funding keypair required for fee sponsorship')
+	}
+	const accountResponse = await ctx.server.getAccount(ctx.fundingKeypair.publicKey())
+	return new Account(accountResponse.accountId(), accountResponse.sequenceNumber())
+}
+
+/** Get smart wallet account (for self-paying transactions). */
+export function getSmartWalletAccount(address: string): Account {
+	// Smart wallets use sequence number 0 for contract invocations
+	return new Account(address, '0')
+}
+
+/** Simulate a transaction (read-only ops like NFT balance/metadata queries). */
+export function simulateTransaction(server: Server, transaction: Transaction) {
+	return server.simulateTransaction(transaction)
+}
+
+/**
+ * Builds a transaction for WebAuthn signing.
+ * @returns the transaction envelope and challenge hash
+ */
+export async function buildTransaction(
+	ctx: SmartWalletTxContext,
+	params: BuildTransactionParams,
+): Promise<TransactionChallenge> {
+	const { smartWalletAddress, operations, sponsorFees } = params
+
+	const sourceAccount = sponsorFees
+		? await getFundingAccount(ctx)
+		: getSmartWalletAccount(smartWalletAddress)
+
+	let txBuilder = new TransactionBuilder(sourceAccount, {
+		fee: ctx.fee,
+		networkPassphrase: ctx.networkPassphrase,
+	})
+
+	for (const op of operations) {
+		txBuilder = txBuilder.addOperation(op)
+	}
+
+	const transaction = txBuilder.setTimeout(300).build()
+
+	if (sponsorFees && ctx.fundingKeypair) {
+		transaction.sign(ctx.fundingKeypair)
+	}
+
+	const simulation = await ctx.server.simulateTransaction(transaction, {
+		cpuInstructions: 3_500_000,
+	})
+
+	if (Api.isSimulationError(simulation)) {
+		logger.error('❌ Simulation error:', simulation.error)
+		throw new Error(`Transaction simulation failed: ${simulation.error || 'Unknown error'}`)
+	}
+
+	const latestLedger = await ctx.server.getLatestLedger()
+	const validityWindow = 300 // ~25 minutes (300 ledgers × 5 seconds)
+	const signatureExpirationLedger = latestLedger.sequence + validityWindow
+
+	if (
+		!Api.isSimulationError(simulation) &&
+		simulation.result?.auth &&
+		simulation.result.auth.length > 0
+	) {
+		const simAuthEntry = simulation.result.auth[0]
+
+		if (
+			simAuthEntry.credentials().switch() === xdr.SorobanCredentialsType.sorobanCredentialsAddress()
+		) {
+			const addressCredentials = simAuthEntry.credentials().address()
+
+			const newCredentials = new xdr.SorobanAddressCredentials({
+				address: addressCredentials.address(),
+				nonce: addressCredentials.nonce(),
+				signatureExpirationLedger: signatureExpirationLedger,
+				signature: addressCredentials.signature(),
+			})
+
+			const newAuthEntry = new xdr.SorobanAuthorizationEntry({
+				credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(newCredentials),
+				rootInvocation: simAuthEntry.rootInvocation(),
+			})
+
+			simulation.result.auth[0] = newAuthEntry
+
+			const _verifyCredentials = simulation.result.auth[0].credentials().address()
+		}
+	}
+
+	const assembledTx = assembleTransaction(transaction, simulation).build()
+
+	const signaturePayloadResult = deriveSignaturePayload({
+		transactionResult:
+			simulation?.result as unknown as DeriveSignaturePayloadParams['transactionResult'],
+		networkPassphrase: ctx.networkPassphrase,
+	})
+
+	if (!signaturePayloadResult) {
+		logger.warn('⚠️  Could not extract signature_payload, falling back to tx hash')
+		throw new Error('⚠️  Could not extract signature_payload')
+	}
+
+	const challenge = Buffer.from(signaturePayloadResult.payloadHex, 'hex').toString('base64url')
+	const txHash = assembledTx.hash()
+
+	const transactionXDR = assembledTx.toXDR()
+	try {
+		const xdrCheck = TransactionBuilder.fromXDR(
+			transactionXDR,
+			ctx.networkPassphrase,
+		) as Transaction
+		const checkOp = xdrCheck.operations[0] as unknown as Api.SimulateHostFunctionResult
+		const checkAuthEntries = checkOp?.auth || []
+		if (checkAuthEntries.length > 0) {
+			const checkAuthEntry = checkAuthEntries[0]
+			if (
+				checkAuthEntry.credentials().switch() ===
+				xdr.SorobanCredentialsType.sorobanCredentialsAddress()
+			) {
+				const checkCredentials = checkAuthEntry.credentials().address()
+				if (
+					checkCredentials.signatureExpirationLedger().toString() !==
+					signatureExpirationLedger.toString()
+				) {
+					logger.error('❌ CRITICAL: XDR bytes do NOT contain correct expiration!')
+				}
+			}
+		}
+	} catch (error) {
+		logger.error('❌ Error verifying XDR:', error)
+	}
+
+	return {
+		transactionXDR,
+		challenge,
+		hash: txHash.toString('hex'),
+	}
+}

--- a/apps/web/lib/stellar/smart-wallet-transactions.ts
+++ b/apps/web/lib/stellar/smart-wallet-transactions.ts
@@ -1,6 +1,5 @@
 import { Buffer } from 'node:buffer'
 import { appEnvConfig } from '@packages/lib/config'
-import { deriveSignaturePayload } from '@packages/lib/passkey'
 import type { WebAuthnSignatureData } from '@packages/lib/stellar'
 import type { AppEnvInterface } from '@packages/lib/types'
 import {
@@ -16,8 +15,18 @@ import {
 	TransactionBuilder,
 	xdr,
 } from '@stellar/stellar-sdk'
-import { Api, assembleTransaction, Server } from '@stellar/stellar-sdk/rpc'
+import { Api, Server } from '@stellar/stellar-sdk/rpc'
 import { logger } from '@/lib/logger'
+import { submitTransaction, submitTransactionWithWebAuthn } from './smart-wallet-submission.utils'
+import {
+	buildTransaction,
+	getFundingAccount,
+	type SmartWalletTxContext,
+	simulateTransaction,
+	type TransactionChallenge,
+} from './smart-wallet-transaction-builder.utils'
+
+export type { TransactionChallenge } from './smart-wallet-transaction-builder.utils'
 
 const appConfig: AppEnvInterface = appEnvConfig('web')
 
@@ -48,6 +57,15 @@ export class SmartWalletTransactionService {
 		}
 	}
 
+	private ctx(): SmartWalletTxContext {
+		return {
+			server: this.server,
+			networkPassphrase: this.networkPassphrase,
+			fundingKeypair: this.fundingKeypair,
+			fee: this.STANDARD_FEE,
+		}
+	}
+
 	/**
 	 * Transfer XLM (native lumens) from smart wallet to another address
 	 *
@@ -66,7 +84,7 @@ export class SmartWalletTransactionService {
 		)
 
 		// Build and return transaction for signing
-		return await this.buildTransaction({
+		return await buildTransaction(this.ctx(), {
 			smartWalletAddress: from,
 			operations: [transferOp],
 			sponsorFees,
@@ -91,7 +109,7 @@ export class SmartWalletTransactionService {
 			nativeToScVal(amount, { type: 'i128' }),
 		)
 
-		return await this.buildTransaction({
+		return await buildTransaction(this.ctx(), {
 			smartWalletAddress: from,
 			operations: [transferOp],
 			sponsorFees,
@@ -140,7 +158,7 @@ export class SmartWalletTransactionService {
 			xdr.ScVal.scvVec(scArgs),
 		)
 
-		return await this.buildTransaction({
+		return await buildTransaction(this.ctx(), {
 			smartWalletAddress: from,
 			operations: [invokeOp],
 			sponsorFees,
@@ -162,7 +180,7 @@ export class SmartWalletTransactionService {
 
 			// Use funding account for simulation (required for read operations)
 			const sourceAccount = this.fundingKeypair
-				? await this.getFundingAccount()
+				? await getFundingAccount(this.ctx())
 				: new Account(smartWalletAddress, '0')
 
 			// Query balance from Native XLM SAC
@@ -212,14 +230,14 @@ export class SmartWalletTransactionService {
 	 * Simulate a transaction (for read-only operations like NFT balance/metadata queries)
 	 */
 	async simulateTransaction(transaction: Transaction) {
-		return this.server.simulateTransaction(transaction)
+		return simulateTransaction(this.server, transaction)
 	}
 
 	/**
 	 * Get funding account for simulation (required when simulating read operations)
 	 */
 	async getFundingAccountForSimulation(): Promise<Account> {
-		return this.getFundingAccount()
+		return getFundingAccount(this.ctx())
 	}
 
 	/**
@@ -232,23 +250,13 @@ export class SmartWalletTransactionService {
 	 * @param params Transaction submission parameters with WebAuthn signature
 	 * @returns Transaction hash and status
 	 */
-	async submitTransactionWithWebAuthn(_params: {
+	async submitTransactionWithWebAuthn(params: {
 		smartWalletAddress: string
 		operation: Operation
 		webAuthnSignature: WebAuthnSignatureData
 		publicKey: Uint8Array
 	}): Promise<{ transactionHash: string; status: string }> {
-		logger.warn(
-			'⚠️ submitTransactionWithWebAuthn requires Smart Account Kit SDK. ' +
-				'Use SmartAccountKitService.signAndSubmit() instead, or use legacy submitTransaction() method.',
-		)
-
-		// This would require Smart Account Kit SDK integration
-		// For now, throw helpful error
-		throw new Error(
-			'WebAuthn transaction submission via Channels requires Smart Account Kit SDK. ' +
-				'Install smart-account-kit and use SmartAccountKitService.signAndSubmit() instead.',
-		)
+		return submitTransactionWithWebAuthn(params)
 	}
 
 	/**
@@ -259,201 +267,7 @@ export class SmartWalletTransactionService {
 	 * @returns Transaction hash
 	 */
 	async submitTransaction(signedTransaction: Transaction): Promise<string> {
-		const result = await this.server.sendTransaction(signedTransaction)
-
-		if (result.status === 'ERROR') {
-			throw new Error(`Transaction failed: ${JSON.stringify(result)}`)
-		}
-
-		let attempts = 0
-		const maxAttempts = 120
-
-		while (attempts < maxAttempts) {
-			await new Promise((resolve) => setTimeout(resolve, 1000))
-			attempts++
-
-			try {
-				const txResult = await this.server.getTransaction(result.hash)
-
-				if (txResult.status === Api.GetTransactionStatus.SUCCESS) {
-					return result.hash
-				}
-
-				if (txResult.status === Api.GetTransactionStatus.FAILED) {
-					throw new Error(`Transaction failed: ${JSON.stringify(txResult)}`)
-				}
-			} catch (error) {
-				if (attempts === maxAttempts) {
-					throw error
-				}
-			}
-		}
-
-		throw new Error('Transaction timeout')
-	}
-
-	/**
-	 * Builds a transaction for WebAuthn signing
-	 * @returns the transaction envelope and challenge hash
-	 */
-	private async buildTransaction(params: BuildTransactionParams): Promise<TransactionChallenge> {
-		const { smartWalletAddress, operations, sponsorFees } = params
-
-		// Determine source account (funding account if sponsoring fees, otherwise smart wallet)
-		const sourceAccount = sponsorFees
-			? await this.getFundingAccount()
-			: await this.getSmartWalletAccount(smartWalletAddress)
-		// Build transaction
-		let txBuilder = new TransactionBuilder(sourceAccount, {
-			fee: this.STANDARD_FEE,
-			networkPassphrase: this.networkPassphrase,
-		})
-
-		// Add operations
-		for (const op of operations) {
-			txBuilder = txBuilder.addOperation(op)
-		}
-
-		const transaction = txBuilder.setTimeout(300).build()
-
-		// If sponsoring fees, sign with funding account before simulation
-		if (sponsorFees && this.fundingKeypair) {
-			transaction.sign(this.fundingKeypair)
-		}
-
-		// Simulate to get auth entry with signature_payload
-		const simulation = await this.server.simulateTransaction(transaction, {
-			cpuInstructions: 3_500_000,
-		})
-
-		if (Api.isSimulationError(simulation)) {
-			logger.error('❌ Simulation error:', simulation.error)
-			throw new Error(`Transaction simulation failed: ${simulation.error || 'Unknown error'}`)
-		}
-		// Get current ledger to set valid signature expiration
-		const latestLedger = await this.server.getLatestLedger()
-		const validityWindow = 300 // ~25 minutes (300 ledgers × 5 seconds)
-		const signatureExpirationLedger = latestLedger.sequence + validityWindow
-
-		// CRITICAL FIX: Modify the simulation result BEFORE assembling
-		// The simulation.result.auth contains the auth entries that will be used
-		// We need to update the signatureExpirationLedger in the simulation BEFORE calling assembleTransaction
-		if (
-			!Api.isSimulationError(simulation) &&
-			simulation.result?.auth &&
-			simulation.result.auth.length > 0
-		) {
-			// Get the first auth entry from simulation
-			const simAuthEntry = simulation.result.auth[0]
-
-			// Check if it's an address credentials type
-			if (
-				simAuthEntry.credentials().switch() ===
-				xdr.SorobanCredentialsType.sorobanCredentialsAddress()
-			) {
-				const addressCredentials = simAuthEntry.credentials().address()
-
-				// Create NEW credentials with valid expiration
-				const newCredentials = new xdr.SorobanAddressCredentials({
-					address: addressCredentials.address(),
-					nonce: addressCredentials.nonce(),
-					signatureExpirationLedger: signatureExpirationLedger,
-					signature: addressCredentials.signature(),
-				})
-
-				// Create new auth entry with updated credentials
-				const newAuthEntry = new xdr.SorobanAuthorizationEntry({
-					credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(newCredentials),
-					rootInvocation: simAuthEntry.rootInvocation(),
-				})
-
-				// Replace the auth entry in the simulation result
-				simulation.result.auth[0] = newAuthEntry
-
-				// VERIFY: Check that modification worked
-				const _verifyCredentials = simulation.result.auth[0].credentials().address()
-			}
-		}
-
-		// NOW assemble the transaction with our modified simulation
-		// This will bake in the correct signatureExpirationLedger
-		const assembledTx = assembleTransaction(transaction, simulation)
-			// .setSorobanData(sorobanData)
-			.build()
-
-		// IMPORTANT: Extract signature_payload from the SIMULATION transaction
-		// The assembly process will have the definitive auth entry values, so we must use the values linked to the transaction (simulation)
-		const signaturePayloadResult = deriveSignaturePayload({
-			transactionResult:
-				simulation?.result as unknown as DeriveSignaturePayloadParams['transactionResult'],
-			networkPassphrase: this.networkPassphrase,
-		})
-
-		if (!signaturePayloadResult) {
-			// Fallback to transaction hash if we can't extract signature_payload
-			logger.warn('⚠️  Could not extract signature_payload, falling back to tx hash')
-			throw new Error('⚠️  Could not extract signature_payload')
-		}
-
-		// Use signature_payload as the WebAuthn challenge
-		const challenge = Buffer.from(signaturePayloadResult.payloadHex, 'hex').toString('base64url')
-		const txHash = assembledTx.hash()
-
-		// DIAGNOSTIC: Verify XDR encoding contains correct values
-		const transactionXDR = assembledTx.toXDR()
-		try {
-			const xdrCheck = TransactionBuilder.fromXDR(
-				transactionXDR,
-				this.networkPassphrase,
-			) as Transaction
-			const checkOp = xdrCheck.operations[0] as unknown as Api.SimulateHostFunctionResult
-			const checkAuthEntries = checkOp?.auth || []
-			if (checkAuthEntries.length > 0) {
-				const checkAuthEntry = checkAuthEntries[0]
-				if (
-					checkAuthEntry.credentials().switch() ===
-					xdr.SorobanCredentialsType.sorobanCredentialsAddress()
-				) {
-					const checkCredentials = checkAuthEntry.credentials().address()
-
-					if (
-						checkCredentials.signatureExpirationLedger().toString() !==
-						signatureExpirationLedger.toString()
-					) {
-						logger.error('❌ CRITICAL: XDR bytes do NOT contain correct expiration!')
-					}
-				}
-			}
-		} catch (error) {
-			logger.error('❌ Error verifying XDR:', error)
-		}
-
-		return {
-			transactionXDR,
-			challenge,
-			hash: txHash.toString('hex'),
-		}
-	}
-
-	/**
-	 * Get funding account for fee sponsorship
-	 */
-	private async getFundingAccount(): Promise<Account> {
-		if (!this.fundingKeypair) {
-			throw new Error('Funding keypair required for fee sponsorship')
-		}
-
-		const accountResponse = await this.server.getAccount(this.fundingKeypair.publicKey())
-
-		return new Account(accountResponse.accountId(), accountResponse.sequenceNumber())
-	}
-
-	/**
-	 * Get smart wallet account (for self-paying transactions)
-	 */
-	private async getSmartWalletAccount(address: string): Promise<Account> {
-		// Smart wallets use sequence number 0 for contract invocations
-		return new Account(address, '0')
+		return submitTransaction(this.server, signedTransaction)
 	}
 }
 
@@ -496,15 +310,6 @@ export interface InvokeContractParams {
 	sponsorFees?: boolean
 }
 
-export interface TransactionChallenge {
-	/** Transaction envelope in XDR format */
-	transactionXDR: string
-	/** Base64URL-encoded challenge hash for WebAuthn */
-	challenge: string
-	/** Transaction hash (hex) */
-	hash: string
-}
-
 export interface SmartWalletBalances {
 	/** XLM balance in stroops */
 	xlm: string
@@ -516,11 +321,3 @@ export interface SmartWalletBalances {
 		decimals?: number
 	}>
 }
-
-interface BuildTransactionParams {
-	smartWalletAddress: string
-	operations: xdr.Operation[]
-	sponsorFees: boolean
-}
-
-type DeriveSignaturePayloadParams = Parameters<typeof deriveSignaturePayload>[0]

--- a/apps/web/test/smart-wallet-submission.utils.test.ts
+++ b/apps/web/test/smart-wallet-submission.utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test'
+import { submitTransactionWithWebAuthn } from '../lib/stellar/smart-wallet-submission.utils'
+
+describe('submitTransactionWithWebAuthn', () => {
+	test('throws a helpful error directing to Smart Account Kit', async () => {
+		await expect(
+			submitTransactionWithWebAuthn({
+				smartWalletAddress: 'C...',
+				operation: {} as never,
+				webAuthnSignature: {} as never,
+				publicKey: new Uint8Array(),
+			}),
+		).rejects.toThrow('Smart Account Kit')
+	})
+})

--- a/apps/web/test/smart-wallet-transaction-builder.utils.test.ts
+++ b/apps/web/test/smart-wallet-transaction-builder.utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+import {
+	getFundingAccount,
+	getSmartWalletAccount,
+} from '../lib/stellar/smart-wallet-transaction-builder.utils'
+
+describe('getSmartWalletAccount', () => {
+	test('returns an Account at sequence 0 for the given address', () => {
+		const address = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
+		const account = getSmartWalletAccount(address)
+		expect(account.accountId()).toBe(address)
+		expect(account.sequenceNumber()).toBe('0')
+	})
+})
+
+describe('getFundingAccount', () => {
+	test('throws when no funding keypair is configured', async () => {
+		const ctx = {
+			server: {} as never,
+			networkPassphrase: 'Test SDF Network ; September 2015',
+			fee: '5000000',
+		}
+		await expect(getFundingAccount(ctx)).rejects.toThrow(
+			'Funding keypair required for fee sponsorship',
+		)
+	})
+})


### PR DESCRIPTION
## Context

`apps/web/lib/stellar/smart-wallet-transactions.ts` was 526 lines. The `SmartWalletTransactionService` class mixed high-level transfer/invoke operations with lower-level transaction building, simulation, and submission logic.

This follows the same pattern introduced in #976 (splitting `StellarPasskeyService` into focused modules): standalone functions that receive a runtime context object, with the service delegating to them.

## Changes

- **New** `smart-wallet-transaction-builder.utils.ts` — transaction building/simulation helpers (`buildTransaction`, `simulateTransaction`, `getFundingAccount`, `getSmartWalletAccount`) plus the `SmartWalletTxContext`, `BuildTransactionParams`, and `TransactionChallenge` types.
- **New** `smart-wallet-submission.utils.ts` — submission helpers (`submitTransaction`, `submitTransactionWithWebAuthn`).
- `SmartWalletTransactionService` now delegates to these utilities via a private `ctx()` accessor and stays focused on the public transfer/invoke/balances API. `TransactionChallenge` is re-exported from the main module, so existing consumers import nothing new.
- Added unit tests for both new util modules.

The service file drops from 526 to 323 lines.

## Acceptance criteria

- [x] No behavior change; the class's public methods keep the same signatures.
- [x] New utility modules are independently unit-testable (tests added).
- [x] No circular imports; the 4 API-route consumers (`transfer/prepare`, `contract/invoke`, `balances/[address]`, `nfts/[address]`) are untouched.

## Testing

- `bun test test/smart-wallet-transaction-builder.utils.test.ts test/smart-wallet-submission.utils.test.ts` → 3 pass / 0 fail.
- `bunx tsc --noEmit` → no new type errors.
- `biome check` → clean.

Closes #958


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Smart Wallet transaction building with simulation, fee sponsorship, WebAuthn challenges, and authorization expiration handling.
  * Added transaction submission with status polling and clear timeout or failure errors.
* **Bug Fixes**
  * Improved error handling when fee sponsorship credentials are missing or WebAuthn support is unavailable.
* **Tests**
  * Added coverage for transaction submission errors, account creation, and fee sponsorship validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->