### PR TITLE
fix: source Released progress bar from on-chain escrow milestones

### DIFF
--- a/apps/web/components/sections/projects/cards/project-card-grid.tsx
+++ b/apps/web/components/sections/projects/cards/project-card-grid.tsx
@@ -7,12 +7,12 @@ import Link from 'next/link'
 import { Badge } from '~/components/base/badge'
 import { CategoryBadge, ReleasedProgressBar } from '~/components/sections/projects/shared'
 import { useProjectFundingDisplay } from '~/hooks/projects/use-project-funding-display'
+import { useProjectReleasedDisplay } from '~/hooks/projects/use-project-released-display'
 import { cardHover, progressBarAnimation } from '~/lib/constants/animations'
 import { useI18n } from '~/lib/i18n'
 import type { Project } from '~/lib/types/project'
 import { cn } from '~/lib/utils'
 import { getContrastTextColor } from '~/lib/utils/color-utils'
-import { calculateReleasedProgressPercent } from '~/lib/utils/projects/milestone-funding'
 
 interface ProjectCardGridProps {
 	project: Project
@@ -29,9 +29,15 @@ export function ProjectCardGrid({ project, index = 0 }: ProjectCardGridProps) {
 		raised: project.raised,
 	})
 
+	const { displayReleased, releasedProgressPercent } = useProjectReleasedDisplay({
+		escrowContractAddress: project.escrowContractAddress,
+		escrowType: project.escrowType,
+		goal: project.goal,
+	})
+
 	const progressPercentage = progressPercent ?? 0
-	const releasedAmount = project.releasedAmount ?? 0
-	const releasedPercentage = calculateReleasedProgressPercent(releasedAmount, project.goal) ?? 0
+	const releasedAmount = displayReleased ?? 0
+	const releasedPercentage = releasedProgressPercent ?? 0
 
 	const imageSrc = project.image || '/images/placeholder.png'
 

--- a/apps/web/components/sections/projects/cards/project-card-list.tsx
+++ b/apps/web/components/sections/projects/cards/project-card-list.tsx
@@ -7,12 +7,12 @@ import Link from 'next/link'
 import { Badge } from '~/components/base/badge'
 import { CategoryBadge, ReleasedProgressBar } from '~/components/sections/projects/shared'
 import { useProjectFundingDisplay } from '~/hooks/projects/use-project-funding-display'
+import { useProjectReleasedDisplay } from '~/hooks/projects/use-project-released-display'
 import { cardHover, progressBarAnimation } from '~/lib/constants/animations'
 import { useI18n } from '~/lib/i18n'
 import type { Project } from '~/lib/types/project'
 import { cn } from '~/lib/utils'
 import { getContrastTextColor } from '~/lib/utils/color-utils'
-import { calculateReleasedProgressPercent } from '~/lib/utils/projects/milestone-funding'
 
 interface ProjectCardListProps {
 	project: Project
@@ -27,9 +27,15 @@ export function ProjectCardList({ project }: ProjectCardListProps) {
 		raised: project.raised,
 	})
 
+	const { displayReleased, releasedProgressPercent } = useProjectReleasedDisplay({
+		escrowContractAddress: project.escrowContractAddress,
+		escrowType: project.escrowType,
+		goal: project.goal,
+	})
+
 	const progressPercentage = progressPercent ?? 0
-	const releasedAmount = project.releasedAmount ?? 0
-	const releasedPercentage = calculateReleasedProgressPercent(releasedAmount, project.goal) ?? 0
+	const releasedAmount = displayReleased ?? 0
+	const releasedPercentage = releasedProgressPercent ?? 0
 
 	return (
 		<Link

--- a/apps/web/components/sections/projects/detail/project-hero.tsx
+++ b/apps/web/components/sections/projects/detail/project-hero.tsx
@@ -13,13 +13,10 @@ import {
 } from '~/components/sections/projects/shared'
 import { ShareButtons } from '~/components/shared/share-buttons'
 import { useProjectFundingDisplay } from '~/hooks/projects/use-project-funding-display'
+import { useProjectReleasedDisplay } from '~/hooks/projects/use-project-released-display'
 import { getProjectPageUrl } from '~/lib/seo/project-metadata'
 import type { ProjectDetail } from '~/lib/types/project/project-detail.types'
 import { getCountryNameFromAlpha3 } from '~/lib/utils/project-utils'
-import {
-	calculateReleasedAmount,
-	calculateReleasedProgressPercent,
-} from '~/lib/utils/projects/milestone-funding'
 
 interface ProjectHeroProps {
 	project: ProjectDetail
@@ -43,11 +40,15 @@ export function ProjectHero({ project, projectSlug }: ProjectHeroProps) {
 		[project.slug, projectSlug],
 	)
 
-	const releasedAmount = useMemo(
-		() => calculateReleasedAmount(project.milestones),
-		[project.milestones],
-	)
-	const releasedPercentage = calculateReleasedProgressPercent(releasedAmount, project.goal) ?? 0
+	const { displayReleased, releasedProgressPercent } = useProjectReleasedDisplay({
+		escrowContractAddress: project.escrowContractAddress,
+		escrowType: project.escrowType,
+		goal: project.goal,
+		dbMilestones: project.milestones,
+	})
+
+	const releasedAmount = displayReleased ?? 0
+	const releasedPercentage = releasedProgressPercent ?? 0
 
 	return (
 		<motion.section
@@ -117,7 +118,13 @@ export function ProjectHero({ project, projectSlug }: ProjectHeroProps) {
 					<div className="p-4 text-center bg-gray-50 rounded-lg">
 						<p className="mb-1 text-sm text-muted-foreground">Released</p>
 						<p className="text-xl font-bold tabular-nums">
-							$<AnimatedCounter value={releasedAmount} />
+							{displayReleased === null ? (
+								'…'
+							) : (
+								<>
+									$<AnimatedCounter value={releasedAmount} />
+								</>
+							)}
 						</p>
 					</div>
 					<div className="p-4 text-center bg-gray-50 rounded-lg">

--- a/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar-escrow-state.ts
+++ b/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar-escrow-state.ts
@@ -5,6 +5,11 @@ import { useEscrow } from '~/hooks/contexts/use-escrow.context'
 import { useEscrowData } from '~/hooks/escrow/use-escrow-data'
 import type { ProjectDetail } from '~/lib/types/project/project-detail.types'
 import { resolveEscrowType } from '~/lib/utils/escrow/resolve-escrow-type'
+import {
+	calculateReleasedAmountFromEscrow,
+	calculateReleasedProgressPercent,
+	resolveDisplayReleasedAmount,
+} from '~/lib/utils/projects/milestone-funding'
 
 export function useProjectSidebarEscrowState(project: ProjectDetail) {
 	const { getMultipleBalances, getEscrowByContractIds } = useEscrow()
@@ -35,6 +40,25 @@ export function useProjectSidebarEscrowState(project: ProjectDetail) {
 	const isGoalReached = useMemo(
 		() => hasEscrow && project.goal > 0 && effectiveRaised >= project.goal,
 		[hasEscrow, project.goal, effectiveRaised],
+	)
+
+	const displayReleased = useMemo(
+		() =>
+			resolveDisplayReleasedAmount({
+				dbMilestones: project.milestones,
+				escrowContractAddress: project.escrowContractAddress,
+				onChainReleasedAmount: escrowData ? calculateReleasedAmountFromEscrow(escrowData) : null,
+				isLoadingOnChain: hasEscrow && isEscrowDataLoading,
+			}),
+		[escrowData, hasEscrow, isEscrowDataLoading, project.escrowContractAddress, project.milestones],
+	)
+
+	const releasedProgressPercent = useMemo(
+		() =>
+			displayReleased === null
+				? null
+				: calculateReleasedProgressPercent(displayReleased, project.goal),
+		[displayReleased, project.goal],
 	)
 
 	const resolveEscrowTypeForFunding = useCallback(async (): Promise<EscrowType> => {
@@ -90,6 +114,8 @@ export function useProjectSidebarEscrowState(project: ProjectDetail) {
 		effectiveRaised,
 		progressPercentage,
 		isGoalReached,
+		displayReleased,
+		releasedProgressPercent,
 		fetchEscrowBalance,
 		resolveEscrowTypeForFunding,
 	}

--- a/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar.tsx
+++ b/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar.tsx
@@ -29,6 +29,8 @@ export function useProjectSidebar(project: ProjectDetail, projectSlug: string) {
 		isFetchingBalance,
 		progressPercentage,
 		isGoalReached,
+		displayReleased,
+		releasedProgressPercent,
 		fetchEscrowBalance,
 		resolveEscrowTypeForFunding,
 	} = useProjectSidebarEscrowState(project)
@@ -128,6 +130,8 @@ export function useProjectSidebar(project: ProjectDetail, projectSlug: string) {
 		isDonationReady,
 		isEscrowDataLoading,
 		progressPercentage,
+		displayReleased,
+		releasedProgressPercent,
 		onChainRaised,
 		isFetchingBalance,
 		isMounted,

--- a/apps/web/components/sections/projects/detail/project-sidebar/project-sidebar.tsx
+++ b/apps/web/components/sections/projects/detail/project-sidebar/project-sidebar.tsx
@@ -1,14 +1,9 @@
 'use client'
 
 import { motion, useReducedMotion } from 'framer-motion'
-import { useMemo } from 'react'
 import { Badge } from '~/components/base/badge'
 import { ReleasedProgressBar } from '~/components/sections/projects/shared'
 import type { ProjectDetail } from '~/lib/types/project/project-detail.types'
-import {
-	calculateReleasedAmount,
-	calculateReleasedProgressPercent,
-} from '~/lib/utils/projects/milestone-funding'
 import { DonationForm, DonationNotices } from './components/donation-form'
 import { EscrowContractInfo } from './components/escrow-contract-info'
 import { FoundationLink } from './components/foundation-link'
@@ -32,6 +27,8 @@ export function ProjectSidebar({ project, projectSlug }: ProjectSidebarProps) {
 		isDonationReady,
 		isEscrowDataLoading,
 		progressPercentage,
+		displayReleased,
+		releasedProgressPercent,
 		onChainRaised,
 		isFetchingBalance,
 		isMounted,
@@ -48,11 +45,8 @@ export function ProjectSidebar({ project, projectSlug }: ProjectSidebarProps) {
 		signInHref,
 	} = useProjectSidebar(project, projectSlug)
 
-	const releasedAmount = useMemo(
-		() => calculateReleasedAmount(project.milestones),
-		[project.milestones],
-	)
-	const releasedPercentage = calculateReleasedProgressPercent(releasedAmount, project.goal) ?? 0
+	const releasedAmount = displayReleased ?? 0
+	const releasedPercentage = releasedProgressPercent ?? 0
 
 	return (
 		<motion.div

--- a/apps/web/hooks/projects/use-project-released-display.ts
+++ b/apps/web/hooks/projects/use-project-released-display.ts
@@ -1,0 +1,109 @@
+'use client'
+
+import type { EscrowType, GetEscrowsFromIndexerResponse } from '@trustless-work/escrow'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useOptionalEscrow } from '~/hooks/contexts/use-escrow.context'
+import {
+	calculateReleasedAmountFromEscrow,
+	calculateReleasedProgressPercent,
+	type ReleasableMilestone,
+	resolveDisplayReleasedAmount,
+} from '~/lib/utils/projects/milestone-funding'
+import { projectHasEscrow } from '~/lib/utils/projects/project-funding'
+
+interface UseProjectReleasedDisplayParams {
+	escrowContractAddress?: string | null
+	escrowType?: EscrowType
+	goal?: number | null
+	dbMilestones?: ReadonlyArray<ReleasableMilestone> | null
+	preloadedEscrowData?: GetEscrowsFromIndexerResponse | null
+}
+
+export function useProjectReleasedDisplay({
+	escrowContractAddress,
+	goal,
+	dbMilestones,
+	preloadedEscrowData,
+}: UseProjectReleasedDisplayParams) {
+	const escrow = useOptionalEscrow()
+	const getEscrowByContractIds = escrow?.getEscrowByContractIds
+
+	const hasEscrow = projectHasEscrow({ escrowContractAddress })
+	const [onChainReleasedAmount, setOnChainReleasedAmount] = useState<number | null>(null)
+	const [isLoading, setIsLoading] = useState(false)
+
+	const effectiveOnChainAmount = useMemo(() => {
+		if (preloadedEscrowData) {
+			return calculateReleasedAmountFromEscrow(preloadedEscrowData)
+		}
+		return onChainReleasedAmount
+	}, [preloadedEscrowData, onChainReleasedAmount])
+
+	const fetchReleasedAmount = useCallback(
+		async (showLoading = true) => {
+			if (!escrowContractAddress || !getEscrowByContractIds || preloadedEscrowData) {
+				return
+			}
+
+			try {
+				if (showLoading) setIsLoading(true)
+				const response = await getEscrowByContractIds({
+					contractIds: [escrowContractAddress],
+					validateOnChain: true,
+				})
+				const escrowData = Array.isArray(response) ? response[0] : response
+				setOnChainReleasedAmount(calculateReleasedAmountFromEscrow(escrowData))
+			} catch {
+				setOnChainReleasedAmount(null)
+			} finally {
+				if (showLoading) setIsLoading(false)
+			}
+		},
+		[escrowContractAddress, getEscrowByContractIds, preloadedEscrowData],
+	)
+
+	useEffect(() => {
+		if (!hasEscrow || preloadedEscrowData) {
+			setOnChainReleasedAmount(null)
+			setIsLoading(false)
+			return
+		}
+
+		if (!getEscrowByContractIds) {
+			return
+		}
+
+		fetchReleasedAmount(true)
+
+		const intervalId = setInterval(() => {
+			fetchReleasedAmount(false)
+		}, 10000)
+
+		return () => {
+			clearInterval(intervalId)
+		}
+	}, [fetchReleasedAmount, getEscrowByContractIds, hasEscrow, preloadedEscrowData])
+
+	const displayReleased = useMemo(
+		() =>
+			resolveDisplayReleasedAmount({
+				dbMilestones,
+				escrowContractAddress,
+				onChainReleasedAmount: hasEscrow ? effectiveOnChainAmount : null,
+				isLoadingOnChain: hasEscrow && isLoading && effectiveOnChainAmount === null,
+			}),
+		[dbMilestones, escrowContractAddress, effectiveOnChainAmount, hasEscrow, isLoading],
+	)
+
+	const releasedProgressPercent = useMemo(
+		() =>
+			displayReleased === null ? null : calculateReleasedProgressPercent(displayReleased, goal),
+		[displayReleased, goal],
+	)
+
+	return {
+		displayReleased,
+		releasedProgressPercent,
+		isLoadingReleased: displayReleased === null && hasEscrow,
+	}
+}

--- a/apps/web/lib/queries/projects/get-all-projects.ts
+++ b/apps/web/lib/queries/projects/get-all-projects.ts
@@ -5,7 +5,6 @@ import {
 	resolveProjectEscrowContracts,
 } from '~/lib/queries/projects/resolve-project-escrow-contracts'
 import type { Project } from '~/lib/types/project'
-import { calculateReleasedAmount } from '~/lib/utils/projects/milestone-funding'
 
 export type ProjectListItem = Project & {
 	status?: string
@@ -40,10 +39,6 @@ export async function getAllProjects(
       category:category_id ( * ),
       project_tag_relationships (
         tag:tag_id ( id, name, color )
-      ),
-      milestones (
-        amount,
-        status
       ),
       project_escrows:project_escrows!left (
         escrow_id
@@ -117,13 +112,6 @@ export async function getAllProjects(
 				tags: project.project_tag_relationships.map((r) => r.tag),
 				escrowContractAddress: escrow?.escrowContractAddress,
 				escrowType: escrow?.escrowType,
-				releasedAmount: calculateReleasedAmount(
-					(
-						project as unknown as {
-							milestones?: Array<{ amount: number | string | null; status: string | null }>
-						}
-					).milestones,
-				),
 			} satisfies ProjectListItem
 		}) ?? []
 	)

--- a/apps/web/lib/utils/projects/milestone-funding.ts
+++ b/apps/web/lib/utils/projects/milestone-funding.ts
@@ -1,3 +1,9 @@
+import type {
+	GetEscrowsFromIndexerResponse,
+	MultiReleaseMilestone,
+	SingleReleaseMilestone,
+} from '@trustless-work/escrow'
+import { isMilestoneReleased, isSingleReleaseMilestone } from '~/lib/utils/escrow/milestone-utils'
 import { coerceNumericAmount } from '~/lib/utils/format-currency'
 import { calculateFundingProgressPercent } from '~/lib/utils/projects/project-funding'
 
@@ -33,4 +39,69 @@ export function calculateReleasedProgressPercent(
 	goal?: number | null,
 ): number | null {
 	return calculateFundingProgressPercent(releasedAmount, goal)
+}
+
+/** Sum of amounts for milestones released on-chain in a Trustless Work escrow. */
+export function calculateReleasedAmountFromEscrow(
+	escrow: GetEscrowsFromIndexerResponse | null | undefined,
+): number {
+	if (!escrow) {
+		return 0
+	}
+
+	const escrowReleased = escrow.flags?.released ?? false
+
+	if (escrow.type === 'single-release') {
+		return escrowReleased ? (coerceNumericAmount(escrow.amount) ?? 0) : 0
+	}
+
+	const milestones =
+		(escrow.milestones as (SingleReleaseMilestone | MultiReleaseMilestone)[] | undefined) ?? []
+
+	return milestones.reduce((total, milestone) => {
+		if (!isMilestoneReleased(milestone, escrowReleased)) {
+			return total
+		}
+
+		if (isSingleReleaseMilestone(milestone)) {
+			return total
+		}
+
+		return total + (coerceNumericAmount(milestone.amount) ?? 0)
+	}, 0)
+}
+
+export type ResolveDisplayReleasedParams = {
+	dbMilestones?: ReadonlyArray<ReleasableMilestone> | null
+	escrowContractAddress?: string | null
+	onChainReleasedAmount?: number | null
+	isLoadingOnChain?: boolean
+}
+
+/**
+ * Canonical released amount: on-chain escrow milestone totals when available,
+ * otherwise DB milestone status sum. Returns null while on-chain data is loading.
+ */
+export function resolveDisplayReleasedAmount({
+	dbMilestones,
+	escrowContractAddress,
+	onChainReleasedAmount,
+	isLoadingOnChain = false,
+}: ResolveDisplayReleasedParams): number | null {
+	const hasEscrow = Boolean(escrowContractAddress)
+	const dbReleased = calculateReleasedAmount(dbMilestones)
+
+	if (!hasEscrow) {
+		return dbReleased
+	}
+
+	if (onChainReleasedAmount !== undefined && onChainReleasedAmount !== null) {
+		return onChainReleasedAmount
+	}
+
+	if (isLoadingOnChain) {
+		return null
+	}
+
+	return dbReleased
 }

--- a/apps/web/test/milestone-funding.test.ts
+++ b/apps/web/test/milestone-funding.test.ts
@@ -1,8 +1,29 @@
 import { describe, expect, test } from 'bun:test'
+import type { GetEscrowsFromIndexerResponse } from '@trustless-work/escrow'
 import {
 	calculateReleasedAmount,
+	calculateReleasedAmountFromEscrow,
 	calculateReleasedProgressPercent,
+	resolveDisplayReleasedAmount,
 } from '~/lib/utils/projects/milestone-funding'
+
+const baseEscrow = {
+	contractId: 'CEScrow12345678901234567890123456789012',
+	engagementId: 'project-1',
+	title: 'Test Escrow',
+	description: 'Test description',
+	platformFee: 100,
+	roles: {
+		approver: 'GApprover1234567890123456789012345678901',
+		serviceProvider: 'GService1234567890123456789012345678901',
+		platformAddress: 'GPLATFORM12345678901234567890123456789012',
+		releaseSigner: 'GRelease1234567890123456789012345678901',
+		disputeResolver: 'GDispute1234567890123456789012345678901',
+		receiver: 'GReceiver1234567890123456789012345678901',
+	},
+	flags: { disputed: false, released: false },
+	trustline: { address: 'USDC_ADDRESS', decimals: 7 },
+} as unknown as GetEscrowsFromIndexerResponse
 
 describe('calculateReleasedAmount', () => {
 	test('sums only milestones with released status', () => {
@@ -56,5 +77,95 @@ describe('calculateReleasedProgressPercent', () => {
 		expect(calculateReleasedProgressPercent(50, 0)).toBeNull()
 		expect(calculateReleasedProgressPercent(50, null)).toBeNull()
 		expect(calculateReleasedProgressPercent(50, undefined)).toBeNull()
+	})
+})
+
+describe('calculateReleasedAmountFromEscrow', () => {
+	test('sums only released multi-release milestone amounts', () => {
+		const escrow = {
+			...baseEscrow,
+			type: 'multi-release',
+			milestones: [
+				{ amount: 100, receiver: 'G1', flags: { released: true } },
+				{ amount: 50, receiver: 'G2', flags: { released: false } },
+				{ amount: 30, receiver: 'G3', flags: { released: true } },
+			],
+		} as unknown as GetEscrowsFromIndexerResponse
+
+		expect(calculateReleasedAmountFromEscrow(escrow)).toBe(130)
+	})
+
+	test('returns 0 for multi-release when no milestones are released', () => {
+		const escrow = {
+			...baseEscrow,
+			type: 'multi-release',
+			milestones: [
+				{ amount: 100, receiver: 'G1', flags: { released: false } },
+				{ amount: 50, receiver: 'G2', flags: { released: false } },
+			],
+		} as unknown as GetEscrowsFromIndexerResponse
+
+		expect(calculateReleasedAmountFromEscrow(escrow)).toBe(0)
+	})
+
+	test('returns full amount for single-release when escrow is released', () => {
+		const escrow = {
+			...baseEscrow,
+			type: 'single-release',
+			amount: 500,
+			flags: { disputed: false, released: true },
+			milestones: [{ approved: true }],
+		} as unknown as GetEscrowsFromIndexerResponse
+
+		expect(calculateReleasedAmountFromEscrow(escrow)).toBe(500)
+	})
+
+	test('returns 0 for single-release when escrow is not released', () => {
+		const escrow = {
+			...baseEscrow,
+			type: 'single-release',
+			amount: 500,
+			flags: { disputed: false, released: false },
+			milestones: [{ approved: true }],
+		} as unknown as GetEscrowsFromIndexerResponse
+
+		expect(calculateReleasedAmountFromEscrow(escrow)).toBe(0)
+	})
+
+	test('returns 0 for null or undefined escrow', () => {
+		expect(calculateReleasedAmountFromEscrow(null)).toBe(0)
+		expect(calculateReleasedAmountFromEscrow(undefined)).toBe(0)
+	})
+})
+
+describe('resolveDisplayReleasedAmount', () => {
+	test('returns null while on-chain data is loading for escrow projects', () => {
+		expect(
+			resolveDisplayReleasedAmount({
+				escrowContractAddress: 'CEScrow12345678901234567890123456789012',
+				isLoadingOnChain: true,
+			}),
+		).toBeNull()
+	})
+
+	test('uses on-chain amount when available for escrow projects', () => {
+		expect(
+			resolveDisplayReleasedAmount({
+				escrowContractAddress: 'CEScrow12345678901234567890123456789012',
+				onChainReleasedAmount: 250,
+				isLoadingOnChain: false,
+			}),
+		).toBe(250)
+	})
+
+	test('falls back to DB milestones when project has no escrow', () => {
+		expect(
+			resolveDisplayReleasedAmount({
+				dbMilestones: [
+					{ amount: 100, status: 'released' },
+					{ amount: 50, status: 'pending' },
+				],
+			}),
+		).toBe(100)
 	})
 })


### PR DESCRIPTION
## Summary
- Fix the Released progress bar always showing $0 by calculating totals from Trustless Work on-chain milestone release flags instead of Supabase milestone status.
- Add `calculateReleasedAmountFromEscrow`, `resolveDisplayReleasedAmount`, and `useProjectReleasedDisplay` to mirror the existing Raised/on-chain funding pattern.
- Wire the fix across project hero, project cards, and donation sidebar; reuse existing sidebar escrow data to avoid duplicate indexer calls.

## Test plan
- [ ] Open a project with escrow that has at least one released milestone
- [ ] Confirm Released stat and progress bar on project hero, donation sidebar, and project list cards
- [ ] Verify Released equals the sum of released milestone amounts (matches Milestones tab)
- [ ] Verify Raised still shows current escrow balance
- [x] `bun test apps/web/test/milestone-funding.test.ts`


Made with [Cursor](https://cursor.com)