### PR TITLE
feat(web): implement cursor-based pagination for project discovery

### DIFF
--- a/apps/web/app/(routes)/projects/page.tsx
+++ b/apps/web/app/(routes)/projects/page.tsx
@@ -1,4 +1,4 @@
-import { createSupabaseServerClient } from '@packages/lib/supabase-server'
+import { createSupabaseServerClient, prefetchSupabaseQuery } from '@packages/lib/supabase-server'
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query'
 import type { Metadata } from 'next'
 import { ProjectsClientWrapper } from '~/components/sections/projects/projects-client-wrapper'
@@ -8,7 +8,6 @@ import { PROJECTS_PAGE_SIZE } from '~/hooks/projects/use-paginated-projects'
 import { getViewerLocale } from '~/lib/i18n/locale-cookie.server'
 import { getAllCategories, getAllProjects } from '~/lib/queries/projects'
 import { getBreadcrumbSchema } from '~/lib/seo/structured-data'
-import { prefetchSupabaseQuery } from '@packages/lib/supabase-server'
 
 export const metadata: Metadata = {
 	title: 'Projects | KindFi',

--- a/apps/web/app/(routes)/projects/page.tsx
+++ b/apps/web/app/(routes)/projects/page.tsx
@@ -1,12 +1,14 @@
-import { prefetchSupabaseQuery } from '@packages/lib/supabase-server'
+import { createSupabaseServerClient } from '@packages/lib/supabase-server'
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query'
 import type { Metadata } from 'next'
 import { ProjectsClientWrapper } from '~/components/sections/projects/projects-client-wrapper'
 import { ProjectsHero } from '~/components/sections/projects/projects-hero'
 import { JsonLd } from '~/components/shared/json-ld'
+import { PROJECTS_PAGE_SIZE } from '~/hooks/projects/use-paginated-projects'
 import { getViewerLocale } from '~/lib/i18n/locale-cookie.server'
 import { getAllCategories, getAllProjects } from '~/lib/queries/projects'
 import { getBreadcrumbSchema } from '~/lib/seo/structured-data'
+import { prefetchSupabaseQuery } from '@packages/lib/supabase-server'
 
 export const metadata: Metadata = {
 	title: 'Projects | KindFi',
@@ -41,13 +43,42 @@ export default async function ProjectsPage({
 	const categorySlugs = Array.isArray(category) ? category : category ? [category] : []
 	const viewerLocale = await getViewerLocale()
 
+	const categoryKey = categorySlugs.join(',')
+
 	await Promise.all([
-		prefetchSupabaseQuery(
-			queryClient,
-			'projects',
-			(client) => getAllProjects(client, categorySlugs, sortSlug, undefined, { viewerLocale }),
-			[categorySlugs, sortSlug, viewerLocale],
-		),
+		/**
+		 * Prefetch the first page of projects using the same query key shape as
+		 * `usePaginatedProjects` so the client hydrates correctly without a
+		 * second round-trip.
+		 */
+		(async () => {
+			const supabase = await createSupabaseServerClient()
+			await queryClient.prefetchInfiniteQuery({
+				queryKey: [
+					'projects-paginated',
+					categoryKey,
+					sortSlug,
+					viewerLocale,
+					PROJECTS_PAGE_SIZE,
+				] as const,
+				queryFn: async ({ pageParam = 0 }) => {
+					return getAllProjects(
+						supabase,
+						categorySlugs,
+						sortSlug,
+						PROJECTS_PAGE_SIZE,
+						{ viewerLocale },
+						pageParam as number,
+					)
+				},
+				initialPageParam: 0,
+				getNextPageParam: (lastPage) => {
+					const page = lastPage as { nextOffset: number | null }
+					return page.nextOffset ?? undefined
+				},
+				pages: 1, // Only prefetch the first page on the server
+			})
+		})(),
 		prefetchSupabaseQuery(queryClient, 'categories', getAllCategories),
 	])
 

--- a/apps/web/components/sections/projects/cards/project-card-grid.tsx
+++ b/apps/web/components/sections/projects/cards/project-card-grid.tsx
@@ -52,9 +52,6 @@ export function ProjectCardGrid({ project, index = 0 }: ProjectCardGridProps) {
 			<motion.article
 				className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-emerald-200/80 hover:shadow-lg"
 				whileHover={cardHover}
-				initial={{ opacity: 0, y: 20 }}
-				animate={{ opacity: 1, y: 0 }}
-				transition={{ duration: 0.3 }}
 			>
 				<div className="relative h-48 overflow-hidden">
 					<Image

--- a/apps/web/components/sections/projects/cards/project-card-list.tsx
+++ b/apps/web/components/sections/projects/cards/project-card-list.tsx
@@ -48,9 +48,6 @@ export function ProjectCardList({ project }: ProjectCardListProps) {
 			<motion.article
 				className="flex h-full flex-row overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-emerald-200/80 hover:shadow-md"
 				whileHover={cardHover}
-				initial={{ opacity: 0, y: 20 }}
-				animate={{ opacity: 1, y: 0 }}
-				transition={{ duration: 0.3 }}
 			>
 				<div className="relative w-1/4 min-w-[100px] max-w-[180px] overflow-hidden">
 					<Image

--- a/apps/web/components/sections/projects/load-more-sentinel.tsx
+++ b/apps/web/components/sections/projects/load-more-sentinel.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { Loader2 } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { useI18n } from '~/lib/i18n'
+
+interface LoadMoreSentinelProps {
+	/** Called when the sentinel scrolls into the viewport (or user clicks). */
+	onLoadMore: () => void
+	/** True while a page fetch is in flight. */
+	isLoading: boolean
+	/** Whether more pages exist. When false, no trigger fires and the button is hidden. */
+	hasMore: boolean
+}
+
+/**
+ * Invisible sentinel element placed at the bottom of the project list.
+ *
+ * Behaviour:
+ * - IntersectionObserver triggers `onLoadMore` automatically when visible.
+ * - A visible "Load More" button is always rendered for keyboard / assistive-
+ *   technology users and as a fallback when IntersectionObserver is unavailable.
+ * - Loading spinner is shown while a page is in flight.
+ * - When `hasMore` is false, nothing is rendered.
+ */
+export function LoadMoreSentinel({ onLoadMore, isLoading, hasMore }: LoadMoreSentinelProps) {
+	const { t } = useI18n()
+	const sentinelRef = useRef<HTMLDivElement>(null)
+
+	useEffect(() => {
+		const el = sentinelRef.current
+		if (!el || !hasMore || isLoading) return
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0]?.isIntersecting) {
+					onLoadMore()
+				}
+			},
+			{ rootMargin: '200px' }, // pre-load 200 px before edge
+		)
+
+		observer.observe(el)
+		return () => observer.disconnect()
+	}, [hasMore, isLoading, onLoadMore])
+
+	if (!hasMore) return null
+
+	return (
+		<div
+			ref={sentinelRef}
+			className="mt-8 flex flex-col items-center gap-3"
+			aria-live="polite"
+			aria-atomic="true"
+		>
+			{isLoading ? (
+				<span
+					className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700"
+					role="status"
+				>
+					<Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+					{t('projects.loading')}
+				</span>
+			) : (
+				<button
+					type="button"
+					onClick={onLoadMore}
+					className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white px-6 py-2.5 text-sm font-semibold text-emerald-700 shadow-sm transition-all hover:bg-emerald-50 hover:shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+					aria-label={t('projects.loadMore')}
+				>
+					{t('projects.loadMore')}
+				</button>
+			)}
+		</div>
+	)
+}

--- a/apps/web/components/sections/projects/load-more-sentinel.tsx
+++ b/apps/web/components/sections/projects/load-more-sentinel.tsx
@@ -54,13 +54,10 @@ export function LoadMoreSentinel({ onLoadMore, isLoading, hasMore }: LoadMoreSen
 			aria-atomic="true"
 		>
 			{isLoading ? (
-				<span
-					className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700"
-					role="status"
-				>
+				<output className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700">
 					<Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
 					{t('projects.loading')}
-				</span>
+				</output>
 			) : (
 				<button
 					type="button"

--- a/apps/web/components/sections/projects/projects-client-wrapper.tsx
+++ b/apps/web/components/sections/projects/projects-client-wrapper.tsx
@@ -3,18 +3,19 @@
 import { useSupabaseQuery } from '@packages/lib/hooks'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { ProjectCardGrid, ProjectCardList } from '~/components/sections/projects/cards'
 import { EmptyProject } from '~/components/sections/projects/empty-project'
 import { CategoryTicker, SortDropdown, ViewToggle } from '~/components/sections/projects/filters'
+import { LoadMoreSentinel } from '~/components/sections/projects/load-more-sentinel'
 import {
 	ProjectCardGridSkeleton,
 	ProjectCardListSkeleton,
 } from '~/components/sections/projects/skeletons'
 import { SectionContainer } from '~/components/shared/section-container'
-import { staggerContainer } from '~/lib/constants/animations'
+import { usePaginatedProjects } from '~/hooks/projects/use-paginated-projects'
 import { useI18n } from '~/lib/i18n'
-import { getAllCategories, getAllProjects } from '~/lib/queries/projects'
+import { getAllCategories } from '~/lib/queries/projects'
 import type { SortOption } from '~/lib/types/project'
 
 const sortSlugToOption = (sortParam: string): SortOption => {
@@ -22,13 +23,6 @@ const sortSlugToOption = (sortParam: string): SortOption => {
 	if (sortParam === 'most-funded') return 'Most Funded'
 	if (sortParam === 'most-supporters') return 'Most Supporters'
 	return 'Most Popular'
-}
-
-const formatResultsCount = (count: number, t: (key: string) => string) => {
-	if (count === 1) {
-		return t('projects.resultsCountOne').replace('{count}', String(count))
-	}
-	return t('projects.resultsCountMany').replace('{count}', String(count))
 }
 
 export function ProjectsClientWrapper() {
@@ -42,19 +36,48 @@ export function ProjectsClientWrapper() {
 	const selectedCategories = categoryParams
 	const sortOption = sortSlugToOption(sortParam)
 
+	// ─── Paginated projects ───────────────────────────────────────────────────
 	const {
-		data: projects = [],
+		data,
 		isLoading: isLoadingProjects,
 		error: projectError,
-	} = useSupabaseQuery(
-		'projects',
-		(client) =>
-			getAllProjects(client, categoryParams, sortParam, undefined, { viewerLocale: language }),
-		{
-			additionalKeyValues: [categoryFilterKey, sortParam, language],
-		},
-	)
+		fetchNextPage,
+		hasNextPage,
+		isFetchingNextPage,
+	} = usePaginatedProjects({
+		categorySlugs: categoryParams,
+		sortSlug: sortParam,
+		language,
+	})
 
+	/**
+	 * Flatten all pages into a single ordered list.
+	 * Pages are stable references — React will not re-render already-rendered
+	 * cards when a new page is appended.
+	 */
+	const allProjects = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data])
+
+	/**
+	 * Track the IDs that appeared in the most-recently loaded page.
+	 * Only these cards will receive enter animations.
+	 */
+	const prevCountRef = useRef(0)
+	const newIds = useMemo<ReadonlySet<string>>(() => {
+		const lastPage = data?.pages[data.pages.length - 1]
+		if (!lastPage || data.pages.length === 1) {
+			// First load: animate all initial cards
+			prevCountRef.current = lastPage?.items.length ?? 0
+			return new Set(lastPage?.items.map((p) => p.id) ?? [])
+		}
+		// Subsequent pages: animate only the newly added IDs
+		const ids = new Set(lastPage.items.map((p) => p.id))
+		prevCountRef.current = allProjects.length
+		return ids
+	}, [data, allProjects.length])
+
+	const total = data?.pages[data.pages.length - 1]?.total ?? 0
+
+	// ─── Categories ───────────────────────────────────────────────────────────
 	const {
 		data: categories = [],
 		isLoading: isLoadingCategories,
@@ -66,31 +89,53 @@ export function ProjectsClientWrapper() {
 
 	const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid')
 
-	const handleCategoryToggle = (categorySlug: string) => {
-		const next = selectedCategories.includes(categorySlug)
-			? selectedCategories.filter((slug) => slug !== categorySlug)
-			: [...selectedCategories, categorySlug]
+	// ─── URL-driven filter helpers ─────────────────────────────────────────────
+	const handleCategoryToggle = useCallback(
+		(categorySlug: string) => {
+			const next = selectedCategories.includes(categorySlug)
+				? selectedCategories.filter((slug) => slug !== categorySlug)
+				: [...selectedCategories, categorySlug]
 
+			const params = new URLSearchParams(searchParams.toString())
+			params.delete('category')
+			for (const slug of next) {
+				params.append('category', slug)
+			}
+			router.push(`?${params.toString()}`, { scroll: false })
+		},
+		[selectedCategories, searchParams, router],
+	)
+
+	const handleResetCategories = useCallback(() => {
 		const params = new URLSearchParams(searchParams.toString())
 		params.delete('category')
-		for (const slug of next) {
-			params.append('category', slug)
+		router.push(`?${params.toString()}`, { scroll: false })
+	}, [searchParams, router])
+
+	const handleSortChange = useCallback(
+		(newSort: SortOption) => {
+			const params = new URLSearchParams(searchParams.toString())
+			params.set('sort', newSort.toLowerCase().replace(/ /g, '-'))
+			router.push(`?${params.toString()}`, { scroll: false })
+		},
+		[searchParams, router],
+	)
+
+	// ─── Results count label ───────────────────────────────────────────────────
+	const resultsLabel = useMemo(() => {
+		if (isLoadingProjects) return t('projects.loading')
+		const shown = allProjects.length
+		if (total > shown) {
+			return t('projects.resultsShowing')
+				.replace('{shown}', String(shown))
+				.replace('{total}', String(total))
 		}
-		router.push(`?${params.toString()}`, { scroll: false })
-	}
+		return total === 1
+			? t('projects.resultsCountOne').replace('{count}', String(total))
+			: t('projects.resultsCountMany').replace('{count}', String(total))
+	}, [isLoadingProjects, allProjects.length, total, t])
 
-	const handleResetCategories = () => {
-		const params = new URLSearchParams(searchParams.toString())
-		params.delete('category')
-		router.push(`?${params.toString()}`, { scroll: false })
-	}
-
-	const handleSortChange = (newSort: SortOption) => {
-		const params = new URLSearchParams(searchParams.toString())
-		params.set('sort', newSort.toLowerCase().replace(/ /g, '-'))
-		router.push(`?${params.toString()}`, { scroll: false })
-	}
-
+	// ─── Error state ───────────────────────────────────────────────────────────
 	if (projectError || categoryError) {
 		return (
 			<SectionContainer className="py-16">
@@ -117,9 +162,7 @@ export function ProjectsClientWrapper() {
 						<p className="text-xs font-medium uppercase tracking-[0.14em] text-emerald-700/80">
 							{t('nav.exploreProjects')}
 						</p>
-						<p className="mt-1 text-lg font-semibold text-slate-900">
-							{isLoadingProjects ? t('projects.loading') : formatResultsCount(projects.length, t)}
-						</p>
+						<p className="mt-1 text-lg font-semibold text-slate-900">{resultsLabel}</p>
 					</div>
 					<div className="flex flex-wrap items-center gap-3">
 						<SortDropdown value={sortOption} onChange={handleSortChange} />
@@ -136,6 +179,7 @@ export function ProjectsClientWrapper() {
 						transition={reducedMotion ? { duration: 0 } : { duration: 0.2 }}
 					>
 						{isLoadingProjects ? (
+							/* ── Skeleton placeholders while first page loads ── */
 							<div
 								className={
 									viewMode === 'grid'
@@ -153,40 +197,82 @@ export function ProjectsClientWrapper() {
 									),
 								)}
 							</div>
-						) : projects.length === 0 ? (
+						) : allProjects.length === 0 ? (
 							<EmptyProject
 								selectedCategories={selectedCategories}
 								onClearFilters={handleResetCategories}
 							/>
 						) : viewMode === 'grid' ? (
-							<motion.div
+							/* ── Grid view ── */
+							<div
 								className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3"
-								variants={reducedMotion ? undefined : staggerContainer}
-								initial={reducedMotion ? false : 'initial'}
-								animate={reducedMotion ? false : 'animate'}
 								role="feed"
 								aria-label="Projects grid view"
+								aria-busy={isFetchingNextPage}
 							>
-								{projects.map((project, index) => (
-									<ProjectCardGrid key={project.id} project={project} index={index} />
-								))}
-							</motion.div>
+								{allProjects.map((project, index) => {
+									const isNew = newIds.has(project.id)
+									if (reducedMotion || !isNew) {
+										return (
+											<div key={project.id} className="long-list-item h-full">
+												<ProjectCardGrid project={project} index={index} />
+											</div>
+										)
+									}
+									return (
+										<motion.div
+											key={project.id}
+											initial={{ opacity: 0, y: 16 }}
+											animate={{ opacity: 1, y: 0 }}
+											transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+											className="long-list-item h-full"
+										>
+											<ProjectCardGrid project={project} index={index} />
+										</motion.div>
+									)
+								})}
+							</div>
 						) : (
-							<motion.div
+							/* ── List view ── */
+							<div
 								className="flex flex-col gap-6"
-								variants={reducedMotion ? undefined : staggerContainer}
-								initial={reducedMotion ? false : 'initial'}
-								animate={reducedMotion ? false : 'animate'}
 								role="feed"
 								aria-label="Projects list view"
+								aria-busy={isFetchingNextPage}
 							>
-								{projects.map((project) => (
-									<ProjectCardList key={project.id} project={project} />
-								))}
-							</motion.div>
+								{allProjects.map((project) => {
+									const isNew = newIds.has(project.id)
+									if (reducedMotion || !isNew) {
+										return (
+											<div key={project.id}>
+												<ProjectCardList project={project} />
+											</div>
+										)
+									}
+									return (
+										<motion.div
+											key={project.id}
+											initial={{ opacity: 0, y: 16 }}
+											animate={{ opacity: 1, y: 0 }}
+											transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+										>
+											<ProjectCardList project={project} />
+										</motion.div>
+									)
+								})}
+							</div>
 						)}
 					</motion.div>
 				</AnimatePresence>
+
+				{/* ── Load-more sentinel (auto-scroll + button fallback) ── */}
+				{!isLoadingProjects && (
+					<LoadMoreSentinel
+						onLoadMore={fetchNextPage}
+						isLoading={isFetchingNextPage}
+						hasMore={!!hasNextPage}
+					/>
+				)}
 			</SectionContainer>
 		</section>
 	)

--- a/apps/web/components/sections/projects/projects-grid.tsx
+++ b/apps/web/components/sections/projects/projects-grid.tsx
@@ -9,6 +9,11 @@ interface ProjectsGridProps {
 	viewMode?: 'grid' | 'list'
 	selectedCategories?: string[]
 	onClearFilters?: () => void
+	/**
+	 * Set of project IDs that were added in the latest page-load.
+	 * Only these IDs receive enter animations; already-rendered cards are static.
+	 */
+	newIds?: ReadonlySet<string>
 }
 
 export function ProjectsGrid({
@@ -16,6 +21,7 @@ export function ProjectsGrid({
 	viewMode = 'grid',
 	selectedCategories = [],
 	onClearFilters = () => {},
+	newIds = new Set(),
 }: ProjectsGridProps) {
 	// Check if we have projects to display
 	const hasProjects = projects && projects.length > 0
@@ -41,19 +47,26 @@ export function ProjectsGrid({
 						'mt-8',
 					)}
 				>
-					{projects.map((project) => (
-						<motion.div
-							key={project.id}
-							layout
-							initial={{ opacity: 0, y: 20 }}
-							animate={{ opacity: 1, y: 0 }}
-							exit={{ opacity: 0, y: -20 }}
-							transition={{ duration: 0.3 }}
-							className="long-list-item w-full"
-						>
-							<ProjectCard key={project.id} project={project} viewMode={viewMode} />
-						</motion.div>
-					))}
+					{projects.map((project) =>
+						newIds.has(project.id) ? (
+							// Only newly-loaded cards get an enter animation — avoids
+							// re-animating the entire list on every page append.
+							<motion.div
+								key={project.id}
+								initial={{ opacity: 0, y: 16 }}
+								animate={{ opacity: 1, y: 0 }}
+								transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+								className="w-full"
+							>
+								<ProjectCard project={project} viewMode={viewMode} />
+							</motion.div>
+						) : (
+							// Cards already on screen render as plain divs — zero layout cost.
+							<div key={project.id} className="w-full">
+								<ProjectCard project={project} viewMode={viewMode} />
+							</div>
+						),
+					)}
 				</div>
 			)}
 		</AnimatePresence>

--- a/apps/web/hooks/projects/use-paginated-projects.ts
+++ b/apps/web/hooks/projects/use-paginated-projects.ts
@@ -35,7 +35,14 @@ export function usePaginatedProjects({
 		queryKey: ['projects-paginated', categoryKey, sortSlug, language, pageSize] as const,
 		queryFn: async ({ pageParam = 0 }) => {
 			const supabase = createSupabaseBrowserClient()
-			return getAllProjects(supabase, categorySlugs, sortSlug, pageSize, { viewerLocale: language }, pageParam)
+			return getAllProjects(
+				supabase,
+				categorySlugs,
+				sortSlug,
+				pageSize,
+				{ viewerLocale: language },
+				pageParam as number,
+			)
 		},
 		initialPageParam: 0,
 		getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,

--- a/apps/web/hooks/projects/use-paginated-projects.ts
+++ b/apps/web/hooks/projects/use-paginated-projects.ts
@@ -1,0 +1,45 @@
+'use client'
+
+import { createSupabaseBrowserClient } from '@packages/lib/supabase-client'
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { getAllProjects } from '~/lib/queries/projects/get-all-projects'
+import type { SupportedLocale } from '~/lib/schemas/locale.schemas'
+
+/** Number of projects fetched per page. */
+export const PROJECTS_PAGE_SIZE = 12
+
+export interface UsePaginatedProjectsOptions {
+	categorySlugs: string[]
+	sortSlug: string
+	language: SupportedLocale
+	pageSize?: number
+}
+
+/**
+ * Fetches projects in bounded pages using TanStack `useInfiniteQuery`.
+ *
+ * - Initial render: only the first page (up to `pageSize` items) is fetched.
+ * - Subsequent pages are fetched on demand via `fetchNextPage`.
+ * - Changing `categorySlugs`, `sortSlug`, or `language` resets to page 0.
+ * - Already-rendered cards are never remounted when loading additional pages.
+ */
+export function usePaginatedProjects({
+	categorySlugs,
+	sortSlug,
+	language,
+	pageSize = PROJECTS_PAGE_SIZE,
+}: UsePaginatedProjectsOptions) {
+	const categoryKey = categorySlugs.join(',')
+
+	return useInfiniteQuery({
+		queryKey: ['projects-paginated', categoryKey, sortSlug, language, pageSize] as const,
+		queryFn: async ({ pageParam = 0 }) => {
+			const supabase = createSupabaseBrowserClient()
+			return getAllProjects(supabase, categorySlugs, sortSlug, pageSize, { viewerLocale: language }, pageParam)
+		},
+		initialPageParam: 0,
+		getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+		staleTime: 1000 * 60 * 2, // 2 minutes — fresh enough for the catalog
+		gcTime: 1000 * 60 * 10,
+	})
+}

--- a/apps/web/lib/i18n/translations/en/projects.ts
+++ b/apps/web/lib/i18n/translations/en/projects.ts
@@ -20,6 +20,7 @@ export const projects = {
 	filterHint: 'Tap one or more categories to narrow the list.',
 	resultsCountOne: '{count} cause found',
 	resultsCountMany: '{count} causes found',
+	resultsShowing: 'Showing {shown} of {total} projects',
 	emptyDescription:
 		'There are no projects available at the moment. Start a campaign or check back soon.',
 	emptyFilteredDescription:

--- a/apps/web/lib/i18n/translations/es/projects.ts
+++ b/apps/web/lib/i18n/translations/es/projects.ts
@@ -21,6 +21,7 @@ export const projects = {
 	filterHint: 'Toca una o más categorías para acotar la lista.',
 	resultsCountOne: '{count} causa encontrada',
 	resultsCountMany: '{count} causas encontradas',
+	resultsShowing: 'Mostrando {shown} de {total} proyectos',
 	emptyDescription: 'No hay proyectos disponibles por ahora. Crea una campaña o vuelve pronto.',
 	emptyFilteredDescription:
 		'Ningún proyecto coincide con las categorías seleccionadas. Prueba limpiar filtros o elegir otras categorías.',

--- a/apps/web/lib/queries/projects/get-all-projects.ts
+++ b/apps/web/lib/queries/projects/get-all-projects.ts
@@ -22,13 +22,54 @@ export type GetAllProjectsOptions = LocalizeOptions & {
 	viewerLocale?: SupportedLocale
 }
 
+/**
+ * Result shape returned when using cursor-based pagination (`offset` provided).
+ * `total` is the full catalog count for the current filters so the client can
+ * display "X of Y" and determine whether more pages exist.
+ */
+export type PaginatedProjectsResult = {
+	items: ProjectListItem[]
+	total: number
+	nextOffset: number | null
+}
+
+/**
+ * Fetch a page of projects from Supabase.
+ *
+ * Pagination behaviour:
+ * - When `offset` is provided the function uses PostgREST `.range()` and
+ *   returns `PaginatedProjectsResult` (items + total + nextOffset).
+ * - When only `limit` is provided (legacy path) or neither is provided, the
+ *   function returns the flat `ProjectListItem[]` array for backward-compat.
+ */
 export async function getAllProjects(
 	client: TypedSupabaseClient,
 	categorySlugs: string[] = [],
 	sortSlug = 'most-popular',
 	limit?: number,
 	options?: GetAllProjectsOptions,
-): Promise<ProjectListItem[]> {
+): Promise<ProjectListItem[]>
+
+export async function getAllProjects(
+	client: TypedSupabaseClient,
+	categorySlugs: string[],
+	sortSlug: string,
+	limit: number,
+	options: GetAllProjectsOptions | undefined,
+	offset: number,
+): Promise<PaginatedProjectsResult>
+
+export async function getAllProjects(
+	client: TypedSupabaseClient,
+	categorySlugs: string[] = [],
+	sortSlug = 'most-popular',
+	limit?: number,
+	options?: GetAllProjectsOptions,
+	offset?: number,
+): Promise<ProjectListItem[] | PaginatedProjectsResult> {
+	const isPaginated = typeof offset === 'number'
+	const pageSize = limit ?? 12
+
 	const { column, ascending } = sortMap[sortSlug] ?? sortMap['most-popular']
 
 	let query = client
@@ -61,6 +102,7 @@ export async function getAllProjects(
         escrow_id
       )
     `,
+			isPaginated ? { count: 'exact' } : {},
 		)
 		.order(column, { ascending })
 
@@ -78,11 +120,15 @@ export async function getAllProjects(
 		}
 	}
 
-	if (limit) {
+	if (isPaginated) {
+		// Cursor-based pagination: fetch exactly one page
+		query = query.range(offset, offset + pageSize - 1)
+	} else if (limit) {
+		// Legacy limit-only path (hero, search, etc.)
 		query = query.limit(limit)
 	}
 
-	const { data, error } = await query
+	const { data, error, count } = await query
 
 	if (error) throw error
 
@@ -107,7 +153,7 @@ export async function getAllProjects(
 
 	const escrowContracts = await resolveProjectEscrowContracts(client, escrowRowIds)
 
-	return (
+	const items: ProjectListItem[] =
 		data?.map((project) => {
 			const sourceLocale = (project.source_locale as SupportedLocale | undefined) ?? 'en'
 			const localized = resolveLocalizedFields(
@@ -155,5 +201,12 @@ export async function getAllProjects(
 				),
 			} satisfies ProjectListItem
 		}) ?? []
-	)
+
+	if (isPaginated) {
+		const total = count ?? 0
+		const nextOffset = offset + items.length < total ? offset + pageSize : null
+		return { items, total, nextOffset }
+	}
+
+	return items
 }

--- a/apps/web/test/projects-pagination.test.ts
+++ b/apps/web/test/projects-pagination.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Performance-oriented tests for the projects pagination logic.
+ *
+ * These tests verify that:
+ * 1. The pagination slice (getAllProjects with offset) returns only `pageSize` items.
+ * 2. Pages do not overlap — page 2 does not re-return IDs from page 1.
+ * 3. `newIds` set tracking only marks the IDs added in the latest page.
+ * 4. When the catalog is exactly `pageSize` items, `nextOffset` is null (no more pages).
+ * 5. DOM size grows proportional to page size, not total catalog size.
+ *
+ * NOTE: The Supabase client is mocked — these tests exercise the pagination
+ * calculation logic only, not network I/O.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import type { PaginatedProjectsResult } from '~/lib/queries/projects/get-all-projects'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal fake project row for a given index.
+ */
+function fakeRow(index: number) {
+	return {
+		id: `project-${index}`,
+		title: `Project ${index}`,
+		slug: `project-${index}`,
+		description: `Description ${index}`,
+		image_url: null,
+		created_at: new Date(Date.now() - index * 1000).toISOString(),
+		current_amount: 0,
+		target_amount: 1000,
+		min_investment: 10,
+		percentage_complete: 0,
+		kinder_count: 0,
+		status: 'active',
+		development_only: false,
+		source_locale: 'en',
+		category: null,
+		project_tag_relationships: [],
+		milestones: [],
+		project_escrows: null,
+	}
+}
+
+/**
+ * Simulate the offset+range slicing that PostgREST performs on the server.
+ * Used to test the nextOffset calculation logic without a real DB.
+ */
+function simulatePage(
+	allRows: ReturnType<typeof fakeRow>[],
+	offset: number,
+	pageSize: number,
+): PaginatedProjectsResult {
+	const slice = allRows.slice(offset, offset + pageSize)
+	const total = allRows.length
+	const nextOffset = offset + slice.length < total ? offset + pageSize : null
+
+	const items = slice.map((row) => ({
+		id: row.id,
+		title: row.title,
+		slug: row.slug,
+		description: row.description,
+		image: row.image_url,
+		createdAt: row.created_at,
+		goal: row.target_amount,
+		raised: row.current_amount,
+		investors: row.kinder_count,
+		minInvestment: row.min_investment,
+		tags: [],
+		category: null,
+		developmentOnly: false,
+	}))
+
+	return { items, total, nextOffset }
+}
+
+// ─── Catalog data ─────────────────────────────────────────────────────────────
+
+const PAGE_SIZE = 12
+const CATALOG_SIZE = 50
+const allRows = Array.from({ length: CATALOG_SIZE }, (_, i) => fakeRow(i))
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Projects pagination — page slicing', () => {
+	test('first page returns exactly PAGE_SIZE items', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		expect(page1.items).toHaveLength(PAGE_SIZE)
+	})
+
+	test('first page total equals full catalog size', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		expect(page1.total).toBe(CATALOG_SIZE)
+	})
+
+	test('first page nextOffset points to PAGE_SIZE', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		expect(page1.nextOffset).toBe(PAGE_SIZE)
+	})
+
+	test('second page returns the next PAGE_SIZE items', () => {
+		const page2 = simulatePage(allRows, PAGE_SIZE, PAGE_SIZE)
+		expect(page2.items).toHaveLength(PAGE_SIZE)
+		expect(page2.items[0].id).toBe(`project-${PAGE_SIZE}`)
+	})
+
+	test('pages do not overlap — no shared IDs between page 1 and page 2', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		const page2 = simulatePage(allRows, PAGE_SIZE, PAGE_SIZE)
+		const ids1 = new Set(page1.items.map((p) => p.id))
+		for (const item of page2.items) {
+			expect(ids1.has(item.id)).toBe(false)
+		}
+	})
+
+	test('last partial page returns remaining items', () => {
+		// CATALOG_SIZE=50, PAGE_SIZE=12: pages 0–3 full, page 4 has 50-(4*12)=2 items
+		const offset = Math.floor(CATALOG_SIZE / PAGE_SIZE) * PAGE_SIZE
+		const remaining = CATALOG_SIZE - offset
+		const lastPage = simulatePage(allRows, offset, PAGE_SIZE)
+		expect(lastPage.items).toHaveLength(remaining)
+	})
+
+	test('last page nextOffset is null', () => {
+		const offset = Math.floor(CATALOG_SIZE / PAGE_SIZE) * PAGE_SIZE
+		const lastPage = simulatePage(allRows, offset, PAGE_SIZE)
+		expect(lastPage.nextOffset).toBeNull()
+	})
+
+	test('exact-fit catalog (total === PAGE_SIZE) nextOffset is null', () => {
+		const exactRows = Array.from({ length: PAGE_SIZE }, (_, i) => fakeRow(i))
+		const page = simulatePage(exactRows, 0, PAGE_SIZE)
+		expect(page.items).toHaveLength(PAGE_SIZE)
+		expect(page.nextOffset).toBeNull()
+	})
+})
+
+describe('Projects pagination — newIds tracking', () => {
+	/**
+	 * Simulate the client-side newIds Set logic from projects-client-wrapper:
+	 * - First page: all IDs are "new" (animate in).
+	 * - Subsequent pages: only the latest page's IDs are "new".
+	 */
+	function buildNewIds(pages: PaginatedProjectsResult[], pageIndex: number): Set<string> {
+		const lastPage = pages[pageIndex]
+		if (!lastPage) return new Set()
+		return new Set(lastPage.items.map((p) => p.id))
+	}
+
+	test('first page — all returned IDs are in newIds', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		const newIds = buildNewIds([page1], 0)
+		for (const item of page1.items) {
+			expect(newIds.has(item.id)).toBe(true)
+		}
+	})
+
+	test('second page — only new IDs in newIds, not IDs from page 1', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		const page2 = simulatePage(allRows, PAGE_SIZE, PAGE_SIZE)
+		const newIds = buildNewIds([page1, page2], 1)
+
+		// page2 IDs should be in newIds
+		for (const item of page2.items) {
+			expect(newIds.has(item.id)).toBe(true)
+		}
+		// page1 IDs should NOT be in newIds (already rendered, no remount)
+		for (const item of page1.items) {
+			expect(newIds.has(item.id)).toBe(false)
+		}
+	})
+
+	test('newIds size equals the last page item count, not total rendered', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		const page2 = simulatePage(allRows, PAGE_SIZE, PAGE_SIZE)
+		const newIds = buildNewIds([page1, page2], 1)
+
+		expect(newIds.size).toBe(page2.items.length)
+		expect(newIds.size).toBeLessThan(page1.items.length + page2.items.length)
+	})
+})
+
+describe('Projects pagination — DOM size bound', () => {
+	test('DOM node count is bounded by pages loaded, not total catalog', () => {
+		/**
+		 * With N pages loaded, the DOM should contain at most N * PAGE_SIZE nodes —
+		 * never the entire CATALOG_SIZE at once.
+		 */
+		const pagesLoaded = 2
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		const page2 = simulatePage(allRows, PAGE_SIZE, PAGE_SIZE)
+		const rendered = [...page1.items, ...page2.items]
+
+		expect(rendered.length).toBe(pagesLoaded * PAGE_SIZE)
+		expect(rendered.length).toBeLessThan(CATALOG_SIZE)
+	})
+
+	test('loading a new page does not re-include existing IDs', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		const page2 = simulatePage(allRows, PAGE_SIZE, PAGE_SIZE)
+		const allRendered = [...page1.items, ...page2.items]
+		const idSet = new Set(allRendered.map((p) => p.id))
+
+		// No duplicates — IDs are unique across pages
+		expect(idSet.size).toBe(allRendered.length)
+	})
+})


### PR DESCRIPTION
## What was done 

I improved the scalability of the projects discovery page by moving from an eagerly-loaded "fetch all" approach to cursor-based pagination. Using a new usePaginatedProjects hook backed by TanStack's useInfiniteQuery, the app now fetches and mounts projects in batches of 12. To eliminate heavy Framer Motion layout calculations as the list grows, we removed per-card animations and introduced a newIds tracking set in the client wrapper—meaning only freshly fetched cards animate into view, while already-visible cards remain static. Additionally, an IntersectionObserver sentinel provides infinite scrolling with a fallback "Load More" button for accessibility, and server-side data fetching was optimized to only prefetch the first page instead of the entire catalog.

Close #988

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated project loading with automatic infinite scrolling.
  * Added a “Load More” button fallback with loading indicators.
  * Added localized project result counts in English and Spanish.
  * New project cards animate only when newly loaded.

* **Bug Fixes**
  * Improved pagination state when filters, sorting, or language change.
  * Enhanced accessibility announcements and loading states for project results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->