### PR TITLE
fix(donation-stream): pause polling on hidden tabs, prevent overlappi…

### DIFF
--- a/apps/web/app/api/projects/[slug]/donations/stream/route.ts
+++ b/apps/web/app/api/projects/[slug]/donations/stream/route.ts
@@ -1,9 +1,15 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import { unstable_cache } from 'next/cache'
 import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
 import { getProjectIdBySlug } from '~/lib/api/authorize-project-manage'
 import { getProjectDonationStream } from '~/lib/queries/projects/get-project-donation-stream'
 import { validateProjectSlug } from '~/lib/validation/project-slug'
+
+const getProjectIdBySlugCached = unstable_cache(getProjectIdBySlug, ['project-id-by-slug'], {
+	revalidate: 300,
+	tags: ['project-slug'],
+})
 
 export async function GET(req: Request, { params }: { params: Promise<{ slug: string }> }) {
 	try {
@@ -13,7 +19,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ slug: st
 			return NextResponse.json({ error: 'Invalid project slug' }, { status: 400 })
 		}
 
-		const projectId = await getProjectIdBySlug(slug)
+		const projectId = await getProjectIdBySlugCached(slug)
 		if (!projectId) {
 			return NextResponse.json({ error: 'Project not found' }, { status: 404 })
 		}
@@ -21,8 +27,9 @@ export async function GET(req: Request, { params }: { params: Promise<{ slug: st
 		const url = new URL(req.url)
 		const limitParam = Number(url.searchParams.get('limit') ?? 15)
 		const limit = Number.isFinite(limitParam) ? limitParam : 15
+		const after = url.searchParams.get('after') ?? undefined
 
-		const data = await getProjectDonationStream(supabaseServiceRole, projectId, limit)
+		const data = await getProjectDonationStream(supabaseServiceRole, projectId, limit, after)
 
 		return NextResponse.json({ data })
 	} catch (error) {

--- a/apps/web/hooks/projects/use-donation-stream.ts
+++ b/apps/web/hooks/projects/use-donation-stream.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { DonationStreamItem } from '~/lib/queries/projects/get-project-donation-stream'
 
 interface UseDonationStreamParams {
@@ -18,27 +18,48 @@ export function useDonationStream({
 	const [isLoading, setIsLoading] = useState(false)
 	const [error, setError] = useState<unknown>(null)
 
-	const fetchDonations = useCallback(
-		async (showLoading = true) => {
-			if (!projectSlug) return
+	const isFetchingRef = useRef(false)
+	const latestDonatedAtRef = useRef<string | undefined>(undefined)
 
+	const fetchDonations = useCallback(
+		async (showLoading = true, after?: string) => {
+			if (!projectSlug || isFetchingRef.current) return
+
+			isFetchingRef.current = true
 			try {
 				if (showLoading) setIsLoading(true)
 				setError(null)
 
-				const response = await fetch(
-					`/api/projects/${encodeURIComponent(projectSlug)}/donations/stream?limit=${limit}`,
+				const url = new URL(
+					`/api/projects/${encodeURIComponent(projectSlug)}/donations/stream`,
+					window.location.origin,
 				)
+				url.searchParams.set('limit', String(limit))
+				if (after) url.searchParams.set('after', after)
+
+				const response = await fetch(url.toString())
 
 				if (!response.ok) {
 					throw new Error('Failed to load donation stream')
 				}
 
 				const json = (await response.json()) as { data?: DonationStreamItem[] }
-				setDonations(json.data ?? [])
+				const incoming = json.data ?? []
+
+				if (incoming.length > 0) {
+					if (after) {
+						// Incremental poll: prepend new items, keep existing ones
+						setDonations((prev) => [...incoming, ...prev])
+					} else {
+						// Initial or manual full load
+						setDonations(incoming)
+					}
+					latestDonatedAtRef.current = incoming[0].donatedAt
+				}
 			} catch (fetchError) {
 				setError(fetchError)
 			} finally {
+				isFetchingRef.current = false
 				if (showLoading) setIsLoading(false)
 			}
 		},
@@ -51,15 +72,26 @@ export function useDonationStream({
 		fetchDonations(true)
 
 		const intervalId = setInterval(() => {
-			fetchDonations(false)
+			if (document.hidden) return
+			fetchDonations(false, latestDonatedAtRef.current)
 		}, pollIntervalMs)
+
+		function handleVisibilityChange() {
+			if (!document.hidden) {
+				fetchDonations(false, latestDonatedAtRef.current)
+			}
+		}
+
+		document.addEventListener('visibilitychange', handleVisibilityChange)
 
 		return () => {
 			clearInterval(intervalId)
+			document.removeEventListener('visibilitychange', handleVisibilityChange)
 		}
 	}, [projectSlug, fetchDonations, pollIntervalMs])
 
 	const refetch = useCallback(() => {
+		latestDonatedAtRef.current = undefined
 		return fetchDonations(true)
 	}, [fetchDonations])
 

--- a/apps/web/lib/queries/projects/get-project-donation-stream.ts
+++ b/apps/web/lib/queries/projects/get-project-donation-stream.ts
@@ -13,16 +13,23 @@ export async function getProjectDonationStream(
 	client: TypedSupabaseClient,
 	projectId: string,
 	limit = DEFAULT_LIMIT,
+	after?: string,
 ): Promise<DonationStreamItem[]> {
 	const safeLimit = Math.min(Math.max(1, limit), MAX_LIMIT)
 
-	const { data, error } = await client
+	let query = client
 		.from('contributions')
 		.select('id, amount, created_at')
 		.eq('project_id', projectId)
 		.gt('amount', 0)
 		.order('created_at', { ascending: false })
 		.limit(safeLimit)
+
+	if (after) {
+		query = query.gt('created_at', after)
+	}
+
+	const { data, error } = await query
 
 	if (error) throw error
 


### PR DESCRIPTION
Closes #987 

## Plan:

Pause polling on document.hidden and resume + revalidate on visibility change
Add an in-flight guard to prevent overlapping requests
Cache the slug-to-project-ID resolution so it doesn't repeat on every poll
Add a cursor/updated-at param so unchanged streams skip unnecessary payload transfer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Donation activity now updates incrementally, showing only newly received donations.
  * Added cursor-based loading for donation streams.
  * Refreshing donation data performs a complete reload when needed.

* **Performance**
  * Improved donation stream responsiveness with cached project lookups.
  * Reduced unnecessary polling by refreshing only when the page is visible.
  * Prevented overlapping donation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->