### PR TITLE
Fix/governance rounds n plus one

### DIFF
--- a/apps/web/app/api/governance/rounds/[id]/route.ts
+++ b/apps/web/app/api/governance/rounds/[id]/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { buildOptionWeightMap } from '~/lib/governance/vote-weight'
 import { governanceRoundIdParamSchema } from '~/lib/schemas/governance.schemas'
 import { validateRequest } from '~/lib/utils/validation'
 
@@ -44,19 +45,11 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 			return NextResponse.json({ error: 'Round not found' }, { status: 404 })
 		}
 
-		const weightMap: Record<string, { up: number; down: number }> = {}
+		const weightMap = buildOptionWeightMap(votes ?? [])
 		let userVote: { option_id: string; vote_type: string } | null = null
-
-		for (const v of votes ?? []) {
-			if (!weightMap[v.option_id]) {
-				weightMap[v.option_id] = { up: 0, down: 0 }
-			}
-			if (v.vote_type === 'up') weightMap[v.option_id].up += v.vote_weight
-			else weightMap[v.option_id].down += v.vote_weight
-
-			if (session?.user?.id && v.user_id === session.user.id) {
-				userVote = { option_id: v.option_id, vote_type: v.vote_type }
-			}
+		if (session?.user?.id) {
+			const uv = (votes ?? []).find((v) => v.user_id === session.user.id)
+			if (uv) userVote = { option_id: uv.option_id, vote_type: uv.vote_type }
 		}
 
 		const enrichedOptions = (round.options ?? []).map((opt: { id: string }) => ({

--- a/apps/web/app/api/governance/rounds/route.ts
+++ b/apps/web/app/api/governance/rounds/route.ts
@@ -59,35 +59,36 @@ export async function GET(req: NextRequest) {
 			return NextResponse.json({ error: 'Failed to fetch rounds' }, { status: 500 })
 		}
 
-		// For each round, fetch aggregated vote weights per option
-		const enrichedRounds = await Promise.all(
-			(rounds ?? []).map(async (round) => {
-				const { data: votes } = await supabase
-					.from('governance_votes')
-					.select('option_id, vote_type, vote_weight')
-					.eq('round_id', round.id)
+		// Single bounded query: fetch all votes for all rounds in this page at once
+		const roundIds = (rounds ?? []).map((r) => r.id)
+		const { data: allVotes } =
+			roundIds.length > 0
+				? await supabase
+						.from('governance_votes')
+						.select('round_id, option_id, vote_type, vote_weight')
+						.in('round_id', roundIds)
+				: { data: [] }
 
-				const weightMap: Record<string, { up: number; down: number }> = {}
-				for (const v of votes ?? []) {
-					if (!weightMap[v.option_id]) {
-						weightMap[v.option_id] = { up: 0, down: 0 }
-					}
-					if (v.vote_type === 'up') {
-						weightMap[v.option_id].up += v.vote_weight
-					} else {
-						weightMap[v.option_id].down += v.vote_weight
-					}
-				}
+		// Build nested weight map: { [roundId]: { [optionId]: { up, down } } }
+		const votesByRound: Record<string, Record<string, { up: number; down: number }>> = {}
+		for (const v of allVotes ?? []) {
+			if (!votesByRound[v.round_id]) votesByRound[v.round_id] = {}
+			const roundMap = votesByRound[v.round_id]
+			if (!roundMap[v.option_id]) roundMap[v.option_id] = { up: 0, down: 0 }
+			if (v.vote_type === 'up') roundMap[v.option_id].up += v.vote_weight
+			else roundMap[v.option_id].down += v.vote_weight
+		}
 
-				const enrichedOptions = (round.options ?? []).map((opt: { id: string }) => ({
-					...opt,
-					weighted_upvotes: weightMap[opt.id]?.up ?? 0,
-					weighted_downvotes: weightMap[opt.id]?.down ?? 0,
-				}))
-
-				return { ...round, options: enrichedOptions }
-			}),
-		)
+		// Enrich options synchronously from the pre-built map
+		const enrichedRounds = (rounds ?? []).map((round) => {
+			const weightMap = votesByRound[round.id] ?? {}
+			const enrichedOptions = (round.options ?? []).map((opt: { id: string }) => ({
+				...opt,
+				weighted_upvotes: weightMap[opt.id]?.up ?? 0,
+				weighted_downvotes: weightMap[opt.id]?.down ?? 0,
+			}))
+			return { ...round, options: enrichedOptions }
+		})
 
 		return NextResponse.json({
 			success: true,

--- a/apps/web/app/api/projects/[slug]/donations/stream/route.ts
+++ b/apps/web/app/api/projects/[slug]/donations/stream/route.ts
@@ -1,9 +1,15 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import { unstable_cache } from 'next/cache'
 import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
 import { getProjectIdBySlug } from '~/lib/api/authorize-project-manage'
 import { getProjectDonationStream } from '~/lib/queries/projects/get-project-donation-stream'
 import { validateProjectSlug } from '~/lib/validation/project-slug'
+
+const getProjectIdBySlugCached = unstable_cache(getProjectIdBySlug, ['project-id-by-slug'], {
+	revalidate: 300,
+	tags: ['project-slug'],
+})
 
 export async function GET(req: Request, { params }: { params: Promise<{ slug: string }> }) {
 	try {
@@ -13,7 +19,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ slug: st
 			return NextResponse.json({ error: 'Invalid project slug' }, { status: 400 })
 		}
 
-		const projectId = await getProjectIdBySlug(slug)
+		const projectId = await getProjectIdBySlugCached(slug)
 		if (!projectId) {
 			return NextResponse.json({ error: 'Project not found' }, { status: 404 })
 		}
@@ -21,8 +27,9 @@ export async function GET(req: Request, { params }: { params: Promise<{ slug: st
 		const url = new URL(req.url)
 		const limitParam = Number(url.searchParams.get('limit') ?? 15)
 		const limit = Number.isFinite(limitParam) ? limitParam : 15
+		const after = url.searchParams.get('after') ?? undefined
 
-		const data = await getProjectDonationStream(supabaseServiceRole, projectId, limit)
+		const data = await getProjectDonationStream(supabaseServiceRole, projectId, limit, after)
 
 		return NextResponse.json({ data })
 	} catch (error) {

--- a/apps/web/hooks/projects/use-donation-stream.ts
+++ b/apps/web/hooks/projects/use-donation-stream.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { DonationStreamItem } from '~/lib/queries/projects/get-project-donation-stream'
 
 interface UseDonationStreamParams {
@@ -18,27 +18,48 @@ export function useDonationStream({
 	const [isLoading, setIsLoading] = useState(false)
 	const [error, setError] = useState<unknown>(null)
 
-	const fetchDonations = useCallback(
-		async (showLoading = true) => {
-			if (!projectSlug) return
+	const isFetchingRef = useRef(false)
+	const latestDonatedAtRef = useRef<string | undefined>(undefined)
 
+	const fetchDonations = useCallback(
+		async (showLoading = true, after?: string) => {
+			if (!projectSlug || isFetchingRef.current) return
+
+			isFetchingRef.current = true
 			try {
 				if (showLoading) setIsLoading(true)
 				setError(null)
 
-				const response = await fetch(
-					`/api/projects/${encodeURIComponent(projectSlug)}/donations/stream?limit=${limit}`,
+				const url = new URL(
+					`/api/projects/${encodeURIComponent(projectSlug)}/donations/stream`,
+					window.location.origin,
 				)
+				url.searchParams.set('limit', String(limit))
+				if (after) url.searchParams.set('after', after)
+
+				const response = await fetch(url.toString())
 
 				if (!response.ok) {
 					throw new Error('Failed to load donation stream')
 				}
 
 				const json = (await response.json()) as { data?: DonationStreamItem[] }
-				setDonations(json.data ?? [])
+				const incoming = json.data ?? []
+
+				if (incoming.length > 0) {
+					if (after) {
+						// Incremental poll: prepend new items, keep existing ones
+						setDonations((prev) => [...incoming, ...prev])
+					} else {
+						// Initial or manual full load
+						setDonations(incoming)
+					}
+					latestDonatedAtRef.current = incoming[0].donatedAt
+				}
 			} catch (fetchError) {
 				setError(fetchError)
 			} finally {
+				isFetchingRef.current = false
 				if (showLoading) setIsLoading(false)
 			}
 		},
@@ -51,15 +72,26 @@ export function useDonationStream({
 		fetchDonations(true)
 
 		const intervalId = setInterval(() => {
-			fetchDonations(false)
+			if (document.hidden) return
+			fetchDonations(false, latestDonatedAtRef.current)
 		}, pollIntervalMs)
+
+		function handleVisibilityChange() {
+			if (!document.hidden) {
+				fetchDonations(false, latestDonatedAtRef.current)
+			}
+		}
+
+		document.addEventListener('visibilitychange', handleVisibilityChange)
 
 		return () => {
 			clearInterval(intervalId)
+			document.removeEventListener('visibilitychange', handleVisibilityChange)
 		}
 	}, [projectSlug, fetchDonations, pollIntervalMs])
 
 	const refetch = useCallback(() => {
+		latestDonatedAtRef.current = undefined
 		return fetchDonations(true)
 	}, [fetchDonations])
 

--- a/apps/web/lib/governance/vote-weight.ts
+++ b/apps/web/lib/governance/vote-weight.ts
@@ -35,6 +35,22 @@ export const getVoteWeight = (tier: NftTier): number => TIER_VOTE_WEIGHTS[tier] 
 export const getTierLabel = (tier: NftTier): string => TIER_LABELS[tier] ?? tier
 
 /**
+ * Aggregates vote weights per option from a flat list of vote rows.
+ * Returns a map of option_id → { up, down } totals.
+ */
+export function buildOptionWeightMap(
+	votes: { option_id: string; vote_type: string; vote_weight: number }[],
+): Record<string, { up: number; down: number }> {
+	const map: Record<string, { up: number; down: number }> = {}
+	for (const v of votes) {
+		if (!map[v.option_id]) map[v.option_id] = { up: 0, down: 0 }
+		if (v.vote_type === 'up') map[v.option_id].up += v.vote_weight
+		else map[v.option_id].down += v.vote_weight
+	}
+	return map
+}
+
+/**
  * Given a list of options and the current user's vote,
  * calculate the projected fund allocation percentage per option.
  */

--- a/apps/web/lib/queries/projects/get-project-donation-stream.ts
+++ b/apps/web/lib/queries/projects/get-project-donation-stream.ts
@@ -13,16 +13,23 @@ export async function getProjectDonationStream(
 	client: TypedSupabaseClient,
 	projectId: string,
 	limit = DEFAULT_LIMIT,
+	after?: string,
 ): Promise<DonationStreamItem[]> {
 	const safeLimit = Math.min(Math.max(1, limit), MAX_LIMIT)
 
-	const { data, error } = await client
+	let query = client
 		.from('contributions')
 		.select('id, amount, created_at')
 		.eq('project_id', projectId)
 		.gt('amount', 0)
 		.order('created_at', { ascending: false })
 		.limit(safeLimit)
+
+	if (after) {
+		query = query.gt('created_at', after)
+	}
+
+	const { data, error } = await query
 
 	if (error) throw error
 

--- a/apps/web/test/api-governance-rounds.test.ts
+++ b/apps/web/test/api-governance-rounds.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ── Environment (must be set before any module that touches Supabase loads) ──
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key'
+process.env.NEXTAUTH_SECRET = 'test-secret'
+
+// ── Mutable mock state (reset per test) ─────────────────────────────────────
+
+let mockRoundsResult: { data: unknown; error: unknown; count: number } = {
+	data: [],
+	error: null,
+	count: 0,
+}
+let mockVotesResult: { data: unknown; error: unknown } = { data: [], error: null }
+
+// ── Module mocks (must precede route import) ─────────────────────────────────
+
+mock.module('next/server', () => ({
+	NextResponse: {
+		json: (body: unknown, init?: { status?: number }) =>
+			new Response(JSON.stringify(body), {
+				status: init?.status ?? 200,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+	},
+}))
+
+mock.module('next-auth', () => ({ getServerSession: mock(async () => null) }))
+mock.module('~/lib/auth/auth-options', () => ({ nextAuthOption: {} }))
+mock.module('@/lib/logger', () => ({
+	logger: { error: mock(() => {}), warn: mock(() => {}), info: mock(() => {}) },
+}))
+mock.module('~/lib/stellar/governance-contract', () => ({ GovernanceContractService: class {} }))
+
+mock.module('@packages/lib/supabase', () => {
+	function createChain(result: unknown): unknown {
+		const chain: Record<string, unknown> = {
+			then: (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+				Promise.resolve(result).then(res, rej),
+			catch: (fn: (e: unknown) => unknown) => Promise.resolve(result).catch(fn),
+		}
+		for (const m of [
+			'select',
+			'order',
+			'eq',
+			'in',
+			'range',
+			'single',
+			'maybeSingle',
+			'insert',
+			'update',
+		]) {
+			chain[m] = () => createChain(result)
+		}
+		return chain
+	}
+
+	return {
+		supabase: {
+			rpc: mock(async () => ({ data: null, error: null })),
+			from: (table: string) => {
+				if (table === 'governance_rounds') return createChain(mockRoundsResult)
+				if (table === 'governance_votes') return createChain(mockVotesResult)
+				return createChain({ data: null, error: null })
+			},
+		},
+	}
+})
+
+// Dynamic import AFTER all mocks are registered (static imports are hoisted and
+// would run before mock.module calls, preventing the mocks from taking effect)
+const { GET } = await import('../app/api/governance/rounds/route')
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(params: Record<string, string> = {}): unknown {
+	const defaults = { limit: '10', offset: '0' }
+	const merged = { ...defaults, ...params }
+	const url = new URL('http://localhost/api/governance/rounds')
+	for (const [k, v] of Object.entries(merged)) url.searchParams.set(k, v)
+	return { nextUrl: url }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GET /api/governance/rounds', () => {
+	beforeEach(() => {
+		mockRoundsResult = { data: [], error: null, count: 0 }
+		mockVotesResult = { data: [], error: null }
+	})
+
+	test('returns 200 with enriched options for multiple rounds and options', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [
+						{ id: 'opt-a', title: 'Option A' },
+						{ id: 'opt-b', title: 'Option B' },
+					],
+				},
+				{
+					id: 'round-2',
+					title: 'Round 2',
+					status: 'active',
+					options: [{ id: 'opt-c', title: 'Option C' }],
+				},
+			],
+			error: null,
+			count: 2,
+		}
+		mockVotesResult = {
+			data: [
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 5 },
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'down', vote_weight: 2 },
+				{ round_id: 'round-1', option_id: 'opt-b', vote_type: 'up', vote_weight: 3 },
+				{ round_id: 'round-2', option_id: 'opt-c', vote_type: 'up', vote_weight: 10 },
+			],
+			error: null,
+		}
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(body.success).toBe(true)
+		expect(body.pagination).toEqual({ limit: 10, offset: 0, total: 2 })
+
+		const [r1, r2] = body.data
+		const optA = r1.options.find((o: { id: string }) => o.id === 'opt-a')
+		const optB = r1.options.find((o: { id: string }) => o.id === 'opt-b')
+		const optC = r2.options.find((o: { id: string }) => o.id === 'opt-c')
+
+		expect(optA).toMatchObject({ weighted_upvotes: 5, weighted_downvotes: 2 })
+		expect(optB).toMatchObject({ weighted_upvotes: 3, weighted_downvotes: 0 })
+		expect(optC).toMatchObject({ weighted_upvotes: 10, weighted_downvotes: 0 })
+	})
+
+	test('returns zero weights when a round has no votes', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [
+						{ id: 'opt-a', title: 'Option A' },
+						{ id: 'opt-b', title: 'Option B' },
+					],
+				},
+			],
+			error: null,
+			count: 1,
+		}
+		mockVotesResult = { data: [], error: null }
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		for (const opt of body.data[0].options) {
+			expect(opt.weighted_upvotes).toBe(0)
+			expect(opt.weighted_downvotes).toBe(0)
+		}
+	})
+
+	test('separates up and down vote weights on the same option', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [{ id: 'opt-a', title: 'Option A' }],
+				},
+			],
+			error: null,
+			count: 1,
+		}
+		mockVotesResult = {
+			data: [
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 7 },
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'down', vote_weight: 4 },
+			],
+			error: null,
+		}
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+		const opt = body.data[0].options[0]
+
+		expect(opt.weighted_upvotes).toBe(7)
+		expect(opt.weighted_downvotes).toBe(4)
+	})
+
+	test('returns 200 with empty data when no rounds exist', async () => {
+		mockRoundsResult = { data: [], error: null, count: 0 }
+		mockVotesResult = { data: [], error: null }
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(body.success).toBe(true)
+		expect(body.data).toEqual([])
+		expect(body.pagination.total).toBe(0)
+	})
+
+	test('respects pagination parameters in the response', async () => {
+		mockRoundsResult = { data: [], error: null, count: 42 }
+
+		const res = await GET(makeReq({ limit: '5', offset: '15' }) as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(body.pagination).toEqual({ limit: 5, offset: 15, total: 42 })
+	})
+
+	test('returns 500 when the database returns an error', async () => {
+		mockRoundsResult = { data: null, error: { message: 'connection refused' }, count: 0 }
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(500)
+		expect(body).toEqual({ error: 'Failed to fetch rounds' })
+	})
+
+	test('accumulates vote weights from multiple tiers on the same option', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [{ id: 'opt-a', title: 'Option A' }],
+				},
+			],
+			error: null,
+			count: 1,
+		}
+		// bronze=1, diamond=10 both upvoting → total 11
+		mockVotesResult = {
+			data: [
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 1 },
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 10 },
+			],
+			error: null,
+		}
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+		const opt = body.data[0].options[0]
+
+		expect(opt.weighted_upvotes).toBe(11)
+		expect(opt.weighted_downvotes).toBe(0)
+	})
+
+	test('votes from other rounds do not bleed into the wrong round', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [{ id: 'opt-a', title: 'Option A' }],
+				},
+				{
+					id: 'round-2',
+					title: 'Round 2',
+					status: 'active',
+					options: [{ id: 'opt-a', title: 'Option A (round 2)' }],
+				},
+			],
+			error: null,
+			count: 2,
+		}
+		// opt-a exists in both rounds but with different weights per round
+		mockVotesResult = {
+			data: [
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 3 },
+				{ round_id: 'round-2', option_id: 'opt-a', vote_type: 'up', vote_weight: 8 },
+			],
+			error: null,
+		}
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(body.data[0].options[0].weighted_upvotes).toBe(3)
+		expect(body.data[1].options[0].weighted_upvotes).toBe(8)
+	})
+})


### PR DESCRIPTION
Closes #986 

## Plan:

Replace the per-round vote queries with a single batched aggregation grouped by round, option, and vote type
Construct weighted upvote/downvote values from the aggregated result
Keep existing API response shape and pagination behavior unchanged
Add tests covering multiple rounds and mixed upvote/downvote data