### PR TITLE
Feat/project matching cache and prerank

### DIFF
--- a/apps/web/app/api/governance/rounds/[id]/route.ts
+++ b/apps/web/app/api/governance/rounds/[id]/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { buildOptionWeightMap } from '~/lib/governance/vote-weight'
 import { governanceRoundIdParamSchema } from '~/lib/schemas/governance.schemas'
 import { validateRequest } from '~/lib/utils/validation'
 
@@ -44,19 +45,11 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 			return NextResponse.json({ error: 'Round not found' }, { status: 404 })
 		}
 
-		const weightMap: Record<string, { up: number; down: number }> = {}
+		const weightMap = buildOptionWeightMap(votes ?? [])
 		let userVote: { option_id: string; vote_type: string } | null = null
-
-		for (const v of votes ?? []) {
-			if (!weightMap[v.option_id]) {
-				weightMap[v.option_id] = { up: 0, down: 0 }
-			}
-			if (v.vote_type === 'up') weightMap[v.option_id].up += v.vote_weight
-			else weightMap[v.option_id].down += v.vote_weight
-
-			if (session?.user?.id && v.user_id === session.user.id) {
-				userVote = { option_id: v.option_id, vote_type: v.vote_type }
-			}
+		if (session?.user?.id) {
+			const uv = (votes ?? []).find((v) => v.user_id === session.user.id)
+			if (uv) userVote = { option_id: uv.option_id, vote_type: uv.vote_type }
 		}
 
 		const enrichedOptions = (round.options ?? []).map((opt: { id: string }) => ({

--- a/apps/web/app/api/governance/rounds/route.ts
+++ b/apps/web/app/api/governance/rounds/route.ts
@@ -59,35 +59,36 @@ export async function GET(req: NextRequest) {
 			return NextResponse.json({ error: 'Failed to fetch rounds' }, { status: 500 })
 		}
 
-		// For each round, fetch aggregated vote weights per option
-		const enrichedRounds = await Promise.all(
-			(rounds ?? []).map(async (round) => {
-				const { data: votes } = await supabase
-					.from('governance_votes')
-					.select('option_id, vote_type, vote_weight')
-					.eq('round_id', round.id)
+		// Single bounded query: fetch all votes for all rounds in this page at once
+		const roundIds = (rounds ?? []).map((r) => r.id)
+		const { data: allVotes } =
+			roundIds.length > 0
+				? await supabase
+						.from('governance_votes')
+						.select('round_id, option_id, vote_type, vote_weight')
+						.in('round_id', roundIds)
+				: { data: [] }
 
-				const weightMap: Record<string, { up: number; down: number }> = {}
-				for (const v of votes ?? []) {
-					if (!weightMap[v.option_id]) {
-						weightMap[v.option_id] = { up: 0, down: 0 }
-					}
-					if (v.vote_type === 'up') {
-						weightMap[v.option_id].up += v.vote_weight
-					} else {
-						weightMap[v.option_id].down += v.vote_weight
-					}
-				}
+		// Build nested weight map: { [roundId]: { [optionId]: { up, down } } }
+		const votesByRound: Record<string, Record<string, { up: number; down: number }>> = {}
+		for (const v of allVotes ?? []) {
+			if (!votesByRound[v.round_id]) votesByRound[v.round_id] = {}
+			const roundMap = votesByRound[v.round_id]
+			if (!roundMap[v.option_id]) roundMap[v.option_id] = { up: 0, down: 0 }
+			if (v.vote_type === 'up') roundMap[v.option_id].up += v.vote_weight
+			else roundMap[v.option_id].down += v.vote_weight
+		}
 
-				const enrichedOptions = (round.options ?? []).map((opt: { id: string }) => ({
-					...opt,
-					weighted_upvotes: weightMap[opt.id]?.up ?? 0,
-					weighted_downvotes: weightMap[opt.id]?.down ?? 0,
-				}))
-
-				return { ...round, options: enrichedOptions }
-			}),
-		)
+		// Enrich options synchronously from the pre-built map
+		const enrichedRounds = (rounds ?? []).map((round) => {
+			const weightMap = votesByRound[round.id] ?? {}
+			const enrichedOptions = (round.options ?? []).map((opt: { id: string }) => ({
+				...opt,
+				weighted_upvotes: weightMap[opt.id]?.up ?? 0,
+				weighted_downvotes: weightMap[opt.id]?.down ?? 0,
+			}))
+			return { ...round, options: enrichedOptions }
+		})
 
 		return NextResponse.json({
 			success: true,

--- a/apps/web/app/api/profile/project-matching/route.ts
+++ b/apps/web/app/api/profile/project-matching/route.ts
@@ -3,13 +3,16 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import type { UserMatchingContext } from '~/lib/services/project-matching/build-matching-context'
 import {
 	buildMatchingPrompt,
 	buildUserMatchingContext,
 	fetchMatchingCandidates,
 	MATCHING_SYSTEM_PROMPT,
+	preRankCandidates,
 } from '~/lib/services/project-matching/build-matching-context'
 import {
+	type MatchingCandidateProject,
 	matchingAiResponseSchema,
 	type ProjectMatchingResult,
 } from '~/lib/services/project-matching/schemas'
@@ -18,8 +21,17 @@ export const maxDuration = 30
 
 const DEFAULT_MATCHING_MODEL = 'google/gemini-2.5-flash-lite'
 const MIN_CANDIDATES = 3
+const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
 
-export async function POST() {
+interface MatchingCacheEntry {
+	userContext: UserMatchingContext
+	candidates: MatchingCandidateProject[]
+	cachedAt: number
+}
+
+const matchingCache = new Map<string, MatchingCacheEntry>()
+
+export async function POST(request: Request) {
 	try {
 		const session = await getServerSession(nextAuthOption)
 		if (!session?.user?.id) {
@@ -29,10 +41,24 @@ export async function POST() {
 		const userId = session.user.id
 		const { supabase } = await import('@packages/lib/supabase')
 
-		const [userContext, candidates] = await Promise.all([
-			buildUserMatchingContext(supabase, userId),
-			fetchMatchingCandidates(supabase, userId),
-		])
+		const forceRefresh = request.headers.get('x-invalidate-cache') === 'true'
+		const cached = matchingCache.get(userId)
+		const isCacheValid =
+			!forceRefresh && cached !== undefined && Date.now() - cached.cachedAt < CACHE_TTL_MS
+
+		let userContext: UserMatchingContext
+		let candidates: MatchingCandidateProject[]
+
+		if (isCacheValid) {
+			userContext = cached.userContext
+			candidates = cached.candidates
+		} else {
+			;[userContext, candidates] = await Promise.all([
+				buildUserMatchingContext(supabase, userId),
+				fetchMatchingCandidates(supabase, userId),
+			])
+			matchingCache.set(userId, { userContext, candidates, cachedAt: Date.now() })
+		}
 
 		if (candidates.length < MIN_CANDIDATES) {
 			return NextResponse.json(
@@ -47,6 +73,8 @@ export async function POST() {
 		const modelId = process.env.AI_PROJECT_MATCHING_MODEL ?? DEFAULT_MATCHING_MODEL
 		const candidateMap = new Map(candidates.map((project) => [project.id, project]))
 
+		const promptCandidates = preRankCandidates(userContext, candidates)
+
 		const { object } = await generateObject({
 			model: gateway(modelId),
 			schema: matchingAiResponseSchema,
@@ -54,7 +82,7 @@ export async function POST() {
 			schemaDescription:
 				'Personalized project recommendations for a KindFi donor based on their profile and history',
 			system: MATCHING_SYSTEM_PROMPT,
-			prompt: buildMatchingPrompt(userContext, candidates),
+			prompt: buildMatchingPrompt(userContext, promptCandidates),
 			providerOptions: {
 				gateway: {
 					user: userId,

--- a/apps/web/app/api/projects/[slug]/donations/stream/route.ts
+++ b/apps/web/app/api/projects/[slug]/donations/stream/route.ts
@@ -1,9 +1,15 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import { unstable_cache } from 'next/cache'
 import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
 import { getProjectIdBySlug } from '~/lib/api/authorize-project-manage'
 import { getProjectDonationStream } from '~/lib/queries/projects/get-project-donation-stream'
 import { validateProjectSlug } from '~/lib/validation/project-slug'
+
+const getProjectIdBySlugCached = unstable_cache(getProjectIdBySlug, ['project-id-by-slug'], {
+	revalidate: 300,
+	tags: ['project-slug'],
+})
 
 export async function GET(req: Request, { params }: { params: Promise<{ slug: string }> }) {
 	try {
@@ -13,7 +19,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ slug: st
 			return NextResponse.json({ error: 'Invalid project slug' }, { status: 400 })
 		}
 
-		const projectId = await getProjectIdBySlug(slug)
+		const projectId = await getProjectIdBySlugCached(slug)
 		if (!projectId) {
 			return NextResponse.json({ error: 'Project not found' }, { status: 404 })
 		}
@@ -21,8 +27,9 @@ export async function GET(req: Request, { params }: { params: Promise<{ slug: st
 		const url = new URL(req.url)
 		const limitParam = Number(url.searchParams.get('limit') ?? 15)
 		const limit = Number.isFinite(limitParam) ? limitParam : 15
+		const after = url.searchParams.get('after') ?? undefined
 
-		const data = await getProjectDonationStream(supabaseServiceRole, projectId, limit)
+		const data = await getProjectDonationStream(supabaseServiceRole, projectId, limit, after)
 
 		return NextResponse.json({ data })
 	} catch (error) {

--- a/apps/web/hooks/projects/use-donation-stream.ts
+++ b/apps/web/hooks/projects/use-donation-stream.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { DonationStreamItem } from '~/lib/queries/projects/get-project-donation-stream'
 
 interface UseDonationStreamParams {
@@ -18,27 +18,48 @@ export function useDonationStream({
 	const [isLoading, setIsLoading] = useState(false)
 	const [error, setError] = useState<unknown>(null)
 
-	const fetchDonations = useCallback(
-		async (showLoading = true) => {
-			if (!projectSlug) return
+	const isFetchingRef = useRef(false)
+	const latestDonatedAtRef = useRef<string | undefined>(undefined)
 
+	const fetchDonations = useCallback(
+		async (showLoading = true, after?: string) => {
+			if (!projectSlug || isFetchingRef.current) return
+
+			isFetchingRef.current = true
 			try {
 				if (showLoading) setIsLoading(true)
 				setError(null)
 
-				const response = await fetch(
-					`/api/projects/${encodeURIComponent(projectSlug)}/donations/stream?limit=${limit}`,
+				const url = new URL(
+					`/api/projects/${encodeURIComponent(projectSlug)}/donations/stream`,
+					window.location.origin,
 				)
+				url.searchParams.set('limit', String(limit))
+				if (after) url.searchParams.set('after', after)
+
+				const response = await fetch(url.toString())
 
 				if (!response.ok) {
 					throw new Error('Failed to load donation stream')
 				}
 
 				const json = (await response.json()) as { data?: DonationStreamItem[] }
-				setDonations(json.data ?? [])
+				const incoming = json.data ?? []
+
+				if (incoming.length > 0) {
+					if (after) {
+						// Incremental poll: prepend new items, keep existing ones
+						setDonations((prev) => [...incoming, ...prev])
+					} else {
+						// Initial or manual full load
+						setDonations(incoming)
+					}
+					latestDonatedAtRef.current = incoming[0].donatedAt
+				}
 			} catch (fetchError) {
 				setError(fetchError)
 			} finally {
+				isFetchingRef.current = false
 				if (showLoading) setIsLoading(false)
 			}
 		},
@@ -51,15 +72,26 @@ export function useDonationStream({
 		fetchDonations(true)
 
 		const intervalId = setInterval(() => {
-			fetchDonations(false)
+			if (document.hidden) return
+			fetchDonations(false, latestDonatedAtRef.current)
 		}, pollIntervalMs)
+
+		function handleVisibilityChange() {
+			if (!document.hidden) {
+				fetchDonations(false, latestDonatedAtRef.current)
+			}
+		}
+
+		document.addEventListener('visibilitychange', handleVisibilityChange)
 
 		return () => {
 			clearInterval(intervalId)
+			document.removeEventListener('visibilitychange', handleVisibilityChange)
 		}
 	}, [projectSlug, fetchDonations, pollIntervalMs])
 
 	const refetch = useCallback(() => {
+		latestDonatedAtRef.current = undefined
 		return fetchDonations(true)
 	}, [fetchDonations])
 

--- a/apps/web/lib/governance/vote-weight.ts
+++ b/apps/web/lib/governance/vote-weight.ts
@@ -35,6 +35,22 @@ export const getVoteWeight = (tier: NftTier): number => TIER_VOTE_WEIGHTS[tier] 
 export const getTierLabel = (tier: NftTier): string => TIER_LABELS[tier] ?? tier
 
 /**
+ * Aggregates vote weights per option from a flat list of vote rows.
+ * Returns a map of option_id → { up, down } totals.
+ */
+export function buildOptionWeightMap(
+	votes: { option_id: string; vote_type: string; vote_weight: number }[],
+): Record<string, { up: number; down: number }> {
+	const map: Record<string, { up: number; down: number }> = {}
+	for (const v of votes) {
+		if (!map[v.option_id]) map[v.option_id] = { up: 0, down: 0 }
+		if (v.vote_type === 'up') map[v.option_id].up += v.vote_weight
+		else map[v.option_id].down += v.vote_weight
+	}
+	return map
+}
+
+/**
  * Given a list of options and the current user's vote,
  * calculate the projected fund allocation percentage per option.
  */

--- a/apps/web/lib/queries/projects/get-project-donation-stream.ts
+++ b/apps/web/lib/queries/projects/get-project-donation-stream.ts
@@ -13,16 +13,23 @@ export async function getProjectDonationStream(
 	client: TypedSupabaseClient,
 	projectId: string,
 	limit = DEFAULT_LIMIT,
+	after?: string,
 ): Promise<DonationStreamItem[]> {
 	const safeLimit = Math.min(Math.max(1, limit), MAX_LIMIT)
 
-	const { data, error } = await client
+	let query = client
 		.from('contributions')
 		.select('id, amount, created_at')
 		.eq('project_id', projectId)
 		.gt('amount', 0)
 		.order('created_at', { ascending: false })
 		.limit(safeLimit)
+
+	if (after) {
+		query = query.gt('created_at', after)
+	}
+
+	const { data, error } = await query
 
 	if (error) throw error
 

--- a/apps/web/lib/services/project-matching/build-matching-context.test.ts
+++ b/apps/web/lib/services/project-matching/build-matching-context.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test'
+import type { UserMatchingContext } from './build-matching-context'
+import { buildMatchingPrompt, preRankCandidates } from './build-matching-context'
+import type { MatchingCandidateProject } from './schemas'
+import { MAX_PROMPT_CANDIDATES } from './schemas'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeCandidate = (
+	id: string,
+	overrides: Partial<MatchingCandidateProject> = {},
+): MatchingCandidateProject => ({
+	id,
+	slug: id,
+	title: `Project ${id}`,
+	description: `Description for ${id}`,
+	projectLocation: 'United States',
+	category: { id: 'cat-1', name: 'Education', slug: 'education', color: '#fff' },
+	tags: [{ name: 'youth', color: null }],
+	goal: 10000,
+	raised: 5000,
+	investors: 10,
+	percentageComplete: 50,
+	image: null,
+	...overrides,
+})
+
+const coldStartContext: UserMatchingContext = {
+	displayName: 'Alice',
+	bio: null,
+	country: 'US',
+	role: 'donor',
+	donationHistory: [],
+	stats: { donationCount: 0, totalAmount: 0, questsCompleted: 0, streakDays: 0, referralCount: 0 },
+	derivedPreferences: { topCategories: [], topRegions: [], topTags: [] },
+}
+
+const contextWithPreferences: UserMatchingContext = {
+	...coldStartContext,
+	derivedPreferences: {
+		topCategories: ['Education'],
+		topRegions: ['Mexico'],
+		topTags: ['youth', 'literacy'],
+	},
+}
+
+// ---------------------------------------------------------------------------
+// preRankCandidates — truncation
+// ---------------------------------------------------------------------------
+
+describe('preRankCandidates — truncation', () => {
+	test('returns at most MAX_PROMPT_CANDIDATES items when given more candidates', () => {
+		const candidates = Array.from({ length: 50 }, (_, i) => makeCandidate(`p${i}`))
+		const result = preRankCandidates(coldStartContext, candidates)
+		expect(result.length).toBe(MAX_PROMPT_CANDIDATES)
+	})
+
+	test('returns all candidates when fewer than MAX_PROMPT_CANDIDATES exist', () => {
+		const candidates = [makeCandidate('a'), makeCandidate('b')]
+		const result = preRankCandidates(coldStartContext, candidates)
+		expect(result.length).toBe(2)
+	})
+
+	test('respects a custom limit override', () => {
+		const candidates = Array.from({ length: 30 }, (_, i) => makeCandidate(`p${i}`))
+		const result = preRankCandidates(coldStartContext, candidates, 5)
+		expect(result.length).toBe(5)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// preRankCandidates — scoring
+// ---------------------------------------------------------------------------
+
+describe('preRankCandidates — scoring', () => {
+	test('candidate matching category + region + tags ranks first', () => {
+		const best = makeCandidate('best', {
+			category: { id: 'c1', name: 'Education', slug: 'edu', color: '#fff' },
+			projectLocation: 'Mexico',
+			tags: [
+				{ name: 'youth', color: null },
+				{ name: 'literacy', color: null },
+			],
+		})
+		const worst = makeCandidate('worst', {
+			category: { id: 'c2', name: 'Health', slug: 'health', color: '#fff' },
+			projectLocation: 'Brazil',
+			tags: [{ name: 'medicine', color: null }],
+		})
+		const result = preRankCandidates(contextWithPreferences, [worst, best])
+		expect(result[0].id).toBe('best')
+	})
+
+	test('category match alone outranks no-match candidate', () => {
+		const withCategory = makeCandidate('cat-match', {
+			category: { id: 'c1', name: 'Education', slug: 'edu', color: '#fff' },
+			projectLocation: 'Brazil',
+			tags: [],
+		})
+		const noMatch = makeCandidate('no-match', {
+			category: { id: 'c2', name: 'Health', slug: 'health', color: '#fff' },
+			projectLocation: 'Brazil',
+			tags: [],
+		})
+		const result = preRankCandidates(contextWithPreferences, [noMatch, withCategory])
+		expect(result[0].id).toBe('cat-match')
+	})
+
+	test('maps candidates to PromptCandidateProject shape with truncated description', () => {
+		const longDesc = 'x'.repeat(300)
+		const candidate = makeCandidate('p1', { description: longDesc })
+		const result = preRankCandidates(coldStartContext, [candidate])
+		expect(result[0].description.length).toBeLessThanOrEqual(150)
+		expect(result[0]).toHaveProperty('id', 'p1')
+		expect(result[0]).toHaveProperty('category')
+		expect(result[0]).toHaveProperty('tags')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// preRankCandidates — cold-start
+// ---------------------------------------------------------------------------
+
+describe('preRankCandidates — cold-start', () => {
+	test('returns results without error when user has no preferences', () => {
+		const candidates = Array.from({ length: 10 }, (_, i) => makeCandidate(`p${i}`))
+		expect(() => preRankCandidates(coldStartContext, candidates)).not.toThrow()
+	})
+
+	test('preserves original order for cold-start users (all scores equal zero)', () => {
+		const candidates = ['first', 'second', 'third'].map((id) => makeCandidate(id))
+		const result = preRankCandidates(coldStartContext, candidates, 3)
+		expect(result.map((r) => r.id)).toEqual(['first', 'second', 'third'])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// buildMatchingPrompt — bounded size
+// ---------------------------------------------------------------------------
+
+describe('buildMatchingPrompt — bounded size', () => {
+	test('prompt with MAX_PROMPT_CANDIDATES candidates stays within character budget', () => {
+		const candidates = Array.from({ length: MAX_PROMPT_CANDIDATES }, (_, i) =>
+			makeCandidate(`p${i}`),
+		)
+		const promptCandidates = preRankCandidates(coldStartContext, candidates)
+		const prompt = buildMatchingPrompt(coldStartContext, promptCandidates)
+		// Generous upper bound: 20 candidates × ~300 chars each + ~1500 for user section
+		expect(prompt.length).toBeLessThan(20 * 300 + 1500)
+	})
+
+	test('each candidate id appears exactly once in the prompt', () => {
+		const candidates = [makeCandidate('alpha'), makeCandidate('beta')]
+		const promptCandidates = preRankCandidates(coldStartContext, candidates)
+		const prompt = buildMatchingPrompt(coldStartContext, promptCandidates)
+		expect(prompt).toContain('[alpha]')
+		expect(prompt).toContain('[beta]')
+	})
+})

--- a/apps/web/lib/services/project-matching/build-matching-context.ts
+++ b/apps/web/lib/services/project-matching/build-matching-context.ts
@@ -1,6 +1,10 @@
 import type { TypedSupabaseClient } from '@packages/lib/types'
 import { getUserStats } from '~/lib/services/user-stats'
-import type { MatchingCandidateProject } from './schemas'
+import {
+	MAX_PROMPT_CANDIDATES,
+	type MatchingCandidateProject,
+	type PromptCandidateProject,
+} from './schemas'
 
 type CategoryRef = { id: string; name: string; slug: string | null; color: string } | null
 
@@ -215,20 +219,64 @@ export async function fetchMatchingCandidates(
 		}))
 }
 
-export const buildMatchingPrompt = (
+/**
+ * Pre-ranks candidates by relevance to the user's derived preferences and
+ * returns a compact slice bounded to `limit` (default MAX_PROMPT_CANDIDATES).
+ *
+ * Scoring (additive):
+ *   +3  category matches a topCategory
+ *   +2  region matches a topRegion
+ *   +1  per tag matching a topTag (capped at 3)
+ *   +0.5 proportional to percentageComplete (momentum signal)
+ *
+ * Cold-start users (no preferences) get score 0 for all candidates, so the
+ * original Supabase kinder_count ordering is preserved.
+ */
+export function preRankCandidates(
 	userContext: UserMatchingContext,
 	candidates: MatchingCandidateProject[],
+	limit = MAX_PROMPT_CANDIDATES,
+): PromptCandidateProject[] {
+	const { topCategories, topRegions, topTags } = userContext.derivedPreferences
+	const categorySet = new Set(topCategories)
+	const regionSet = new Set(topRegions)
+	const tagSet = new Set(topTags)
+
+	const scored = candidates.map((project) => {
+		let score = 0
+		if (project.category?.name && categorySet.has(project.category.name)) score += 3
+		if (project.projectLocation && regionSet.has(project.projectLocation)) score += 2
+		const tagMatches = project.tags.filter((t) => tagSet.has(t.name)).length
+		score += Math.min(tagMatches, 3)
+		score += ((project.percentageComplete ?? 0) / 100) * 0.5
+		return { project, score }
+	})
+
+	return scored
+		.sort((a, b) => b.score - a.score)
+		.slice(0, limit)
+		.map(({ project }) => ({
+			id: project.id,
+			title: project.title,
+			description: project.description?.slice(0, 150) ?? '',
+			category: project.category?.name ?? 'Uncategorized',
+			region: project.projectLocation ?? null,
+			tags: project.tags.map((t) => t.name),
+			fundingProgress: project.percentageComplete ?? 0,
+			supporters: project.investors,
+		}))
+}
+
+export const buildMatchingPrompt = (
+	userContext: UserMatchingContext,
+	candidates: PromptCandidateProject[],
 ): string => {
-	const candidateList = candidates.map((project) => ({
-		id: project.id,
-		title: project.title,
-		description: project.description?.slice(0, 280) ?? '',
-		category: project.category?.name ?? 'Uncategorized',
-		region: project.projectLocation,
-		tags: project.tags.map((tag) => tag.name),
-		fundingProgress: project.percentageComplete ?? 0,
-		supporters: project.investors,
-	}))
+	const candidateLines = candidates
+		.map(
+			(p) =>
+				`[${p.id}] ${p.title} | ${p.category} | ${p.region ?? 'global'} | tags: ${p.tags.join(',') || 'none'} | ${p.fundingProgress}% funded | ${p.supporters} supporters | ${p.description}`,
+		)
+		.join('\n')
 
 	return `Recommend 3 to 5 projects from the candidate list that best match this KindFi user.
 
@@ -263,7 +311,7 @@ ${
 }
 
 ## Candidate projects (only recommend from this list)
-${JSON.stringify(candidateList, null, 2)}
+${candidateLines}
 
 Rules:
 - Only use project ids from the candidate list.

--- a/apps/web/lib/services/project-matching/schemas.ts
+++ b/apps/web/lib/services/project-matching/schemas.ts
@@ -1,5 +1,24 @@
 import { z } from 'zod'
 
+/** Maximum number of pre-ranked candidates sent to the AI model. */
+export const MAX_PROMPT_CANDIDATES = 20
+
+/**
+ * Compact representation of a candidate project used inside the AI prompt.
+ * Excludes fields not needed for matching (image, raised amounts, etc.)
+ * to keep prompt size bounded.
+ */
+export interface PromptCandidateProject {
+	id: string
+	title: string
+	description: string
+	category: string
+	region: string | null
+	tags: string[]
+	fundingProgress: number
+	supporters: number
+}
+
 export const matchingAiResponseSchema = z.object({
 	summary: z
 		.string()

--- a/apps/web/test/api-governance-rounds.test.ts
+++ b/apps/web/test/api-governance-rounds.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ── Environment (must be set before any module that touches Supabase loads) ──
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key'
+process.env.NEXTAUTH_SECRET = 'test-secret'
+
+// ── Mutable mock state (reset per test) ─────────────────────────────────────
+
+let mockRoundsResult: { data: unknown; error: unknown; count: number } = {
+	data: [],
+	error: null,
+	count: 0,
+}
+let mockVotesResult: { data: unknown; error: unknown } = { data: [], error: null }
+
+// ── Module mocks (must precede route import) ─────────────────────────────────
+
+mock.module('next/server', () => ({
+	NextResponse: {
+		json: (body: unknown, init?: { status?: number }) =>
+			new Response(JSON.stringify(body), {
+				status: init?.status ?? 200,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+	},
+}))
+
+mock.module('next-auth', () => ({ getServerSession: mock(async () => null) }))
+mock.module('~/lib/auth/auth-options', () => ({ nextAuthOption: {} }))
+mock.module('@/lib/logger', () => ({
+	logger: { error: mock(() => {}), warn: mock(() => {}), info: mock(() => {}) },
+}))
+mock.module('~/lib/stellar/governance-contract', () => ({ GovernanceContractService: class {} }))
+
+mock.module('@packages/lib/supabase', () => {
+	function createChain(result: unknown): unknown {
+		const chain: Record<string, unknown> = {
+			then: (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+				Promise.resolve(result).then(res, rej),
+			catch: (fn: (e: unknown) => unknown) => Promise.resolve(result).catch(fn),
+		}
+		for (const m of [
+			'select',
+			'order',
+			'eq',
+			'in',
+			'range',
+			'single',
+			'maybeSingle',
+			'insert',
+			'update',
+		]) {
+			chain[m] = () => createChain(result)
+		}
+		return chain
+	}
+
+	return {
+		supabase: {
+			rpc: mock(async () => ({ data: null, error: null })),
+			from: (table: string) => {
+				if (table === 'governance_rounds') return createChain(mockRoundsResult)
+				if (table === 'governance_votes') return createChain(mockVotesResult)
+				return createChain({ data: null, error: null })
+			},
+		},
+	}
+})
+
+// Dynamic import AFTER all mocks are registered (static imports are hoisted and
+// would run before mock.module calls, preventing the mocks from taking effect)
+const { GET } = await import('../app/api/governance/rounds/route')
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(params: Record<string, string> = {}): unknown {
+	const defaults = { limit: '10', offset: '0' }
+	const merged = { ...defaults, ...params }
+	const url = new URL('http://localhost/api/governance/rounds')
+	for (const [k, v] of Object.entries(merged)) url.searchParams.set(k, v)
+	return { nextUrl: url }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GET /api/governance/rounds', () => {
+	beforeEach(() => {
+		mockRoundsResult = { data: [], error: null, count: 0 }
+		mockVotesResult = { data: [], error: null }
+	})
+
+	test('returns 200 with enriched options for multiple rounds and options', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [
+						{ id: 'opt-a', title: 'Option A' },
+						{ id: 'opt-b', title: 'Option B' },
+					],
+				},
+				{
+					id: 'round-2',
+					title: 'Round 2',
+					status: 'active',
+					options: [{ id: 'opt-c', title: 'Option C' }],
+				},
+			],
+			error: null,
+			count: 2,
+		}
+		mockVotesResult = {
+			data: [
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 5 },
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'down', vote_weight: 2 },
+				{ round_id: 'round-1', option_id: 'opt-b', vote_type: 'up', vote_weight: 3 },
+				{ round_id: 'round-2', option_id: 'opt-c', vote_type: 'up', vote_weight: 10 },
+			],
+			error: null,
+		}
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(body.success).toBe(true)
+		expect(body.pagination).toEqual({ limit: 10, offset: 0, total: 2 })
+
+		const [r1, r2] = body.data
+		const optA = r1.options.find((o: { id: string }) => o.id === 'opt-a')
+		const optB = r1.options.find((o: { id: string }) => o.id === 'opt-b')
+		const optC = r2.options.find((o: { id: string }) => o.id === 'opt-c')
+
+		expect(optA).toMatchObject({ weighted_upvotes: 5, weighted_downvotes: 2 })
+		expect(optB).toMatchObject({ weighted_upvotes: 3, weighted_downvotes: 0 })
+		expect(optC).toMatchObject({ weighted_upvotes: 10, weighted_downvotes: 0 })
+	})
+
+	test('returns zero weights when a round has no votes', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [
+						{ id: 'opt-a', title: 'Option A' },
+						{ id: 'opt-b', title: 'Option B' },
+					],
+				},
+			],
+			error: null,
+			count: 1,
+		}
+		mockVotesResult = { data: [], error: null }
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		for (const opt of body.data[0].options) {
+			expect(opt.weighted_upvotes).toBe(0)
+			expect(opt.weighted_downvotes).toBe(0)
+		}
+	})
+
+	test('separates up and down vote weights on the same option', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [{ id: 'opt-a', title: 'Option A' }],
+				},
+			],
+			error: null,
+			count: 1,
+		}
+		mockVotesResult = {
+			data: [
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 7 },
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'down', vote_weight: 4 },
+			],
+			error: null,
+		}
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+		const opt = body.data[0].options[0]
+
+		expect(opt.weighted_upvotes).toBe(7)
+		expect(opt.weighted_downvotes).toBe(4)
+	})
+
+	test('returns 200 with empty data when no rounds exist', async () => {
+		mockRoundsResult = { data: [], error: null, count: 0 }
+		mockVotesResult = { data: [], error: null }
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(body.success).toBe(true)
+		expect(body.data).toEqual([])
+		expect(body.pagination.total).toBe(0)
+	})
+
+	test('respects pagination parameters in the response', async () => {
+		mockRoundsResult = { data: [], error: null, count: 42 }
+
+		const res = await GET(makeReq({ limit: '5', offset: '15' }) as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(body.pagination).toEqual({ limit: 5, offset: 15, total: 42 })
+	})
+
+	test('returns 500 when the database returns an error', async () => {
+		mockRoundsResult = { data: null, error: { message: 'connection refused' }, count: 0 }
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(500)
+		expect(body).toEqual({ error: 'Failed to fetch rounds' })
+	})
+
+	test('accumulates vote weights from multiple tiers on the same option', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [{ id: 'opt-a', title: 'Option A' }],
+				},
+			],
+			error: null,
+			count: 1,
+		}
+		// bronze=1, diamond=10 both upvoting → total 11
+		mockVotesResult = {
+			data: [
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 1 },
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 10 },
+			],
+			error: null,
+		}
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+		const opt = body.data[0].options[0]
+
+		expect(opt.weighted_upvotes).toBe(11)
+		expect(opt.weighted_downvotes).toBe(0)
+	})
+
+	test('votes from other rounds do not bleed into the wrong round', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [{ id: 'opt-a', title: 'Option A' }],
+				},
+				{
+					id: 'round-2',
+					title: 'Round 2',
+					status: 'active',
+					options: [{ id: 'opt-a', title: 'Option A (round 2)' }],
+				},
+			],
+			error: null,
+			count: 2,
+		}
+		// opt-a exists in both rounds but with different weights per round
+		mockVotesResult = {
+			data: [
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 3 },
+				{ round_id: 'round-2', option_id: 'opt-a', vote_type: 'up', vote_weight: 8 },
+			],
+			error: null,
+		}
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(body.data[0].options[0].weighted_upvotes).toBe(3)
+		expect(body.data[1].options[0].weighted_upvotes).toBe(8)
+	})
+})


### PR DESCRIPTION
## Closes #989 

## Plan:

Define a compact candidate representation with a documented token budget cap
Pre-rank candidates before model invocation to reduce set size while retaining diversity
Cache user-context/candidate snapshots with invalidation on relevant profile, contribution, or project changes
Validate recommendation IDs against the candidate map; add tests for truncation, ranking, and cache invalidation