### PR TITLE
fix(web): recover escrow sync when Trustless Work indexer lags

### DIFF
--- a/apps/web/app/(routes)/projects/page.tsx
+++ b/apps/web/app/(routes)/projects/page.tsx
@@ -1,9 +1,10 @@
-import { prefetchSupabaseQuery } from '@packages/lib/supabase-server'
+import { createSupabaseServerClient, prefetchSupabaseQuery } from '@packages/lib/supabase-server'
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query'
 import type { Metadata } from 'next'
 import { ProjectsClientWrapper } from '~/components/sections/projects/projects-client-wrapper'
 import { ProjectsHero } from '~/components/sections/projects/projects-hero'
 import { JsonLd } from '~/components/shared/json-ld'
+import { PROJECTS_PAGE_SIZE } from '~/hooks/projects/use-paginated-projects'
 import { getViewerLocale } from '~/lib/i18n/locale-cookie.server'
 import { getAllCategories, getAllProjects } from '~/lib/queries/projects'
 import { getBreadcrumbSchema } from '~/lib/seo/structured-data'
@@ -41,13 +42,42 @@ export default async function ProjectsPage({
 	const categorySlugs = Array.isArray(category) ? category : category ? [category] : []
 	const viewerLocale = await getViewerLocale()
 
+	const categoryKey = categorySlugs.join(',')
+
 	await Promise.all([
-		prefetchSupabaseQuery(
-			queryClient,
-			'projects',
-			(client) => getAllProjects(client, categorySlugs, sortSlug, undefined, { viewerLocale }),
-			[categorySlugs, sortSlug, viewerLocale],
-		),
+		/**
+		 * Prefetch the first page of projects using the same query key shape as
+		 * `usePaginatedProjects` so the client hydrates correctly without a
+		 * second round-trip.
+		 */
+		(async () => {
+			const supabase = await createSupabaseServerClient()
+			await queryClient.prefetchInfiniteQuery({
+				queryKey: [
+					'projects-paginated',
+					categoryKey,
+					sortSlug,
+					viewerLocale,
+					PROJECTS_PAGE_SIZE,
+				] as const,
+				queryFn: async ({ pageParam = 0 }) => {
+					return getAllProjects(
+						supabase,
+						categorySlugs,
+						sortSlug,
+						PROJECTS_PAGE_SIZE,
+						{ viewerLocale },
+						pageParam as number,
+					)
+				},
+				initialPageParam: 0,
+				getNextPageParam: (lastPage) => {
+					const page = lastPage as { nextOffset: number | null }
+					return page.nextOffset ?? undefined
+				},
+				pages: 1, // Only prefetch the first page on the server
+			})
+		})(),
 		prefetchSupabaseQuery(queryClient, 'categories', getAllCategories),
 	])
 

--- a/apps/web/app/actions/escrow/sync-escrow-to-database.ts
+++ b/apps/web/app/actions/escrow/sync-escrow-to-database.ts
@@ -4,13 +4,17 @@ import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
 import type { EscrowType } from '@trustless-work/escrow'
 import {
 	enforceRateLimit,
+	escrowSyncRateLimiter,
 	requireAuthenticatedSession,
 	toServerActionFailure,
 	validateInput,
 } from '~/lib/auth/server-action-auth'
 import { Logger } from '~/lib/logger'
 import { syncEscrowToDatabaseInputSchema } from '~/lib/schemas/server-actions.schemas'
-import { getEscrowByContractIdFromIndexer } from '~/lib/services/escrow-indexer.service'
+import {
+	getEscrowByContractIdFromIndexer,
+	updateIndexerFromTxHash,
+} from '~/lib/services/escrow-indexer.service'
 import { mapIndexerEscrowToSaveData } from '~/lib/utils/escrow/map-indexer-escrow-to-save-data'
 import { inferEscrowTypeFromSaveData } from '~/lib/utils/escrow/resolve-escrow-type'
 import { assertCanManageProjectEscrow, persistEscrowContract } from './persist-escrow-contract'
@@ -22,6 +26,7 @@ type SyncEscrowParams = {
 	projectId: string
 	contractId: string
 	escrowSnapshot?: SaveEscrowContractParams['escrowData']
+	txHash?: string
 }
 
 export async function syncEscrowToDatabaseAction(
@@ -50,7 +55,7 @@ export async function syncEscrowToDatabaseAction(
 	}
 
 	try {
-		await enforceRateLimit(userId, 'sync_escrow_to_database')
+		await enforceRateLimit(userId, 'sync_escrow_to_database', escrowSyncRateLimiter)
 	} catch (error) {
 		const failure = toServerActionFailure(error, 'Too many requests. Please try again later.')
 		return { success: false, error: failure.error }
@@ -107,9 +112,26 @@ export async function syncEscrowToDatabaseAction(
 			escrowData = validated.escrowSnapshot
 			escrowType = inferEscrowTypeFromSaveData(escrowData)
 		} else {
-			const indexerResult = await getEscrowByContractIdFromIndexer(validated.contractId, {
-				validateOnChain: true,
+			let indexerResult = await getEscrowByContractIdFromIndexer(validated.contractId, {
+				validateOnChain: false,
 			})
+
+			if (!indexerResult.ok && validated.txHash) {
+				const refreshed = await updateIndexerFromTxHash(validated.txHash)
+				if (refreshed.ok) {
+					indexerResult = refreshed
+				} else {
+					indexerResult = await getEscrowByContractIdFromIndexer(validated.contractId, {
+						validateOnChain: false,
+					})
+					if (!indexerResult.ok) {
+						return {
+							success: false,
+							error: refreshed.error,
+						}
+					}
+				}
+			}
 
 			if (!indexerResult.ok) {
 				return {

--- a/apps/web/app/api/governance/rounds/[id]/route.ts
+++ b/apps/web/app/api/governance/rounds/[id]/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { buildOptionWeightMap } from '~/lib/governance/vote-weight'
 import { governanceRoundIdParamSchema } from '~/lib/schemas/governance.schemas'
 import { validateRequest } from '~/lib/utils/validation'
 
@@ -44,19 +45,11 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 			return NextResponse.json({ error: 'Round not found' }, { status: 404 })
 		}
 
-		const weightMap: Record<string, { up: number; down: number }> = {}
+		const weightMap = buildOptionWeightMap(votes ?? [])
 		let userVote: { option_id: string; vote_type: string } | null = null
-
-		for (const v of votes ?? []) {
-			if (!weightMap[v.option_id]) {
-				weightMap[v.option_id] = { up: 0, down: 0 }
-			}
-			if (v.vote_type === 'up') weightMap[v.option_id].up += v.vote_weight
-			else weightMap[v.option_id].down += v.vote_weight
-
-			if (session?.user?.id && v.user_id === session.user.id) {
-				userVote = { option_id: v.option_id, vote_type: v.vote_type }
-			}
+		if (session?.user?.id) {
+			const uv = (votes ?? []).find((v) => v.user_id === session.user.id)
+			if (uv) userVote = { option_id: uv.option_id, vote_type: uv.vote_type }
 		}
 
 		const enrichedOptions = (round.options ?? []).map((opt: { id: string }) => ({

--- a/apps/web/app/api/governance/rounds/route.ts
+++ b/apps/web/app/api/governance/rounds/route.ts
@@ -59,35 +59,36 @@ export async function GET(req: NextRequest) {
 			return NextResponse.json({ error: 'Failed to fetch rounds' }, { status: 500 })
 		}
 
-		// For each round, fetch aggregated vote weights per option
-		const enrichedRounds = await Promise.all(
-			(rounds ?? []).map(async (round) => {
-				const { data: votes } = await supabase
-					.from('governance_votes')
-					.select('option_id, vote_type, vote_weight')
-					.eq('round_id', round.id)
+		// Single bounded query: fetch all votes for all rounds in this page at once
+		const roundIds = (rounds ?? []).map((r) => r.id)
+		const { data: allVotes } =
+			roundIds.length > 0
+				? await supabase
+						.from('governance_votes')
+						.select('round_id, option_id, vote_type, vote_weight')
+						.in('round_id', roundIds)
+				: { data: [] }
 
-				const weightMap: Record<string, { up: number; down: number }> = {}
-				for (const v of votes ?? []) {
-					if (!weightMap[v.option_id]) {
-						weightMap[v.option_id] = { up: 0, down: 0 }
-					}
-					if (v.vote_type === 'up') {
-						weightMap[v.option_id].up += v.vote_weight
-					} else {
-						weightMap[v.option_id].down += v.vote_weight
-					}
-				}
+		// Build nested weight map: { [roundId]: { [optionId]: { up, down } } }
+		const votesByRound: Record<string, Record<string, { up: number; down: number }>> = {}
+		for (const v of allVotes ?? []) {
+			if (!votesByRound[v.round_id]) votesByRound[v.round_id] = {}
+			const roundMap = votesByRound[v.round_id]
+			if (!roundMap[v.option_id]) roundMap[v.option_id] = { up: 0, down: 0 }
+			if (v.vote_type === 'up') roundMap[v.option_id].up += v.vote_weight
+			else roundMap[v.option_id].down += v.vote_weight
+		}
 
-				const enrichedOptions = (round.options ?? []).map((opt: { id: string }) => ({
-					...opt,
-					weighted_upvotes: weightMap[opt.id]?.up ?? 0,
-					weighted_downvotes: weightMap[opt.id]?.down ?? 0,
-				}))
-
-				return { ...round, options: enrichedOptions }
-			}),
-		)
+		// Enrich options synchronously from the pre-built map
+		const enrichedRounds = (rounds ?? []).map((round) => {
+			const weightMap = votesByRound[round.id] ?? {}
+			const enrichedOptions = (round.options ?? []).map((opt: { id: string }) => ({
+				...opt,
+				weighted_upvotes: weightMap[opt.id]?.up ?? 0,
+				weighted_downvotes: weightMap[opt.id]?.down ?? 0,
+			}))
+			return { ...round, options: enrichedOptions }
+		})
 
 		return NextResponse.json({
 			success: true,

--- a/apps/web/app/api/nfts/[address]/route.ts
+++ b/apps/web/app/api/nfts/[address]/route.ts
@@ -1,5 +1,5 @@
 import { appEnvConfig } from '@packages/lib/config'
-import { isSmartAccountContractAddress } from '@packages/lib/utils/wallet-address'
+import { isValidStellarWalletAddress } from '@packages/lib/utils/wallet-address'
 import {
 	Account,
 	Address,
@@ -13,32 +13,44 @@ import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
 import { SmartWalletTransactionBuilderAdapter } from '@/lib/smart-account/adapters/transaction-builder.adapter'
-import { requireSmartAccountFeature } from '@/lib/smart-account/guards/require-smart-account-feature'
 import { addressParamSchema } from '~/lib/schemas/stellar.schemas'
+import { normalizeNftMetadata, normalizeStellarAddress } from '~/lib/utils/soroban-native'
 import { validateRequest } from '~/lib/utils/validation'
+
+type NftListItem = {
+	tokenId: number
+	owner: string
+	metadata: ReturnType<typeof normalizeNftMetadata>
+}
+
+const addressesMatch = (left: string, right: string): boolean =>
+	left.toLowerCase() === right.toLowerCase()
 
 /**
  * GET /api/nfts/[address]
  *
- * Get NFTs owned by a smart wallet address
- * Note: This is a simplified implementation. For production, use an indexer.
+ * Get NFTs owned by a Stellar wallet address (G-address or Smart Account C-address).
+ * Optional `tokenId` query param fetches a specific token (faster, used when DB record exists).
  */
-export async function GET(_req: NextRequest, { params }: { params: Promise<{ address: string }> }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ address: string }> }) {
 	try {
-		const featureGuard = requireSmartAccountFeature()
-		if (featureGuard) return featureGuard
-
 		const { address } = await params
 		const validation = validateRequest(addressParamSchema, { address })
 		if (!validation.success) return validation.response
 		const { address: validatedAddress } = validation.data
 
-		if (!isSmartAccountContractAddress(validatedAddress)) {
+		if (!isValidStellarWalletAddress(validatedAddress)) {
 			return NextResponse.json(
-				{ error: 'NFT endpoint requires a Smart Account C-address' },
+				{ error: 'Must be a valid Stellar G-address or C-address' },
 				{ status: 400 },
 			)
 		}
+
+		const tokenIdParam = req.nextUrl.searchParams.get('tokenId')
+		const hintedTokenId =
+			tokenIdParam !== null && tokenIdParam !== '' ? Number.parseInt(tokenIdParam, 10) : null
+		const hasValidTokenHint =
+			hintedTokenId !== null && Number.isInteger(hintedTokenId) && hintedTokenId >= 0
 
 		const nftContractAddress =
 			process.env.NFT_CONTRACT_ADDRESS || process.env.NEXT_PUBLIC_NFT_CONTRACT_ADDRESS
@@ -52,7 +64,6 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ add
 			)
 		}
 
-		// Get configuration
 		const config = appEnvConfig('web')
 
 		const txService = new SmartWalletTransactionBuilderAdapter(
@@ -61,35 +72,77 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ add
 			config.stellar.fundingAccount,
 		)
 
-		// Use funding account for simulation (required for read operations)
 		const sourceAccount = config.stellar.fundingAccount
 			? await txService.getService().getFundingAccountForSimulation()
 			: new Account(validatedAddress, '0')
 
 		const nftContract = new Contract(nftContractAddress)
+		const simulate = async (operation: ReturnType<Contract['call']>) => {
+			const tx = new TransactionBuilder(sourceAccount, {
+				fee: '100',
+				networkPassphrase: config.stellar.networkPassphrase,
+			})
+				.addOperation(operation)
+				.setTimeout(30)
+				.build()
 
-		// Get balance (number of NFTs owned)
-		const balanceOp = nftContract.call(
-			'balance',
-			nativeToScVal(Address.fromString(validatedAddress), { type: 'address' }),
+			return txService.getService().simulateTransaction(tx)
+		}
+
+		const fetchOwnedNft = async (tokenId: number): Promise<NftListItem | null> => {
+			const ownerSim = await simulate(
+				nftContract.call('owner_of', nativeToScVal(tokenId, { type: 'u32' })),
+			)
+
+			if (Api.isSimulationError(ownerSim) || !ownerSim.result?.retval) {
+				return null
+			}
+
+			const ownerAddress = normalizeStellarAddress(scValToNative(ownerSim.result.retval))
+			if (!ownerAddress || !addressesMatch(ownerAddress, validatedAddress)) {
+				return null
+			}
+
+			const metadataSim = await simulate(
+				nftContract.call('get_metadata', nativeToScVal(tokenId, { type: 'u32' })),
+			)
+
+			if (Api.isSimulationError(metadataSim) || !metadataSim.result?.retval) {
+				return null
+			}
+
+			const metadata = normalizeNftMetadata(scValToNative(metadataSim.result.retval), tokenId)
+
+			return {
+				tokenId,
+				owner: ownerAddress,
+				metadata,
+			}
+		}
+
+		if (hasValidTokenHint) {
+			const hintedNft = await fetchOwnedNft(hintedTokenId as number)
+			return NextResponse.json({
+				success: true,
+				data: {
+					nfts: hintedNft ? [hintedNft] : [],
+					total: hintedNft ? 1 : 0,
+				},
+			})
+		}
+
+		const balanceSim = await simulate(
+			nftContract.call(
+				'balance',
+				nativeToScVal(Address.fromString(validatedAddress), { type: 'address' }),
+			),
 		)
-
-		const balanceTx = new TransactionBuilder(sourceAccount, {
-			fee: '100',
-			networkPassphrase: config.stellar.networkPassphrase,
-		})
-			.addOperation(balanceOp)
-			.setTimeout(30)
-			.build()
-
-		const balanceSim = await txService.getService().simulateTransaction(balanceTx)
 
 		let balance = 0
 		if (!Api.isSimulationError(balanceSim) && balanceSim.result?.retval) {
 			balance = Number(scValToNative(balanceSim.result.retval))
 		}
 
-		// If balance is 0, return empty array
 		if (balance === 0) {
 			return NextResponse.json({
 				success: true,
@@ -100,91 +153,21 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ add
 			})
 		}
 
-		// Get total supply to know max token ID
-		const totalSupplyOp = nftContract.call('total_supply')
-		const totalSupplyTx = new TransactionBuilder(sourceAccount, {
-			fee: '100',
-			networkPassphrase: config.stellar.networkPassphrase,
-		})
-			.addOperation(totalSupplyOp)
-			.setTimeout(30)
-			.build()
-
-		const totalSupplySim = await txService.getService().simulateTransaction(totalSupplyTx)
+		const totalSupplySim = await simulate(nftContract.call('total_supply'))
 
 		let totalSupply = 0
 		if (!Api.isSimulationError(totalSupplySim) && totalSupplySim.result?.retval) {
 			totalSupply = Number(scValToNative(totalSupplySim.result.retval))
 		}
 
-		// Fetch NFTs owned by this address
-		// Note: This is inefficient - ideally use an indexer
-		const nfts = []
-		const maxTokensToCheck = Math.min(totalSupply, 100) // Limit to 100 for performance
+		const nfts: NftListItem[] = []
+		const maxTokensToCheck = Math.min(totalSupply, 100)
 
 		for (let tokenId = 0; tokenId < maxTokensToCheck; tokenId++) {
 			try {
-				// Check owner
-				const ownerOp = nftContract.call('owner_of', nativeToScVal(tokenId, { type: 'u32' }))
-				const ownerTx = new TransactionBuilder(sourceAccount, {
-					fee: '100',
-					networkPassphrase: config.stellar.networkPassphrase,
-				})
-					.addOperation(ownerOp)
-					.setTimeout(30)
-					.build()
-
-				const ownerSim = await txService.getService().simulateTransaction(ownerTx)
-
-				if (!Api.isSimulationError(ownerSim) && ownerSim.result?.retval) {
-					const ownerAddress = scValToNative(ownerSim.result.retval)
-
-					// If this address owns the token, get metadata
-					if (
-						ownerAddress &&
-						String(ownerAddress).toLowerCase() === validatedAddress.toLowerCase()
-					) {
-						const metadataOp = nftContract.call(
-							'get_metadata',
-							nativeToScVal(tokenId, { type: 'u32' }),
-						)
-						const metadataTx = new TransactionBuilder(sourceAccount, {
-							fee: '100',
-							networkPassphrase: config.stellar.networkPassphrase,
-						})
-							.addOperation(metadataOp)
-							.setTimeout(30)
-							.build()
-
-						const metadataSim = await txService.getService().simulateTransaction(metadataTx)
-
-						if (!Api.isSimulationError(metadataSim) && metadataSim.result?.retval) {
-							const metadata = scValToNative(metadataSim.result.retval) as {
-								name?: string
-								description?: string
-								image_uri?: string
-								external_url?: string
-								attributes?: Array<{
-									trait_type: string
-									value: string
-									display_type?: string
-									max_value?: string
-								}>
-							}
-
-							nfts.push({
-								tokenId,
-								owner: String(ownerAddress),
-								metadata: {
-									name: metadata.name || `Kinder NFT #${tokenId}`,
-									description: metadata.description || '',
-									image_uri: metadata.image_uri || '',
-									external_url: metadata.external_url || '',
-									attributes: metadata.attributes || [],
-								},
-							})
-						}
-					}
+				const nft = await fetchOwnedNft(tokenId)
+				if (nft) {
+					nfts.push(nft)
 				}
 			} catch (_error) {}
 		}

--- a/apps/web/app/api/nfts/user/route.ts
+++ b/apps/web/app/api/nfts/user/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import { getIPFSUrl } from '~/lib/services/pinata'
 import { getUserStats } from '~/lib/services/user-stats'
 
 /**
@@ -30,8 +31,15 @@ export async function GET() {
 			logger.error('Error fetching user NFT:', error)
 		}
 
+		const imageUrl = nft?.image_ipfs_hash ? getIPFSUrl(nft.image_ipfs_hash) : null
+
 		return NextResponse.json({
-			nft: nft || null,
+			nft: nft
+				? {
+						...nft,
+						image_url: imageUrl,
+					}
+				: null,
 			stats,
 		})
 	} catch (error) {

--- a/apps/web/app/api/profile/project-matching/route.ts
+++ b/apps/web/app/api/profile/project-matching/route.ts
@@ -3,13 +3,16 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
 import { nextAuthOption } from '~/lib/auth/auth-options'
+import type { UserMatchingContext } from '~/lib/services/project-matching/build-matching-context'
 import {
 	buildMatchingPrompt,
 	buildUserMatchingContext,
 	fetchMatchingCandidates,
 	MATCHING_SYSTEM_PROMPT,
+	preRankCandidates,
 } from '~/lib/services/project-matching/build-matching-context'
 import {
+	type MatchingCandidateProject,
 	matchingAiResponseSchema,
 	type ProjectMatchingResult,
 } from '~/lib/services/project-matching/schemas'
@@ -18,8 +21,17 @@ export const maxDuration = 30
 
 const DEFAULT_MATCHING_MODEL = 'google/gemini-2.5-flash-lite'
 const MIN_CANDIDATES = 3
+const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
 
-export async function POST() {
+interface MatchingCacheEntry {
+	userContext: UserMatchingContext
+	candidates: MatchingCandidateProject[]
+	cachedAt: number
+}
+
+const matchingCache = new Map<string, MatchingCacheEntry>()
+
+export async function POST(request: Request) {
 	try {
 		const session = await getServerSession(nextAuthOption)
 		if (!session?.user?.id) {
@@ -29,10 +41,24 @@ export async function POST() {
 		const userId = session.user.id
 		const { supabase } = await import('@packages/lib/supabase')
 
-		const [userContext, candidates] = await Promise.all([
-			buildUserMatchingContext(supabase, userId),
-			fetchMatchingCandidates(supabase, userId),
-		])
+		const forceRefresh = request.headers.get('x-invalidate-cache') === 'true'
+		const cached = matchingCache.get(userId)
+		const isCacheValid =
+			!forceRefresh && cached !== undefined && Date.now() - cached.cachedAt < CACHE_TTL_MS
+
+		let userContext: UserMatchingContext
+		let candidates: MatchingCandidateProject[]
+
+		if (isCacheValid) {
+			userContext = cached.userContext
+			candidates = cached.candidates
+		} else {
+			;[userContext, candidates] = await Promise.all([
+				buildUserMatchingContext(supabase, userId),
+				fetchMatchingCandidates(supabase, userId),
+			])
+			matchingCache.set(userId, { userContext, candidates, cachedAt: Date.now() })
+		}
 
 		if (candidates.length < MIN_CANDIDATES) {
 			return NextResponse.json(
@@ -47,6 +73,8 @@ export async function POST() {
 		const modelId = process.env.AI_PROJECT_MATCHING_MODEL ?? DEFAULT_MATCHING_MODEL
 		const candidateMap = new Map(candidates.map((project) => [project.id, project]))
 
+		const promptCandidates = preRankCandidates(userContext, candidates)
+
 		const { object } = await generateObject({
 			model: gateway(modelId),
 			schema: matchingAiResponseSchema,
@@ -54,7 +82,7 @@ export async function POST() {
 			schemaDescription:
 				'Personalized project recommendations for a KindFi donor based on their profile and history',
 			system: MATCHING_SYSTEM_PROMPT,
-			prompt: buildMatchingPrompt(userContext, candidates),
+			prompt: buildMatchingPrompt(userContext, promptCandidates),
 			providerOptions: {
 				gateway: {
 					user: userId,

--- a/apps/web/app/api/projects/[slug]/donations/stream/route.ts
+++ b/apps/web/app/api/projects/[slug]/donations/stream/route.ts
@@ -1,9 +1,15 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import { unstable_cache } from 'next/cache'
 import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
 import { getProjectIdBySlug } from '~/lib/api/authorize-project-manage'
 import { getProjectDonationStream } from '~/lib/queries/projects/get-project-donation-stream'
 import { validateProjectSlug } from '~/lib/validation/project-slug'
+
+const getProjectIdBySlugCached = unstable_cache(getProjectIdBySlug, ['project-id-by-slug'], {
+	revalidate: 300,
+	tags: ['project-slug'],
+})
 
 export async function GET(req: Request, { params }: { params: Promise<{ slug: string }> }) {
 	try {
@@ -13,7 +19,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ slug: st
 			return NextResponse.json({ error: 'Invalid project slug' }, { status: 400 })
 		}
 
-		const projectId = await getProjectIdBySlug(slug)
+		const projectId = await getProjectIdBySlugCached(slug)
 		if (!projectId) {
 			return NextResponse.json({ error: 'Project not found' }, { status: 404 })
 		}
@@ -21,8 +27,9 @@ export async function GET(req: Request, { params }: { params: Promise<{ slug: st
 		const url = new URL(req.url)
 		const limitParam = Number(url.searchParams.get('limit') ?? 15)
 		const limit = Number.isFinite(limitParam) ? limitParam : 15
+		const after = url.searchParams.get('after') ?? undefined
 
-		const data = await getProjectDonationStream(supabaseServiceRole, projectId, limit)
+		const data = await getProjectDonationStream(supabaseServiceRole, projectId, limit, after)
 
 		return NextResponse.json({ data })
 	} catch (error) {

--- a/apps/web/app/api/trustless-work/[...path]/route.ts
+++ b/apps/web/app/api/trustless-work/[...path]/route.ts
@@ -1,5 +1,7 @@
 import { proxyTrustlessWorkRequest } from '~/lib/services/trustless-work-proxy.service'
 
+export const maxDuration = 60
+
 type RouteContext = {
 	params: Promise<{ path: string[] }>
 }

--- a/apps/web/components/sections/gamification/nft-collection/components/nft-additional-list.tsx
+++ b/apps/web/components/sections/gamification/nft-collection/components/nft-additional-list.tsx
@@ -1,13 +1,16 @@
 import { ImageIcon } from 'lucide-react'
 import Image from 'next/image'
 import { Card, CardContent } from '~/components/base/card'
+import type { Tier } from '../constants'
 import type { NFT } from '../types'
+import { resolveNftImageUri } from '../utils/helpers'
 
 interface NftAdditionalListProps {
 	nfts: NFT[]
+	dbTier: Tier
 }
 
-export function NftAdditionalList({ nfts }: NftAdditionalListProps) {
+export function NftAdditionalList({ nfts, dbTier }: NftAdditionalListProps) {
 	if (nfts.length <= 1) {
 		return null
 	}
@@ -18,31 +21,34 @@ export function NftAdditionalList({ nfts }: NftAdditionalListProps) {
 				Other NFTs ({nfts.length - 1})
 			</h4>
 			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-				{nfts.slice(1).map((extra) => (
-					<Card key={extra.tokenId} className="overflow-hidden hover:shadow-md transition-shadow">
-						<div className="relative h-40 bg-muted">
-							{extra.metadata.image_uri ? (
-								<Image
-									src={extra.metadata.image_uri}
-									alt={extra.metadata.name}
-									fill
-									className="object-cover"
-									unoptimized
-								/>
-							) : (
-								<div className="flex items-center justify-center h-full">
-									<ImageIcon className="h-10 w-10 text-muted-foreground" />
+				{nfts.slice(1).map((extra) => {
+					const imageUri = resolveNftImageUri(extra, null, dbTier)
+					return (
+						<Card key={extra.tokenId} className="overflow-hidden hover:shadow-md transition-shadow">
+							<div className="relative h-40 bg-muted">
+								{imageUri ? (
+									<Image
+										src={imageUri}
+										alt={extra.metadata.name}
+										fill
+										className="object-cover"
+										unoptimized
+									/>
+								) : (
+									<div className="flex items-center justify-center h-full">
+										<ImageIcon className="h-10 w-10 text-muted-foreground" />
+									</div>
+								)}
+								<div className="absolute top-2 right-2 bg-black/70 text-white text-xs px-2 py-1 rounded">
+									#{extra.tokenId.toString().padStart(4, '0')}
 								</div>
-							)}
-							<div className="absolute top-2 right-2 bg-black/70 text-white text-xs px-2 py-1 rounded">
-								#{extra.tokenId.toString().padStart(4, '0')}
 							</div>
-						</div>
-						<CardContent className="p-3">
-							<h4 className="font-medium text-sm line-clamp-1">{extra.metadata.name}</h4>
-						</CardContent>
-					</Card>
-				))}
+							<CardContent className="p-3">
+								<h4 className="font-medium text-sm line-clamp-1">{extra.metadata.name}</h4>
+							</CardContent>
+						</Card>
+					)
+				})}
 			</div>
 		</>
 	)

--- a/apps/web/components/sections/gamification/nft-collection/components/nft-hero-card.tsx
+++ b/apps/web/components/sections/gamification/nft-collection/components/nft-hero-card.tsx
@@ -11,6 +11,7 @@ import type { NFT, UserNFTRecord } from '../types'
 interface NftHeroCardProps {
 	nft: NFT | undefined
 	dbNft: UserNFTRecord | null
+	imageUri: string | null
 	tier: Tier
 	currentPts: number
 	progressPct: number
@@ -21,6 +22,7 @@ interface NftHeroCardProps {
 export function NftHeroCard({
 	nft,
 	dbNft,
+	imageUri,
 	tier,
 	currentPts,
 	progressPct,
@@ -34,10 +36,10 @@ export function NftHeroCard({
 		<Card className="overflow-hidden">
 			<div className="flex flex-col sm:flex-row">
 				<div className="relative w-full sm:w-56 h-56 sm:h-auto bg-muted shrink-0">
-					{nft?.metadata?.image_uri ? (
+					{imageUri ? (
 						<Image
-							src={nft.metadata.image_uri}
-							alt={nft.metadata.name}
+							src={imageUri}
+							alt={nft?.metadata?.name ?? `${tierConfig.label} Kinder`}
 							fill
 							className="object-cover"
 							unoptimized

--- a/apps/web/components/sections/gamification/nft-collection/components/nft-metadata-panel.tsx
+++ b/apps/web/components/sections/gamification/nft-collection/components/nft-metadata-panel.tsx
@@ -11,6 +11,7 @@ import { AttrChip } from '../utils/helpers'
 interface NftMetadataPanelProps {
 	nft: NFT | undefined
 	dbNft: UserNFTRecord | null
+	imageUri: string | null
 	userStats: UserStats | undefined
 	tier: Tier
 	showMetadata: boolean
@@ -22,6 +23,7 @@ interface NftMetadataPanelProps {
 export function NftMetadataPanel({
 	nft,
 	dbNft,
+	imageUri,
 	userStats,
 	tier,
 	showMetadata,
@@ -70,16 +72,16 @@ export function NftMetadataPanel({
 								<span className="text-right">{nft.metadata.description}</span>
 							</div>
 						)}
-						{nft?.metadata?.image_uri && (
+						{(nft?.metadata?.image_uri || imageUri) && (
 							<div className="flex justify-between gap-2">
 								<span className="text-muted-foreground shrink-0">Image URI</span>
 								<a
-									href={nft.metadata.image_uri}
+									href={nft?.metadata?.image_uri || imageUri || '#'}
 									target="_blank"
 									rel="noopener noreferrer"
 									className="text-primary hover:underline text-xs truncate max-w-[200px]"
 								>
-									{nft.metadata.image_uri}
+									{nft?.metadata?.image_uri || imageUri}
 								</a>
 							</div>
 						)}

--- a/apps/web/components/sections/gamification/nft-collection/hooks/use-nft-collection.ts
+++ b/apps/web/components/sections/gamification/nft-collection/hooks/use-nft-collection.ts
@@ -1,18 +1,21 @@
 'use client'
 
+import { isValidStellarWalletAddress } from '@packages/lib/utils/wallet-address'
 import { useQuery } from '@tanstack/react-query'
 import { useSession } from 'next-auth/react'
 import { useEffectiveWalletAddress } from '~/hooks/wallet/use-effective-wallet-address'
-import { resolveSmartAccountAddress } from '~/lib/utils/wallet-address'
+import { resolveEffectiveGamificationAddress } from '~/lib/utils/wallet-address'
 import type { NFTCollectionResponse, UserNFTRecord, UserStats } from '../types'
 
 export function useNftCollection() {
 	const { data: session } = useSession()
 	const { address: effectiveAddress } = useEffectiveWalletAddress()
 
-	const smartAccountAddress =
-		resolveSmartAccountAddress(session?.device?.address || session?.user?.device?.address) ??
-		effectiveAddress
+	const walletAddress = resolveEffectiveGamificationAddress({
+		smartAccountAddress: session?.device?.address || session?.user?.device?.address,
+		sessionWalletAddress: session?.wallet?.address ?? session?.user?.wallet?.address,
+		kitWalletAddress: effectiveAddress,
+	})
 
 	const { data: userData, isLoading: dbLoading } = useQuery<{
 		nft: UserNFTRecord | null
@@ -38,21 +41,33 @@ export function useNftCollection() {
 		enabled: !!session?.user?.id,
 	})
 
+	const dbNft = userData?.nft ?? null
+
+	const onChainAddress =
+		dbNft?.stellar_address && isValidStellarWalletAddress(dbNft.stellar_address)
+			? dbNft.stellar_address
+			: walletAddress
+
+	const tokenIdHint =
+		dbNft && Number.isInteger(dbNft.token_id) && dbNft.token_id >= 0 ? dbNft.token_id : null
+
 	const { data: onChainData, isLoading: chainLoading } = useQuery<NFTCollectionResponse>({
-		queryKey: ['nfts', smartAccountAddress],
+		queryKey: ['nfts', onChainAddress, tokenIdHint],
 		queryFn: async () => {
-			if (!smartAccountAddress) throw new Error('No wallet')
-			const res = await fetch(`/api/nfts/${smartAccountAddress}`)
+			if (!onChainAddress) throw new Error('No wallet')
+			const query =
+				tokenIdHint !== null ? `?tokenId=${encodeURIComponent(String(tokenIdHint))}` : ''
+			const res = await fetch(`/api/nfts/${onChainAddress}${query}`)
 			if (!res.ok) throw new Error('Failed to fetch NFTs')
 			return res.json()
 		},
-		enabled: !!smartAccountAddress,
+		enabled: !!onChainAddress,
 	})
 
 	return {
 		session,
-		smartAccountAddress,
-		dbNft: userData?.nft ?? null,
+		smartAccountAddress: walletAddress,
+		dbNft,
 		userStats: userData?.stats,
 		onChainData,
 		isLoading: dbLoading || chainLoading,

--- a/apps/web/components/sections/gamification/nft-collection/nft-collection.tsx
+++ b/apps/web/components/sections/gamification/nft-collection/nft-collection.tsx
@@ -10,7 +10,7 @@ import { TierRoadmap } from './components/tier-roadmap'
 import type { Tier } from './constants'
 import { TIERS } from './constants'
 import { useNftCollection } from './hooks/use-nft-collection'
-import { findAttr, resolveDonationCount } from './utils/helpers'
+import { findAttr, resolveDonationCount, resolveNftImageUri } from './utils/helpers'
 
 export function NFTCollection() {
 	const [showMetadata, setShowMetadata] = useState(false)
@@ -34,6 +34,7 @@ export function NFTCollection() {
 	}
 
 	const nft = nfts[0]
+	const imageUri = resolveNftImageUri(nft, dbNft, tier)
 	const attrs = nft?.metadata?.attributes ?? []
 	const impactScoreOnChain = findAttr(attrs, 'Impact Score')
 	const questsOnChain = findAttr(attrs, 'Quests Completed')
@@ -60,6 +61,7 @@ export function NFTCollection() {
 			<NftHeroCard
 				nft={nft}
 				dbNft={dbNft}
+				imageUri={imageUri}
 				tier={tier}
 				currentPts={currentPts}
 				progressPct={progressPct}
@@ -78,6 +80,7 @@ export function NFTCollection() {
 			<NftMetadataPanel
 				nft={nft}
 				dbNft={dbNft}
+				imageUri={imageUri}
 				userStats={userStats}
 				tier={tier}
 				showMetadata={showMetadata}
@@ -86,7 +89,7 @@ export function NFTCollection() {
 				nftContractAddress={dbNft?.contract_address}
 			/>
 
-			<NftAdditionalList nfts={nfts} />
+			<NftAdditionalList nfts={nfts} dbTier={tier} />
 
 			<TierRoadmap tier={tier} />
 		</div>

--- a/apps/web/components/sections/gamification/nft-collection/types.ts
+++ b/apps/web/components/sections/gamification/nft-collection/types.ts
@@ -32,6 +32,8 @@ export interface UserNFTRecord {
 	contract_address: string
 	stellar_address: string
 	image_ipfs_hash: string | null
+	/** Resolved IPFS gateway URL (from /api/nfts/user). */
+	image_url?: string | null
 	minted_at: string
 	evolved_at: string | null
 }

--- a/apps/web/components/sections/gamification/nft-collection/utils/helpers.tsx
+++ b/apps/web/components/sections/gamification/nft-collection/utils/helpers.tsx
@@ -1,4 +1,40 @@
-import type { NFTAttribute, UserStats } from '../types'
+import type { Tier } from '../constants'
+import type { NFT, NFTAttribute, UserNFTRecord, UserStats } from '../types'
+
+const DEFAULT_IPFS_GATEWAY = 'https://gateway.pinata.cloud/ipfs'
+
+export function ipfsHashToUrl(hash: string): string {
+	if (hash.startsWith('http://') || hash.startsWith('https://')) {
+		return hash
+	}
+	if (hash.startsWith('ipfs://')) {
+		return `${DEFAULT_IPFS_GATEWAY}/${hash.replace('ipfs://', '')}`
+	}
+	return `${DEFAULT_IPFS_GATEWAY}/${hash}`
+}
+
+/** Resolve the best image URL from on-chain metadata, DB IPFS hash, or tier fallback. */
+export function resolveNftImageUri(
+	nft: NFT | undefined,
+	dbNft: UserNFTRecord | null,
+	tier: Tier,
+): string | null {
+	const onChain = nft?.metadata?.image_uri?.trim()
+	if (onChain) {
+		return onChain
+	}
+
+	const dbImageUrl = dbNft?.image_url?.trim()
+	if (dbImageUrl) {
+		return dbImageUrl
+	}
+
+	if (dbNft?.image_ipfs_hash) {
+		return ipfsHashToUrl(dbNft.image_ipfs_hash)
+	}
+
+	return `https://kindfi.org/images/nft-${tier}.svg`
+}
 
 export function findAttr(attrs: NFTAttribute[], traitType: string): string | undefined {
 	return attrs.find((a) => a.trait_type === traitType)?.value

--- a/apps/web/components/sections/profile/cards/kyc-card.tsx
+++ b/apps/web/components/sections/profile/cards/kyc-card.tsx
@@ -26,10 +26,6 @@ export function KYCCard({ userId, shouldRefresh = false }: KYCCardProps) {
 	const [showRedirectModal, setShowRedirectModal] = useState(false)
 	const [verificationUrl, setVerificationUrl] = useState<string | null>(null)
 
-	useEffect(() => {
-		refreshStatus()
-	}, [refreshStatus])
-
 	const refreshRef = useRef(refreshStatus)
 	refreshRef.current = refreshStatus
 

--- a/apps/web/components/sections/profile/profile-section-tabs.tsx
+++ b/apps/web/components/sections/profile/profile-section-tabs.tsx
@@ -223,50 +223,58 @@ const ProfileSectionTabsInner = ({
 			</div>
 
 			<TabsContent value="overview" className="mt-0">
-				{renderSection('overview')}
+				{activeSection === 'overview' ? renderSection('overview') : null}
 			</TabsContent>
 			<TabsContent value="ramps" className="mt-0">
-				<FiatRampsSection
-					userId={user.id}
-					walletAddress={effectiveWalletAddress}
-					isWalletReady={isWalletReady}
-					isPollarUser={isPollarUser}
-					onConnectKit={onConnectKit}
-				/>
+				{activeSection === 'ramps' ? (
+					<FiatRampsSection
+						userId={user.id}
+						walletAddress={effectiveWalletAddress}
+						isWalletReady={isWalletReady}
+						isPollarUser={isPollarUser}
+						onConnectKit={onConnectKit}
+					/>
+				) : null}
 			</TabsContent>
 			<TabsContent value="gamification" className="mt-0">
-				{renderSection('gamification')}
+				{activeSection === 'gamification' ? renderSection('gamification') : null}
 			</TabsContent>
 			<TabsContent value="referrals" className="mt-0">
-				<ReferralSection
-					profilePollarAddress={user.profile?.pollar_wallet_address}
-					profileExternalAddress={user.profile?.external_wallet_address}
-				/>
+				{activeSection === 'referrals' ? (
+					<ReferralSection
+						profilePollarAddress={user.profile?.pollar_wallet_address}
+						profileExternalAddress={user.profile?.external_wallet_address}
+					/>
+				) : null}
 			</TabsContent>
 			<TabsContent value="donations" className="mt-0">
-				{role === 'donor' ? renderSection('donations') : null}
+				{activeSection === 'donations' && role === 'donor' ? renderSection('donations') : null}
 			</TabsContent>
 			<TabsContent value="campaigns" className="mt-0">
-				{showCreatorProfile ? renderSection('campaigns') : null}
+				{activeSection === 'campaigns' && showCreatorProfile ? renderSection('campaigns') : null}
 			</TabsContent>
 			<TabsContent value="foundations" className="mt-0">
-				{showCreatorProfile ? renderSection('foundations') : null}
+				{activeSection === 'foundations' && showCreatorProfile
+					? renderSection('foundations')
+					: null}
 			</TabsContent>
 			<TabsContent value="settings" className="mt-0">
-				<div className="grid gap-6 lg:grid-cols-2">
-					<PersonalInfoCard
-						userId={user.id}
-						displayName={user.profile?.display_name ?? ''}
-						bio={user.profile?.bio ?? ''}
-						imageUrl={user.profile?.image_url ?? ''}
-						_email={user.email}
-					/>
-					<AccountInfoCard
-						userEmail={user.email}
-						createdAt={user.created_at}
-						slug={user.profile?.slug ?? ''}
-					/>
-				</div>
+				{activeSection === 'settings' ? (
+					<div className="grid gap-6 lg:grid-cols-2">
+						<PersonalInfoCard
+							userId={user.id}
+							displayName={user.profile?.display_name ?? ''}
+							bio={user.profile?.bio ?? ''}
+							imageUrl={user.profile?.image_url ?? ''}
+							_email={user.email}
+						/>
+						<AccountInfoCard
+							userEmail={user.email}
+							createdAt={user.created_at}
+							slug={user.profile?.slug ?? ''}
+						/>
+					</div>
+				) : null}
 			</TabsContent>
 		</Tabs>
 	)

--- a/apps/web/components/sections/profile/views/creator-profile/creator-campaigns-section.tsx
+++ b/apps/web/components/sections/profile/views/creator-profile/creator-campaigns-section.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { AnimatePresence } from 'framer-motion'
 import { Plus, Target } from 'lucide-react'
 import Link from 'next/link'
 import { Button } from '~/components/base/button'
@@ -48,35 +47,33 @@ export function CreatorCampaignsSection({
 				</Button>
 			</div>
 
-			<AnimatePresence mode="wait">
-				{isLoading ? (
-					<p className="py-12 text-center text-muted-foreground">{t('profile.loadingCampaigns')}</p>
-				) : error ? (
-					<ProfileSurfaceCard>
-						<p className="py-8 text-center text-destructive">{t('profile.campaignsError')}</p>
-					</ProfileSurfaceCard>
-				) : projectsWithBalances.length > 0 ? (
-					<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-						{projectsWithBalances.map((project) => (
-							<ProjectCard key={project.id} project={project} t={t} />
-						))}
-					</div>
-				) : (
-					<ProfileSurfaceCard className="py-12 text-center">
-						<Target className="mx-auto mb-4 h-12 w-12 text-emerald-600/70" />
-						<h3 className="mb-2 text-lg font-semibold">{t('profile.noCampaignsTitle')}</h3>
-						<p className="mx-auto mb-6 max-w-md text-sm text-muted-foreground">
-							{t('profile.noCampaignsDescription')}
-						</p>
-						<Button asChild className="gradient-btn rounded-full text-white">
-							<Link href="/create-project">
-								<Plus className="h-4 w-4 mr-2" />
-								{t('profile.createFirstCampaign')}
-							</Link>
-						</Button>
-					</ProfileSurfaceCard>
-				)}
-			</AnimatePresence>
+			{isLoading && projectsWithBalances.length === 0 ? (
+				<p className="py-12 text-center text-muted-foreground">{t('profile.loadingCampaigns')}</p>
+			) : error ? (
+				<ProfileSurfaceCard>
+					<p className="py-8 text-center text-destructive">{t('profile.campaignsError')}</p>
+				</ProfileSurfaceCard>
+			) : projectsWithBalances.length > 0 ? (
+				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+					{projectsWithBalances.map((project) => (
+						<ProjectCard key={project.id} project={project} t={t} />
+					))}
+				</div>
+			) : (
+				<ProfileSurfaceCard className="py-12 text-center">
+					<Target className="mx-auto mb-4 h-12 w-12 text-emerald-600/70" />
+					<h3 className="mb-2 text-lg font-semibold">{t('profile.noCampaignsTitle')}</h3>
+					<p className="mx-auto mb-6 max-w-md text-sm text-muted-foreground">
+						{t('profile.noCampaignsDescription')}
+					</p>
+					<Button asChild className="gradient-btn rounded-full text-white">
+						<Link href="/create-project">
+							<Plus className="h-4 w-4 mr-2" />
+							{t('profile.createFirstCampaign')}
+						</Link>
+					</Button>
+				</ProfileSurfaceCard>
+			)}
 		</div>
 	)
 }

--- a/apps/web/components/sections/profile/views/creator-profile/creator-overview.tsx
+++ b/apps/web/components/sections/profile/views/creator-profile/creator-overview.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { AnimatePresence } from 'framer-motion'
 import { Plus, Target } from 'lucide-react'
 import Link from 'next/link'
 import { Button } from '~/components/base/button'
@@ -78,38 +77,36 @@ export function CreatorOverview({
 				</div>
 			)}
 
-			<AnimatePresence mode="wait">
-				{isLoading ? (
-					<p className="py-12 text-center text-muted-foreground">{t('profile.loadingCampaigns')}</p>
-				) : error ? (
-					<ProfileSurfaceCard>
-						<p className="py-8 text-center text-destructive">{t('profile.campaignsError')}</p>
-					</ProfileSurfaceCard>
-				) : projectsWithBalances.length > 0 ? (
-					<div className="space-y-4">
-						<h3 className="text-lg font-semibold">{t('profile.allCampaignsSection')}</h3>
-						<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-							{projectsWithBalances.map((project) => (
-								<ProjectCard key={project.id} project={project} compact t={t} />
-							))}
-						</div>
+			{isLoading && projectsWithBalances.length === 0 ? (
+				<p className="py-12 text-center text-muted-foreground">{t('profile.loadingCampaigns')}</p>
+			) : error ? (
+				<ProfileSurfaceCard>
+					<p className="py-8 text-center text-destructive">{t('profile.campaignsError')}</p>
+				</ProfileSurfaceCard>
+			) : projectsWithBalances.length > 0 ? (
+				<div className="space-y-4">
+					<h3 className="text-lg font-semibold">{t('profile.allCampaignsSection')}</h3>
+					<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						{projectsWithBalances.map((project) => (
+							<ProjectCard key={project.id} project={project} compact t={t} />
+						))}
 					</div>
-				) : !isLoading ? (
-					<ProfileSurfaceCard className="py-12 text-center">
-						<Target className="mx-auto mb-4 h-12 w-12 text-emerald-600/70" />
-						<h3 className="mb-2 text-lg font-semibold">{t('profile.noCampaignsTitle')}</h3>
-						<p className="mx-auto mb-6 max-w-md text-sm text-muted-foreground">
-							{t('profile.noCampaignsDescription')}
-						</p>
-						<Button asChild className="gradient-btn rounded-full text-white">
-							<Link href="/create-project">
-								<Plus className="h-4 w-4 mr-2" />
-								{t('profile.createFirstCampaign')}
-							</Link>
-						</Button>
-					</ProfileSurfaceCard>
-				) : null}
-			</AnimatePresence>
+				</div>
+			) : (
+				<ProfileSurfaceCard className="py-12 text-center">
+					<Target className="mx-auto mb-4 h-12 w-12 text-emerald-600/70" />
+					<h3 className="mb-2 text-lg font-semibold">{t('profile.noCampaignsTitle')}</h3>
+					<p className="mx-auto mb-6 max-w-md text-sm text-muted-foreground">
+						{t('profile.noCampaignsDescription')}
+					</p>
+					<Button asChild className="gradient-btn rounded-full text-white">
+						<Link href="/create-project">
+							<Plus className="h-4 w-4 mr-2" />
+							{t('profile.createFirstCampaign')}
+						</Link>
+					</Button>
+				</ProfileSurfaceCard>
+			)}
 		</div>
 	)
 }

--- a/apps/web/components/sections/profile/views/creator-profile/creator-profile.tsx
+++ b/apps/web/components/sections/profile/views/creator-profile/creator-profile.tsx
@@ -8,11 +8,13 @@ import { CreatorOverview } from './creator-overview'
 import type { CreatorProfileProps } from './types'
 import { useCreatorProfileData } from './use-creator-profile-data'
 
-export function CreatorProfile({
+function CreatorProfileCampaigns({
 	userId,
-	displayName: _displayName,
-	showSection = 'overview',
-}: CreatorProfileProps) {
+	showSection,
+}: {
+	userId: string
+	showSection: 'overview' | 'campaigns'
+}) {
 	const {
 		projects,
 		projectsWithBalances,
@@ -22,18 +24,6 @@ export function CreatorProfile({
 		isLoading,
 		error,
 	} = useCreatorProfileData(userId)
-
-	if (showSection === 'gamification') {
-		return <GamificationSection />
-	}
-
-	if (showSection === 'foundations') {
-		return <FoundationsSection userId={userId} />
-	}
-
-	if (showSection === 'nfts') {
-		return <CreatorNftsSection />
-	}
 
 	if (showSection === 'campaigns') {
 		return (
@@ -58,6 +48,31 @@ export function CreatorProfile({
 			projectsWithBalances={projectsWithBalances}
 			isLoading={isLoading}
 			error={error}
+		/>
+	)
+}
+
+export function CreatorProfile({
+	userId,
+	displayName: _displayName,
+	showSection = 'overview',
+}: CreatorProfileProps) {
+	if (showSection === 'gamification') {
+		return <GamificationSection />
+	}
+
+	if (showSection === 'foundations') {
+		return <FoundationsSection userId={userId} />
+	}
+
+	if (showSection === 'nfts') {
+		return <CreatorNftsSection />
+	}
+
+	return (
+		<CreatorProfileCampaigns
+			userId={userId}
+			showSection={showSection === 'campaigns' ? 'campaigns' : 'overview'}
 		/>
 	)
 }

--- a/apps/web/components/sections/profile/views/creator-profile/use-creator-profile-data.ts
+++ b/apps/web/components/sections/profile/views/creator-profile/use-creator-profile-data.ts
@@ -19,15 +19,16 @@ export function useCreatorProfileData(userId: string) {
 	const { status } = useSession()
 	const {
 		data: projects,
-		isLoading,
+		isPending,
 		error,
 	} = useQuery({
 		queryKey: ['profile', 'user-projects', userId],
 		queryFn: fetchProfileProjects,
 		enabled: status === 'authenticated' && Boolean(userId),
+		staleTime: 60_000,
 	})
 
-	const { getDisplayRaised, isLoadingBalances } = useProjectsFundingBalances(projects)
+	const { getDisplayRaised } = useProjectsFundingBalances(projects ?? [])
 
 	const projectsWithBalances = useMemo((): CreatorProjectWithBalance[] => {
 		return (projects ?? []).map((project) => {
@@ -66,7 +67,7 @@ export function useCreatorProfileData(userId: string) {
 		activeProjects,
 		totalRaised,
 		formatCurrency,
-		isLoading: isLoading || isLoadingBalances,
+		isLoading: isPending,
 		error,
 	}
 }

--- a/apps/web/components/sections/profile/views/donor-profile/donor-overview.tsx
+++ b/apps/web/components/sections/profile/views/donor-profile/donor-overview.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { AnimatePresence } from 'framer-motion'
 import { Heart, Trophy } from 'lucide-react'
 import { useI18n } from '~/lib/i18n'
 import { ProfileSectionHeader } from '../../profile-section-header'
@@ -56,27 +55,25 @@ export function DonorOverview({
 
 			<ProjectMatchingSection />
 
-			<AnimatePresence mode="wait">
-				{isLoading ? (
-					<p className="py-12 text-center text-muted-foreground">{t('profile.loadingProjects')}</p>
-				) : error ? (
-					<ProfileSurfaceCard>
-						<p className="py-8 text-center text-destructive">{t('profile.projectsError')}</p>
-					</ProfileSurfaceCard>
-				) : projectsWithBalances.length > 0 ? (
-					<div className="space-y-4">
-						<h3 className="flex items-center gap-2 text-lg font-semibold">
-							<Heart className="h-4 w-4 fill-emerald-600 text-emerald-600" />
-							{t('profile.supportedProjects')}
-						</h3>
-						<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-							{projectsWithBalances.map((project) => (
-								<SupportedProjectCard key={project.id} project={project} t={t} />
-							))}
-						</div>
+			{isLoading && projectsWithBalances.length === 0 ? (
+				<p className="py-12 text-center text-muted-foreground">{t('profile.loadingProjects')}</p>
+			) : error ? (
+				<ProfileSurfaceCard>
+					<p className="py-8 text-center text-destructive">{t('profile.projectsError')}</p>
+				</ProfileSurfaceCard>
+			) : projectsWithBalances.length > 0 ? (
+				<div className="space-y-4">
+					<h3 className="flex items-center gap-2 text-lg font-semibold">
+						<Heart className="h-4 w-4 fill-emerald-600 text-emerald-600" />
+						{t('profile.supportedProjects')}
+					</h3>
+					<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						{projectsWithBalances.map((project) => (
+							<SupportedProjectCard key={project.id} project={project} t={t} />
+						))}
 					</div>
-				) : null}
-			</AnimatePresence>
+				</div>
+			) : null}
 		</div>
 	)
 }

--- a/apps/web/components/sections/profile/views/donor-profile/donor-profile.tsx
+++ b/apps/web/components/sections/profile/views/donor-profile/donor-profile.tsx
@@ -7,24 +7,18 @@ import { DonorOverview } from './donor-overview'
 import type { DonorProfileProps } from './types'
 import { useDonorProfileData } from './use-donor-profile-data'
 
-export function DonorProfile({
+function DonorProfileWithProjects({
 	userId,
-	displayName: _displayName,
-	showSection = 'overview',
-}: DonorProfileProps) {
+	showSection,
+}: {
+	userId: string
+	showSection: 'overview' | 'donations'
+}) {
 	const { supportedProjects, projectsWithBalances, stats, isLoading, error } =
 		useDonorProfileData(userId)
 
-	if (showSection === 'gamification') {
-		return <GamificationSection />
-	}
-
 	if (showSection === 'donations') {
 		return <DonorDonationsSection projectsWithBalances={projectsWithBalances} />
-	}
-
-	if (showSection === 'nfts') {
-		return <DonorNftsSection />
 	}
 
 	return (
@@ -34,6 +28,27 @@ export function DonorProfile({
 			stats={stats}
 			isLoading={isLoading}
 			error={error}
+		/>
+	)
+}
+
+export function DonorProfile({
+	userId,
+	displayName: _displayName,
+	showSection = 'overview',
+}: DonorProfileProps) {
+	if (showSection === 'gamification') {
+		return <GamificationSection />
+	}
+
+	if (showSection === 'nfts') {
+		return <DonorNftsSection />
+	}
+
+	return (
+		<DonorProfileWithProjects
+			userId={userId}
+			showSection={showSection === 'donations' ? 'donations' : 'overview'}
 		/>
 	)
 }

--- a/apps/web/components/sections/profile/views/donor-profile/use-donor-profile-data.ts
+++ b/apps/web/components/sections/profile/views/donor-profile/use-donor-profile-data.ts
@@ -4,27 +4,28 @@ import { useSupabaseQuery } from '@packages/lib/hooks'
 import { useSession } from 'next-auth/react'
 import { useMemo } from 'react'
 import { useProjectsFundingBalances } from '~/hooks/projects/use-projects-funding-balances'
-import { useAuth } from '~/hooks/use-auth'
 import { getUserSupportedProjects } from '~/lib/queries/projects/get-user-projects'
 import { calculateFundingProgressPercent } from '~/lib/utils/projects/project-funding'
 import type { DonorProjectWithBalance } from './types'
 
 export function useDonorProfileData(userId: string) {
 	const { status } = useSession()
-	const { isSupabaseUserLoading } = useAuth()
-	const queryEnabled = status === 'authenticated' && Boolean(userId) && !isSupabaseUserLoading
 
 	const {
 		data: supportedProjects,
-		isLoading,
+		isPending,
 		error,
 	} = useSupabaseQuery(
 		'user-supported-projects',
 		(client) => getUserSupportedProjects(client, userId),
-		{ additionalKeyValues: [userId], enabled: queryEnabled },
+		{
+			additionalKeyValues: [userId],
+			enabled: status === 'authenticated' && Boolean(userId),
+			staleTime: 60_000,
+		},
 	)
 
-	const { getDisplayRaised, isLoadingBalances } = useProjectsFundingBalances(supportedProjects)
+	const { getDisplayRaised } = useProjectsFundingBalances(supportedProjects ?? [])
 
 	const projectsWithBalances = useMemo((): DonorProjectWithBalance[] => {
 		return (supportedProjects ?? []).map((project) => {
@@ -53,7 +54,8 @@ export function useDonorProfileData(userId: string) {
 		supportedProjects: supportedProjects ?? [],
 		projectsWithBalances,
 		stats,
-		isLoading: isLoading || isLoadingBalances,
+		/** True only on the first fetch — keeps rendered projects mounted during refetches. */
+		isLoading: isPending,
 		error,
 	}
 }

--- a/apps/web/components/sections/projects/cards/project-card-grid.tsx
+++ b/apps/web/components/sections/projects/cards/project-card-grid.tsx
@@ -4,8 +4,8 @@
 import { motion } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
-import { Badge } from '~/components/base/badge'
 import {
+	AcceptingDonationsBadge,
 	CategoryBadge,
 	ProjectTagList,
 	ReleasedProgressBar,
@@ -38,9 +38,9 @@ export function ProjectCardGrid({ project, index = 0 }: ProjectCardGridProps) {
 		dbReleasedAmount: project.releasedAmount,
 	})
 
-	const progressPercentage = progressPercent ?? 0
-	const releasedAmount = displayReleased ?? 0
-	const releasedPercentage = releasedProgressPercent ?? 0
+	const progressPercentage = progressPercent
+	const isLoadingProgress = progressPercentage === null
+	const barProgressPercent = progressPercentage ?? 0
 
 	const imageSrc = project.image || '/images/placeholder.png'
 
@@ -64,16 +64,11 @@ export function ProjectCardGrid({ project, index = 0 }: ProjectCardGridProps) {
 						loading={index >= 6 ? 'lazy' : undefined}
 					/>
 					<div className="absolute inset-0 bg-gradient-to-t from-black/40 via-black/0 to-black/0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-					<div className="absolute top-3 left-3 flex flex-col gap-2 drop-shadow">
-						{project.category && <CategoryBadge category={project.category} variant="display" />}
-						{project.escrowContractAddress && (
-							<Badge
-								className="rounded-full border-0 bg-emerald-600/90 px-1.5 py-0.5 text-[9px] font-medium text-white"
-								aria-label={t('projects.acceptingDonations')}
-							>
-								{t('projects.acceptingDonations')}
-							</Badge>
-						)}
+					<div className="absolute top-3 left-3 right-3 flex max-w-full flex-wrap items-center gap-1.5 drop-shadow">
+						{project.category ? (
+							<CategoryBadge category={project.category} variant="display" />
+						) : null}
+						{project.escrowContractAddress ? <AcceptingDonationsBadge /> : null}
 					</div>
 					<div className="absolute inset-0 flex items-end justify-end p-3 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
 						<span className="inline-flex items-center gap-1 rounded-full bg-white/90 px-3 py-1 text-xs font-medium text-gray-900 shadow-sm backdrop-blur">
@@ -96,14 +91,17 @@ export function ProjectCardGrid({ project, index = 0 }: ProjectCardGridProps) {
 					<div
 						className="w-full bg-gray-100 rounded-full h-1.5 sm:h-2 shadow-inner"
 						role="progressbar"
-						aria-valuenow={progressPercentage}
+						aria-valuenow={barProgressPercent}
 						aria-valuemin={0}
 						aria-valuemax={100}
-						aria-label={`${progressPercentage}% funded`}
+						aria-busy={isLoadingProgress}
+						aria-label={
+							isLoadingProgress ? 'Loading funding progress' : `${barProgressPercent}% funded`
+						}
 					>
 						<motion.div
 							className="h-full rounded-full gradient-progress shadow-sm"
-							custom={progressPercentage}
+							custom={barProgressPercent}
 							variants={progressBarAnimation}
 							initial="initial"
 							animate="animate"
@@ -117,12 +115,12 @@ export function ProjectCardGrid({ project, index = 0 }: ProjectCardGridProps) {
 								: formatCurrency(displayRaised, { maximumFractionDigits: 0 })}{' '}
 							{t('projects.raised').toLowerCase()}
 						</span>
-						<span>{progressPercentage}%</span>
+						<span>{isLoadingProgress ? '…' : `${barProgressPercent}%`}</span>
 					</div>
 
 					<ReleasedProgressBar
-						releasedAmount={releasedAmount}
-						progressPercentage={releasedPercentage}
+						releasedAmount={displayReleased}
+						progressPercentage={releasedProgressPercent}
 						className="mt-2"
 					/>
 

--- a/apps/web/components/sections/projects/cards/project-card-grid.tsx
+++ b/apps/web/components/sections/projects/cards/project-card-grid.tsx
@@ -52,9 +52,6 @@ export function ProjectCardGrid({ project, index = 0 }: ProjectCardGridProps) {
 			<motion.article
 				className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-emerald-200/80 hover:shadow-lg"
 				whileHover={cardHover}
-				initial={{ opacity: 0, y: 20 }}
-				animate={{ opacity: 1, y: 0 }}
-				transition={{ duration: 0.3 }}
 			>
 				<div className="relative h-48 overflow-hidden">
 					<Image

--- a/apps/web/components/sections/projects/cards/project-card-list.tsx
+++ b/apps/web/components/sections/projects/cards/project-card-list.tsx
@@ -4,8 +4,8 @@
 import { motion } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
-import { Badge } from '~/components/base/badge'
 import {
+	AcceptingDonationsBadge,
 	CategoryBadge,
 	ProjectTagList,
 	ReleasedProgressBar,
@@ -36,9 +36,9 @@ export function ProjectCardList({ project }: ProjectCardListProps) {
 		dbReleasedAmount: project.releasedAmount,
 	})
 
-	const progressPercentage = progressPercent ?? 0
-	const releasedAmount = displayReleased ?? 0
-	const releasedPercentage = releasedProgressPercent ?? 0
+	const progressPercentage = progressPercent
+	const isLoadingProgress = progressPercentage === null
+	const barProgressPercent = progressPercentage ?? 0
 
 	return (
 		<Link
@@ -66,22 +66,11 @@ export function ProjectCardList({ project }: ProjectCardListProps) {
 						<h3 className="text-base font-bold sm:text-lg md:text-xl line-clamp-1">
 							{project.title}
 						</h3>
-						<div className="flex shrink-0 flex-wrap gap-1.5">
-							{project.category && (
-								<CategoryBadge
-									category={project.category}
-									variant="display"
-									className="text-[10px] sm:text-[11px]"
-								/>
-							)}
-							{project.escrowContractAddress && (
-								<Badge
-									className="rounded-full border-0 bg-emerald-600/90 px-1.5 py-0.5 text-[9px] font-medium text-white"
-									aria-label={t('projects.acceptingDonations')}
-								>
-									{t('projects.acceptingDonations')}
-								</Badge>
-							)}
+						<div className="flex max-w-full shrink-0 flex-wrap items-center justify-end gap-1.5">
+							{project.category ? (
+								<CategoryBadge category={project.category} variant="display" />
+							) : null}
+							{project.escrowContractAddress ? <AcceptingDonationsBadge /> : null}
 						</div>
 					</div>
 
@@ -93,14 +82,17 @@ export function ProjectCardList({ project }: ProjectCardListProps) {
 						<div
 							className="w-full bg-gray-100 rounded-full h-1.5 sm:h-2"
 							role="progressbar"
-							aria-valuenow={progressPercentage}
+							aria-valuenow={barProgressPercent}
 							aria-valuemin={0}
 							aria-valuemax={100}
-							aria-label={`${progressPercentage}% funded`}
+							aria-busy={isLoadingProgress}
+							aria-label={
+								isLoadingProgress ? 'Loading funding progress' : `${barProgressPercent}% funded`
+							}
 						>
 							<motion.div
 								className="h-full rounded-full gradient-progress"
-								custom={progressPercentage}
+								custom={barProgressPercent}
 								variants={progressBarAnimation}
 								initial="initial"
 								animate="animate"
@@ -114,12 +106,12 @@ export function ProjectCardList({ project }: ProjectCardListProps) {
 									: formatCurrency(displayRaised, { maximumFractionDigits: 0 })}{' '}
 								{t('projects.raised').toLowerCase()}
 							</span>
-							<span>{progressPercentage}%</span>
+							<span>{isLoadingProgress ? '…' : `${barProgressPercent}%`}</span>
 						</div>
 
 						<ReleasedProgressBar
-							releasedAmount={releasedAmount}
-							progressPercentage={releasedPercentage}
+							releasedAmount={displayReleased}
+							progressPercentage={releasedProgressPercent}
 							className="mt-2"
 						/>
 

--- a/apps/web/components/sections/projects/cards/project-card-list.tsx
+++ b/apps/web/components/sections/projects/cards/project-card-list.tsx
@@ -48,9 +48,6 @@ export function ProjectCardList({ project }: ProjectCardListProps) {
 			<motion.article
 				className="flex h-full flex-row overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-emerald-200/80 hover:shadow-md"
 				whileHover={cardHover}
-				initial={{ opacity: 0, y: 20 }}
-				animate={{ opacity: 1, y: 0 }}
-				transition={{ duration: 0.3 }}
 			>
 				<div className="relative w-1/4 min-w-[100px] max-w-[180px] overflow-hidden">
 					<Image

--- a/apps/web/components/sections/projects/detail/project-hero.tsx
+++ b/apps/web/components/sections/projects/detail/project-hero.tsx
@@ -3,11 +3,11 @@
 import { motion, useReducedMotion } from 'framer-motion'
 import { MapPin, Share2, Target, TrendingUp, Unlock, Users, Wallet } from 'lucide-react'
 import { type ReactNode, useMemo } from 'react'
-import { Badge } from '~/components/base/badge'
 import { AnimatedCounter } from '~/components/sections/projects/detail/animated-counter'
 import { ProjectHeroBanner } from '~/components/sections/projects/detail/project-hero-banner'
 import { SocialLinksDisplay } from '~/components/sections/projects/detail/social-links-display'
 import {
+	AcceptingDonationsBadge,
 	CategoryBadge,
 	CountryFlag,
 	ProjectTagList,
@@ -78,9 +78,9 @@ export function ProjectHero({ project, projectSlug }: ProjectHeroProps) {
 		dbMilestones: project.milestones,
 	})
 
-	const releasedAmount = displayReleased ?? 0
-	const releasedPercentage = releasedProgressPercent ?? 0
-	const progressPercentage = progressPercent ?? 0
+	const progressPercentage = progressPercent
+	const isLoadingProgress = progressPercentage === null
+	const barProgressPercent = progressPercentage ?? 0
 	const hasEscrow = Boolean(project.escrowContractAddress)
 
 	return (
@@ -97,11 +97,7 @@ export function ProjectHero({ project, projectSlug }: ProjectHeroProps) {
 				) : (
 					<span />
 				)}
-				{hasEscrow ? (
-					<Badge className="shrink-0 rounded-full border-0 bg-emerald-600/95 px-2.5 py-1 text-[10px] font-semibold text-white shadow-sm backdrop-blur-sm">
-						{t('projects.acceptingDonations')}
-					</Badge>
-				) : null}
+				{hasEscrow ? <AcceptingDonationsBadge /> : null}
 			</ProjectHeroBanner>
 
 			<div className="relative -mt-8 rounded-t-3xl bg-white px-5 pb-6 pt-7 sm:px-6 md:-mt-10 md:px-8 md:pb-8 md:pt-9">
@@ -146,20 +142,23 @@ export function ProjectHero({ project, projectSlug }: ProjectHeroProps) {
 						<div className="mb-2 flex items-center justify-between gap-3 text-sm">
 							<span className="font-medium text-slate-700">{raisedLabel}</span>
 							<span className="font-semibold tabular-nums text-emerald-700">
-								{progressPercentage}%
+								{isLoadingProgress ? '…' : `${barProgressPercent}%`}
 							</span>
 						</div>
 						<div
 							className="h-2 w-full overflow-hidden rounded-full bg-white shadow-inner"
 							role="progressbar"
-							aria-valuenow={progressPercentage}
+							aria-valuenow={barProgressPercent}
 							aria-valuemin={0}
 							aria-valuemax={100}
-							aria-label={`${progressPercentage}% funded`}
+							aria-busy={isLoadingProgress}
+							aria-label={
+								isLoadingProgress ? 'Loading funding progress' : `${barProgressPercent}% funded`
+							}
 						>
 							<motion.div
 								className="h-full rounded-full gradient-progress shadow-sm"
-								custom={progressPercentage}
+								custom={barProgressPercent}
 								variants={progressBarAnimation}
 								initial="initial"
 								animate="animate"
@@ -176,8 +175,8 @@ export function ProjectHero({ project, projectSlug }: ProjectHeroProps) {
 					</div>
 
 					<ReleasedProgressBar
-						releasedAmount={releasedAmount}
-						progressPercentage={releasedPercentage}
+						releasedAmount={displayReleased}
+						progressPercentage={releasedProgressPercent}
 					/>
 				</section>
 
@@ -206,7 +205,7 @@ export function ProjectHero({ project, projectSlug }: ProjectHeroProps) {
 								'…'
 							) : (
 								<>
-									$<AnimatedCounter value={releasedAmount} />
+									$<AnimatedCounter value={displayReleased} />
 								</>
 							)
 						}

--- a/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar-escrow-state.ts
+++ b/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar-escrow-state.ts
@@ -1,7 +1,7 @@
 import type { EscrowType } from '@trustless-work/escrow'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { logger } from '@/lib/logger'
+import { useCallback, useMemo } from 'react'
 import { useEscrow } from '~/hooks/contexts/use-escrow.context'
+import { useEscrowBalance } from '~/hooks/escrow/use-escrow-balance'
 import { useEscrowData } from '~/hooks/escrow/use-escrow-data'
 import type { ProjectDetail } from '~/lib/types/project/project-detail.types'
 import { resolveEscrowType } from '~/lib/utils/escrow/resolve-escrow-type'
@@ -11,11 +11,11 @@ import {
 	resolveDisplayReleasedAmount,
 } from '~/lib/utils/projects/milestone-funding'
 
-export function useProjectSidebarEscrowState(project: ProjectDetail) {
-	const { getMultipleBalances, getEscrowByContractIds } = useEscrow()
+/** Delay balance refetch after a donation so fund-escrow is not competing with reads. */
+const POST_DONATION_BALANCE_REFETCH_DELAY_MS = 2_500
 
-	const [onChainRaised, setOnChainRaised] = useState<number | null>(null)
-	const [isFetchingBalance, setIsFetchingBalance] = useState(false)
+export function useProjectSidebarEscrowState(project: ProjectDetail) {
+	const { getEscrowByContractIds } = useEscrow()
 
 	const { escrowData, isLoading: isEscrowDataLoading } = useEscrowData({
 		escrowContractAddress: project.escrowContractAddress || '',
@@ -27,6 +27,15 @@ export function useProjectSidebarEscrowState(project: ProjectDetail) {
 	const effectiveEscrowType = resolveEscrowType({
 		indexerEscrow: escrowData,
 		projectEscrowType: project.escrowType,
+	})
+
+	const {
+		balance: onChainRaised,
+		isLoading: isFetchingBalance,
+		refetch: refetchEscrowBalance,
+	} = useEscrowBalance({
+		escrowContractAddress: project.escrowContractAddress ?? undefined,
+		escrowType: effectiveEscrowType ?? project.escrowType,
 	})
 
 	const isDonationReady = Boolean(hasEscrow && effectiveEscrowType && !isEscrowDataLoading)
@@ -48,7 +57,7 @@ export function useProjectSidebarEscrowState(project: ProjectDetail) {
 				dbMilestones: project.milestones,
 				escrowContractAddress: project.escrowContractAddress,
 				onChainReleasedAmount: escrowData ? calculateReleasedAmountFromEscrow(escrowData) : null,
-				isLoadingOnChain: hasEscrow && isEscrowDataLoading,
+				isLoadingOnChain: hasEscrow && isEscrowDataLoading && !escrowData,
 			}),
 		[escrowData, hasEscrow, isEscrowDataLoading, project.escrowContractAddress, project.milestones],
 	)
@@ -83,25 +92,9 @@ export function useProjectSidebarEscrowState(project: ProjectDetail) {
 	}, [escrowData, getEscrowByContractIds, project.escrowContractAddress, project.escrowType])
 
 	const fetchEscrowBalance = useCallback(async () => {
-		if (!project.escrowContractAddress || !effectiveEscrowType) return
-		try {
-			setIsFetchingBalance(true)
-			const balances = await getMultipleBalances(
-				{ addresses: [project.escrowContractAddress] },
-				effectiveEscrowType,
-			)
-			const first = balances?.[0]
-			if (first) setOnChainRaised(first.balance)
-		} catch (error) {
-			logger.error('Failed to fetch escrow balance', error)
-		} finally {
-			setIsFetchingBalance(false)
-		}
-	}, [getMultipleBalances, project.escrowContractAddress, effectiveEscrowType])
-
-	useEffect(() => {
-		fetchEscrowBalance()
-	}, [fetchEscrowBalance])
+		await new Promise((resolve) => setTimeout(resolve, POST_DONATION_BALANCE_REFETCH_DELAY_MS))
+		await refetchEscrowBalance()
+	}, [refetchEscrowBalance])
 
 	return {
 		escrowData,

--- a/apps/web/components/sections/projects/detail/project-sidebar/project-sidebar.tsx
+++ b/apps/web/components/sections/projects/detail/project-sidebar/project-sidebar.tsx
@@ -45,9 +45,6 @@ export function ProjectSidebar({ project, projectSlug }: ProjectSidebarProps) {
 		signInHref,
 	} = useProjectSidebar(project, projectSlug)
 
-	const releasedAmount = displayReleased ?? 0
-	const releasedPercentage = releasedProgressPercent ?? 0
-
 	return (
 		<motion.div
 			className="overflow-hidden sticky top-16 rounded-xl shadow-md"
@@ -100,8 +97,8 @@ export function ProjectSidebar({ project, projectSlug }: ProjectSidebarProps) {
 				/>
 
 				<ReleasedProgressBar
-					releasedAmount={releasedAmount}
-					progressPercentage={releasedPercentage}
+					releasedAmount={displayReleased}
+					progressPercentage={releasedProgressPercent}
 					className="mb-3"
 				/>
 

--- a/apps/web/components/sections/projects/load-more-sentinel.tsx
+++ b/apps/web/components/sections/projects/load-more-sentinel.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { Loader2 } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { useI18n } from '~/lib/i18n'
+
+interface LoadMoreSentinelProps {
+	/** Called when the sentinel scrolls into the viewport (or user clicks). */
+	onLoadMore: () => void
+	/** True while a page fetch is in flight. */
+	isLoading: boolean
+	/** Whether more pages exist. When false, no trigger fires and the button is hidden. */
+	hasMore: boolean
+}
+
+/**
+ * Invisible sentinel element placed at the bottom of the project list.
+ *
+ * Behaviour:
+ * - IntersectionObserver triggers `onLoadMore` automatically when visible.
+ * - A visible "Load More" button is always rendered for keyboard / assistive-
+ *   technology users and as a fallback when IntersectionObserver is unavailable.
+ * - Loading spinner is shown while a page is in flight.
+ * - When `hasMore` is false, nothing is rendered.
+ */
+export function LoadMoreSentinel({ onLoadMore, isLoading, hasMore }: LoadMoreSentinelProps) {
+	const { t } = useI18n()
+	const sentinelRef = useRef<HTMLDivElement>(null)
+
+	useEffect(() => {
+		const el = sentinelRef.current
+		if (!el || !hasMore || isLoading) return
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0]?.isIntersecting) {
+					onLoadMore()
+				}
+			},
+			{ rootMargin: '200px' }, // pre-load 200 px before edge
+		)
+
+		observer.observe(el)
+		return () => observer.disconnect()
+	}, [hasMore, isLoading, onLoadMore])
+
+	if (!hasMore) return null
+
+	return (
+		<div
+			ref={sentinelRef}
+			className="mt-8 flex flex-col items-center gap-3"
+			aria-live="polite"
+			aria-atomic="true"
+		>
+			{isLoading ? (
+				<output className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700">
+					<Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+					{t('projects.loading')}
+				</output>
+			) : (
+				<button
+					type="button"
+					onClick={onLoadMore}
+					className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white px-6 py-2.5 text-sm font-semibold text-emerald-700 shadow-sm transition-all hover:bg-emerald-50 hover:shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+					aria-label={t('projects.loadMore')}
+				>
+					{t('projects.loadMore')}
+				</button>
+			)}
+		</div>
+	)
+}

--- a/apps/web/components/sections/projects/manage/escrow/components/sync-escrow-card.tsx
+++ b/apps/web/components/sections/projects/manage/escrow/components/sync-escrow-card.tsx
@@ -29,6 +29,7 @@ export function SyncEscrowCard({
 	const router = useRouter()
 	const { getEscrowByContractIds } = useEscrow()
 	const [contractId, setContractId] = useState(initialContractId)
+	const [txHash, setTxHash] = useState('')
 	const [isSyncing, setIsSyncing] = useState(false)
 
 	const handleSync = async () => {
@@ -38,6 +39,8 @@ export function SyncEscrowCard({
 			return
 		}
 
+		const trimmedTxHash = txHash.trim().replace(/^0x/i, '')
+
 		setIsSyncing(true)
 		try {
 			let escrowSnapshot: ReturnType<typeof mapIndexerEscrowToSaveData> | undefined
@@ -45,7 +48,7 @@ export function SyncEscrowCard({
 			try {
 				const indexerResponse = await getEscrowByContractIds({
 					contractIds: [trimmedContractId],
-					validateOnChain: true,
+					validateOnChain: false,
 				})
 				const indexerEscrow = parseIndexerEscrowResponse(indexerResponse)
 				if (indexerEscrow?.engagementId) {
@@ -59,6 +62,7 @@ export function SyncEscrowCard({
 				projectId,
 				contractId: trimmedContractId,
 				escrowSnapshot,
+				...(trimmedTxHash ? { txHash: trimmedTxHash } : {}),
 			})
 
 			if (!result.success) {
@@ -88,14 +92,22 @@ export function SyncEscrowCard({
 				<div className="space-y-1">
 					<p className="text-sm font-medium">Already deployed on-chain?</p>
 					<p className="text-xs text-muted-foreground">
-						Paste the contract ID to link an existing escrow to this project.
+						Paste the contract ID to link an existing escrow to this project. If Trustless Work has
+						not indexed it yet, also paste the deploy transaction hash.
 					</p>
 				</div>
-				<div className="flex flex-col gap-2 sm:flex-row">
+				<div className="flex flex-col gap-2">
 					<Input
 						value={contractId}
 						onChange={(event) => setContractId(event.target.value)}
 						placeholder="C…"
+						className="font-mono text-sm"
+						disabled={isSyncing}
+					/>
+					<Input
+						value={txHash}
+						onChange={(event) => setTxHash(event.target.value)}
+						placeholder="Deploy transaction hash (optional)"
 						className="font-mono text-sm"
 						disabled={isSyncing}
 					/>
@@ -123,7 +135,8 @@ export function SyncEscrowCard({
 				<CardTitle>Link Existing Escrow</CardTitle>
 				<CardDescription>
 					If the contract was deployed on Stellar but KindFi failed to save it, paste the contract
-					ID below to fetch details from Trustless Work and link it to this project.
+					ID below. If Trustless Work still cannot find it, also paste the deploy transaction hash
+					so we can refresh the indexer and link it.
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-4">
@@ -134,6 +147,17 @@ export function SyncEscrowCard({
 						value={contractId}
 						onChange={(event) => setContractId(event.target.value)}
 						placeholder="CCOWXKJYIKVVC7D7VDI6ZDGBQWNLQWPMNUXLQLVKQNPMX4G5ZGW7M6BX"
+						className="font-mono text-sm"
+						disabled={isSyncing}
+					/>
+				</div>
+				<div className="space-y-2">
+					<Label htmlFor="sync-escrow-tx-hash">Deploy transaction hash (optional)</Label>
+					<Input
+						id="sync-escrow-tx-hash"
+						value={txHash}
+						onChange={(event) => setTxHash(event.target.value)}
+						placeholder="64-character hex hash from Stellar Expert"
 						className="font-mono text-sm"
 						disabled={isSyncing}
 					/>

--- a/apps/web/components/sections/projects/projects-client-wrapper.tsx
+++ b/apps/web/components/sections/projects/projects-client-wrapper.tsx
@@ -3,18 +3,19 @@
 import { useSupabaseQuery } from '@packages/lib/hooks'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { ProjectCardGrid, ProjectCardList } from '~/components/sections/projects/cards'
 import { EmptyProject } from '~/components/sections/projects/empty-project'
 import { CategoryTicker, SortDropdown, ViewToggle } from '~/components/sections/projects/filters'
+import { LoadMoreSentinel } from '~/components/sections/projects/load-more-sentinel'
 import {
 	ProjectCardGridSkeleton,
 	ProjectCardListSkeleton,
 } from '~/components/sections/projects/skeletons'
 import { SectionContainer } from '~/components/shared/section-container'
-import { staggerContainer } from '~/lib/constants/animations'
+import { usePaginatedProjects } from '~/hooks/projects/use-paginated-projects'
 import { useI18n } from '~/lib/i18n'
-import { getAllCategories, getAllProjects } from '~/lib/queries/projects'
+import { getAllCategories } from '~/lib/queries/projects'
 import type { SortOption } from '~/lib/types/project'
 
 const sortSlugToOption = (sortParam: string): SortOption => {
@@ -22,13 +23,6 @@ const sortSlugToOption = (sortParam: string): SortOption => {
 	if (sortParam === 'most-funded') return 'Most Funded'
 	if (sortParam === 'most-supporters') return 'Most Supporters'
 	return 'Most Popular'
-}
-
-const formatResultsCount = (count: number, t: (key: string) => string) => {
-	if (count === 1) {
-		return t('projects.resultsCountOne').replace('{count}', String(count))
-	}
-	return t('projects.resultsCountMany').replace('{count}', String(count))
 }
 
 export function ProjectsClientWrapper() {
@@ -42,19 +36,48 @@ export function ProjectsClientWrapper() {
 	const selectedCategories = categoryParams
 	const sortOption = sortSlugToOption(sortParam)
 
+	// ─── Paginated projects ───────────────────────────────────────────────────
 	const {
-		data: projects = [],
+		data,
 		isLoading: isLoadingProjects,
 		error: projectError,
-	} = useSupabaseQuery(
-		'projects',
-		(client) =>
-			getAllProjects(client, categoryParams, sortParam, undefined, { viewerLocale: language }),
-		{
-			additionalKeyValues: [categoryFilterKey, sortParam, language],
-		},
-	)
+		fetchNextPage,
+		hasNextPage,
+		isFetchingNextPage,
+	} = usePaginatedProjects({
+		categorySlugs: categoryParams,
+		sortSlug: sortParam,
+		language,
+	})
 
+	/**
+	 * Flatten all pages into a single ordered list.
+	 * Pages are stable references — React will not re-render already-rendered
+	 * cards when a new page is appended.
+	 */
+	const allProjects = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data])
+
+	/**
+	 * Track the IDs that appeared in the most-recently loaded page.
+	 * Only these cards will receive enter animations.
+	 */
+	const prevCountRef = useRef(0)
+	const newIds = useMemo<ReadonlySet<string>>(() => {
+		const lastPage = data?.pages[data.pages.length - 1]
+		if (!lastPage || data.pages.length === 1) {
+			// First load: animate all initial cards
+			prevCountRef.current = lastPage?.items.length ?? 0
+			return new Set(lastPage?.items.map((p) => p.id) ?? [])
+		}
+		// Subsequent pages: animate only the newly added IDs
+		const ids = new Set(lastPage.items.map((p) => p.id))
+		prevCountRef.current = allProjects.length
+		return ids
+	}, [data, allProjects.length])
+
+	const total = data?.pages[data.pages.length - 1]?.total ?? 0
+
+	// ─── Categories ───────────────────────────────────────────────────────────
 	const {
 		data: categories = [],
 		isLoading: isLoadingCategories,
@@ -66,31 +89,53 @@ export function ProjectsClientWrapper() {
 
 	const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid')
 
-	const handleCategoryToggle = (categorySlug: string) => {
-		const next = selectedCategories.includes(categorySlug)
-			? selectedCategories.filter((slug) => slug !== categorySlug)
-			: [...selectedCategories, categorySlug]
+	// ─── URL-driven filter helpers ─────────────────────────────────────────────
+	const handleCategoryToggle = useCallback(
+		(categorySlug: string) => {
+			const next = selectedCategories.includes(categorySlug)
+				? selectedCategories.filter((slug) => slug !== categorySlug)
+				: [...selectedCategories, categorySlug]
 
+			const params = new URLSearchParams(searchParams.toString())
+			params.delete('category')
+			for (const slug of next) {
+				params.append('category', slug)
+			}
+			router.push(`?${params.toString()}`, { scroll: false })
+		},
+		[selectedCategories, searchParams, router],
+	)
+
+	const handleResetCategories = useCallback(() => {
 		const params = new URLSearchParams(searchParams.toString())
 		params.delete('category')
-		for (const slug of next) {
-			params.append('category', slug)
+		router.push(`?${params.toString()}`, { scroll: false })
+	}, [searchParams, router])
+
+	const handleSortChange = useCallback(
+		(newSort: SortOption) => {
+			const params = new URLSearchParams(searchParams.toString())
+			params.set('sort', newSort.toLowerCase().replace(/ /g, '-'))
+			router.push(`?${params.toString()}`, { scroll: false })
+		},
+		[searchParams, router],
+	)
+
+	// ─── Results count label ───────────────────────────────────────────────────
+	const resultsLabel = useMemo(() => {
+		if (isLoadingProjects) return t('projects.loading')
+		const shown = allProjects.length
+		if (total > shown) {
+			return t('projects.resultsShowing')
+				.replace('{shown}', String(shown))
+				.replace('{total}', String(total))
 		}
-		router.push(`?${params.toString()}`, { scroll: false })
-	}
+		return total === 1
+			? t('projects.resultsCountOne').replace('{count}', String(total))
+			: t('projects.resultsCountMany').replace('{count}', String(total))
+	}, [isLoadingProjects, allProjects.length, total, t])
 
-	const handleResetCategories = () => {
-		const params = new URLSearchParams(searchParams.toString())
-		params.delete('category')
-		router.push(`?${params.toString()}`, { scroll: false })
-	}
-
-	const handleSortChange = (newSort: SortOption) => {
-		const params = new URLSearchParams(searchParams.toString())
-		params.set('sort', newSort.toLowerCase().replace(/ /g, '-'))
-		router.push(`?${params.toString()}`, { scroll: false })
-	}
-
+	// ─── Error state ───────────────────────────────────────────────────────────
 	if (projectError || categoryError) {
 		return (
 			<SectionContainer className="py-16">
@@ -117,9 +162,7 @@ export function ProjectsClientWrapper() {
 						<p className="text-xs font-medium uppercase tracking-[0.14em] text-emerald-700/80">
 							{t('nav.exploreProjects')}
 						</p>
-						<p className="mt-1 text-lg font-semibold text-slate-900">
-							{isLoadingProjects ? t('projects.loading') : formatResultsCount(projects.length, t)}
-						</p>
+						<p className="mt-1 text-lg font-semibold text-slate-900">{resultsLabel}</p>
 					</div>
 					<div className="flex flex-wrap items-center gap-3">
 						<SortDropdown value={sortOption} onChange={handleSortChange} />
@@ -136,6 +179,7 @@ export function ProjectsClientWrapper() {
 						transition={reducedMotion ? { duration: 0 } : { duration: 0.2 }}
 					>
 						{isLoadingProjects ? (
+							/* ── Skeleton placeholders while first page loads ── */
 							<div
 								className={
 									viewMode === 'grid'
@@ -153,40 +197,82 @@ export function ProjectsClientWrapper() {
 									),
 								)}
 							</div>
-						) : projects.length === 0 ? (
+						) : allProjects.length === 0 ? (
 							<EmptyProject
 								selectedCategories={selectedCategories}
 								onClearFilters={handleResetCategories}
 							/>
 						) : viewMode === 'grid' ? (
-							<motion.div
+							/* ── Grid view ── */
+							<div
 								className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3"
-								variants={reducedMotion ? undefined : staggerContainer}
-								initial={reducedMotion ? false : 'initial'}
-								animate={reducedMotion ? false : 'animate'}
 								role="feed"
 								aria-label="Projects grid view"
+								aria-busy={isFetchingNextPage}
 							>
-								{projects.map((project, index) => (
-									<ProjectCardGrid key={project.id} project={project} index={index} />
-								))}
-							</motion.div>
+								{allProjects.map((project, index) => {
+									const isNew = newIds.has(project.id)
+									if (reducedMotion || !isNew) {
+										return (
+											<div key={project.id} className="long-list-item h-full">
+												<ProjectCardGrid project={project} index={index} />
+											</div>
+										)
+									}
+									return (
+										<motion.div
+											key={project.id}
+											initial={{ opacity: 0, y: 16 }}
+											animate={{ opacity: 1, y: 0 }}
+											transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+											className="long-list-item h-full"
+										>
+											<ProjectCardGrid project={project} index={index} />
+										</motion.div>
+									)
+								})}
+							</div>
 						) : (
-							<motion.div
+							/* ── List view ── */
+							<div
 								className="flex flex-col gap-6"
-								variants={reducedMotion ? undefined : staggerContainer}
-								initial={reducedMotion ? false : 'initial'}
-								animate={reducedMotion ? false : 'animate'}
 								role="feed"
 								aria-label="Projects list view"
+								aria-busy={isFetchingNextPage}
 							>
-								{projects.map((project) => (
-									<ProjectCardList key={project.id} project={project} />
-								))}
-							</motion.div>
+								{allProjects.map((project) => {
+									const isNew = newIds.has(project.id)
+									if (reducedMotion || !isNew) {
+										return (
+											<div key={project.id}>
+												<ProjectCardList project={project} />
+											</div>
+										)
+									}
+									return (
+										<motion.div
+											key={project.id}
+											initial={{ opacity: 0, y: 16 }}
+											animate={{ opacity: 1, y: 0 }}
+											transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+										>
+											<ProjectCardList project={project} />
+										</motion.div>
+									)
+								})}
+							</div>
 						)}
 					</motion.div>
 				</AnimatePresence>
+
+				{/* ── Load-more sentinel (auto-scroll + button fallback) ── */}
+				{!isLoadingProjects && (
+					<LoadMoreSentinel
+						onLoadMore={fetchNextPage}
+						isLoading={isFetchingNextPage}
+						hasMore={!!hasNextPage}
+					/>
+				)}
 			</SectionContainer>
 		</section>
 	)

--- a/apps/web/components/sections/projects/projects-grid.tsx
+++ b/apps/web/components/sections/projects/projects-grid.tsx
@@ -13,7 +13,7 @@ interface ProjectsGridProps {
 	 * Set of project IDs that were added in the latest page-load.
 	 * Only these IDs receive enter animations; already-rendered cards are static.
 	 */
-	newIds?: ReadonlySet<string>
+	newIds?: ReadonlySet<string | number>
 }
 
 export function ProjectsGrid({

--- a/apps/web/components/sections/projects/projects-grid.tsx
+++ b/apps/web/components/sections/projects/projects-grid.tsx
@@ -9,6 +9,11 @@ interface ProjectsGridProps {
 	viewMode?: 'grid' | 'list'
 	selectedCategories?: string[]
 	onClearFilters?: () => void
+	/**
+	 * Set of project IDs that were added in the latest page-load.
+	 * Only these IDs receive enter animations; already-rendered cards are static.
+	 */
+	newIds?: ReadonlySet<string>
 }
 
 export function ProjectsGrid({
@@ -16,6 +21,7 @@ export function ProjectsGrid({
 	viewMode = 'grid',
 	selectedCategories = [],
 	onClearFilters = () => {},
+	newIds = new Set(),
 }: ProjectsGridProps) {
 	// Check if we have projects to display
 	const hasProjects = projects && projects.length > 0
@@ -41,19 +47,26 @@ export function ProjectsGrid({
 						'mt-8',
 					)}
 				>
-					{projects.map((project) => (
-						<motion.div
-							key={project.id}
-							layout
-							initial={{ opacity: 0, y: 20 }}
-							animate={{ opacity: 1, y: 0 }}
-							exit={{ opacity: 0, y: -20 }}
-							transition={{ duration: 0.3 }}
-							className="long-list-item w-full"
-						>
-							<ProjectCard key={project.id} project={project} viewMode={viewMode} />
-						</motion.div>
-					))}
+					{projects.map((project) =>
+						newIds.has(project.id) ? (
+							// Only newly-loaded cards get an enter animation — avoids
+							// re-animating the entire list on every page append.
+							<motion.div
+								key={project.id}
+								initial={{ opacity: 0, y: 16 }}
+								animate={{ opacity: 1, y: 0 }}
+								transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+								className="w-full"
+							>
+								<ProjectCard project={project} viewMode={viewMode} />
+							</motion.div>
+						) : (
+							// Cards already on screen render as plain divs — zero layout cost.
+							<div key={project.id} className="w-full">
+								<ProjectCard project={project} viewMode={viewMode} />
+							</div>
+						),
+					)}
 				</div>
 			)}
 		</AnimatePresence>

--- a/apps/web/components/sections/projects/shared/accepting-donations-badge.tsx
+++ b/apps/web/components/sections/projects/shared/accepting-donations-badge.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { Heart } from 'lucide-react'
+import { useI18n } from '~/lib/i18n'
+import { cn } from '~/lib/utils'
+
+interface AcceptingDonationsBadgeProps {
+	className?: string
+}
+
+/**
+ * Compact, single-line badge for projects with an active escrow.
+ * Matches CategoryBadge display sizing so card overlays stay consistent.
+ */
+export function AcceptingDonationsBadge({ className }: AcceptingDonationsBadgeProps) {
+	const { t } = useI18n()
+	const label = t('projects.acceptingDonations')
+
+	return (
+		<span
+			className={cn(
+				'inline-flex h-6 max-w-[10.5rem] shrink-0 items-center gap-1 rounded-full border-0 bg-emerald-600/95 px-2.5 text-[11px] font-semibold leading-none text-white shadow-sm backdrop-blur-md',
+				className,
+			)}
+			title={label}
+		>
+			<span
+				className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-white/20"
+				aria-hidden="true"
+			>
+				<Heart className="h-2.5 w-2.5 fill-current" />
+			</span>
+			<span className="truncate">{label}</span>
+		</span>
+	)
+}

--- a/apps/web/components/sections/projects/shared/index.ts
+++ b/apps/web/components/sections/projects/shared/index.ts
@@ -1,3 +1,4 @@
+export * from './accepting-donations-badge'
 export * from './breadcrumb-container'
 export * from './category-badge'
 export * from './country-flag'

--- a/apps/web/components/sections/projects/shared/released-progress-bar.tsx
+++ b/apps/web/components/sections/projects/shared/released-progress-bar.tsx
@@ -6,10 +6,10 @@ import { progressBarAnimation } from '~/lib/constants/animations'
 import { cn } from '~/lib/utils'
 
 interface ReleasedProgressBarProps {
-	/** Cumulative amount released via milestones with `released` status. */
-	releasedAmount: number
-	/** Released amount as a percent of goal (0–100). */
-	progressPercentage: number
+	/** Cumulative amount released via milestones with `released` status. Null while loading. */
+	releasedAmount: number | null
+	/** Released amount as a percent of goal (0–100). Null while loading. */
+	progressPercentage: number | null
 	className?: string
 }
 
@@ -29,19 +29,23 @@ export function ReleasedProgressBar({
 	progressPercentage,
 	className,
 }: ReleasedProgressBarProps) {
+	const barPercent = progressPercentage ?? 0
+	const isLoading = releasedAmount === null
+
 	return (
 		<div className={cn('w-full', className)}>
 			<div
 				className="w-full bg-gray-100 rounded-full h-1.5 sm:h-2"
 				role="progressbar"
-				aria-valuenow={progressPercentage}
+				aria-valuenow={barPercent}
 				aria-valuemin={0}
 				aria-valuemax={100}
-				aria-label={`${progressPercentage}% released`}
+				aria-busy={isLoading}
+				aria-label={isLoading ? 'Loading released amount' : `${barPercent}% released`}
 			>
 				<motion.div
 					className="h-full rounded-full gradient-released"
-					custom={progressPercentage}
+					custom={barPercent}
 					variants={progressBarAnimation}
 					initial="initial"
 					animate="animate"
@@ -49,8 +53,8 @@ export function ReleasedProgressBar({
 			</div>
 
 			<div className="flex justify-between mt-1 text-sm text-gray-500 tabular-nums">
-				<span>{releasedFormatter.format(releasedAmount)} released</span>
-				<span>{progressPercentage}%</span>
+				<span>{isLoading ? '…' : releasedFormatter.format(releasedAmount)} released</span>
+				<span>{isLoading ? '…' : `${barPercent}%`}</span>
 			</div>
 		</div>
 	)

--- a/apps/web/hooks/escrow/use-escrow-balance.ts
+++ b/apps/web/hooks/escrow/use-escrow-balance.ts
@@ -1,8 +1,14 @@
 'use client'
 
+import { useQuery } from '@tanstack/react-query'
 import type { EscrowType } from '@trustless-work/escrow'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRef } from 'react'
 import { useOptionalEscrow } from '~/hooks/contexts/use-escrow.context'
+import {
+	ESCROW_QUERY_POLL_MS,
+	ESCROW_QUERY_STALE_MS,
+	escrowBalanceQueryKey,
+} from '~/lib/constants/escrow-query.constants'
 
 interface UseEscrowBalanceParams {
 	escrowContractAddress?: string
@@ -12,60 +18,44 @@ interface UseEscrowBalanceParams {
 export function useEscrowBalance({ escrowContractAddress, escrowType }: UseEscrowBalanceParams) {
 	const escrow = useOptionalEscrow()
 	const getMultipleBalances = escrow?.getMultipleBalances
-	const [balance, setBalance] = useState<number | null>(null)
-	const [isLoading, setIsLoading] = useState(false)
-	const [error, setError] = useState<unknown>(null)
+	const getMultipleBalancesRef = useRef(getMultipleBalances)
+	getMultipleBalancesRef.current = getMultipleBalances
 
-	const fetchBalance = useCallback(
-		async (showLoading = true) => {
-			if (!escrowContractAddress || !getMultipleBalances) return
-			try {
-				if (showLoading) setIsLoading(true)
-				setError(null)
-				const balances = await getMultipleBalances(
-					{ addresses: [escrowContractAddress] },
-					escrowType || 'multi-release',
-				)
-				const first = balances?.[0]
-				if (first?.balance !== undefined && first.balance !== null) {
-					const numericBalance = Number(first.balance)
-					setBalance(Number.isFinite(numericBalance) ? numericBalance : null)
-				}
-			} catch (e) {
-				setError(e)
-			} finally {
-				if (showLoading) setIsLoading(false)
+	const effectiveType: EscrowType = escrowType ?? 'multi-release'
+
+	const {
+		data: balance = null,
+		isPending,
+		error,
+		refetch,
+	} = useQuery({
+		queryKey: escrowBalanceQueryKey(escrowContractAddress ?? '', effectiveType),
+		queryFn: async () => {
+			const getBalances = getMultipleBalancesRef.current
+			if (!escrowContractAddress || !getBalances) {
+				return null
 			}
+
+			const balances = await getBalances({ addresses: [escrowContractAddress] }, effectiveType)
+			const first = balances?.[0]
+			if (first?.balance !== undefined && first.balance !== null) {
+				const numericBalance = Number(first.balance)
+				return Number.isFinite(numericBalance) ? numericBalance : null
+			}
+
+			return null
 		},
-		[escrowContractAddress, escrowType, getMultipleBalances],
-	)
+		enabled: Boolean(escrowContractAddress) && Boolean(getMultipleBalances),
+		staleTime: ESCROW_QUERY_STALE_MS,
+		refetchInterval: ESCROW_QUERY_POLL_MS,
+		refetchOnWindowFocus: false,
+		placeholderData: (previousData) => previousData,
+	})
 
-	useEffect(() => {
-		if (!escrowContractAddress || !getMultipleBalances) {
-			setBalance(null)
-			setIsLoading(false)
-			return
-		}
-
-		// Initial fetch with loading state
-		fetchBalance(true)
-
-		// Set up polling to refresh balance every 10 seconds (without loading state)
-		const intervalId = setInterval(() => {
-			fetchBalance(false)
-		}, 10000) // Poll every 10 seconds
-
-		return () => {
-			clearInterval(intervalId)
-		}
-	}, [escrowContractAddress, fetchBalance, getMultipleBalances])
-
-	const refetch = useCallback(() => {
-		return fetchBalance(true)
-	}, [fetchBalance])
-
-	return useMemo(
-		() => ({ balance, isLoading, error, refetch }),
-		[balance, isLoading, error, refetch],
-	)
+	return {
+		balance,
+		isLoading: isPending,
+		error,
+		refetch: () => refetch(),
+	}
 }

--- a/apps/web/hooks/escrow/use-escrow-data.ts
+++ b/apps/web/hooks/escrow/use-escrow-data.ts
@@ -6,7 +6,7 @@ import type {
 	MultiReleaseMilestone,
 	SingleReleaseMilestone,
 } from '@trustless-work/escrow'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { logger } from '@/lib/logger'
 import { useEscrow } from '~/hooks/contexts/use-escrow.context'
@@ -17,13 +17,17 @@ interface UseEscrowDataParams {
 	escrowType?: EscrowType
 }
 
-const INDEXER_SYNC_DELAYS_MS = [0, 2_000, 5_000] as const
+/** Single delayed refetch after writes — avoids hammering Trustless Work during indexer sync. */
+const POST_TRANSACTION_REFETCH_DELAY_MS = 3_000
 
 export function useEscrowData({
 	escrowContractAddress,
 	escrowType: _escrowType,
 }: UseEscrowDataParams) {
 	const { getEscrowByContractIds } = useEscrow()
+	const getEscrowByContractIdsRef = useRef(getEscrowByContractIds)
+	getEscrowByContractIdsRef.current = getEscrowByContractIds
+
 	const [escrowData, setEscrowData] = useState<GetEscrowsFromIndexerResponse | null>(null)
 	const [isLoading, setIsLoading] = useState(false)
 	const [error, setError] = useState<string | null>(null)
@@ -89,7 +93,7 @@ export function useEscrowData({
 					setError(null)
 				}
 
-				const response = await getEscrowByContractIds({
+				const response = await getEscrowByContractIdsRef.current({
 					contractIds: [escrowContractAddress],
 					validateOnChain,
 				})
@@ -109,16 +113,12 @@ export function useEscrowData({
 				}
 			}
 		},
-		[escrowContractAddress, getEscrowByContractIds, normalizeEscrowResponse],
+		[escrowContractAddress, normalizeEscrowResponse],
 	)
 
 	const refetchAfterTransaction = useCallback(async () => {
-		for (const delayMs of INDEXER_SYNC_DELAYS_MS) {
-			if (delayMs > 0) {
-				await new Promise((resolve) => setTimeout(resolve, delayMs))
-			}
-			await fetchEscrowData({ validateOnChain: true, silent: true })
-		}
+		await new Promise((resolve) => setTimeout(resolve, POST_TRANSACTION_REFETCH_DELAY_MS))
+		await fetchEscrowData({ validateOnChain: true, silent: true })
 	}, [fetchEscrowData])
 
 	const patchMilestone = useCallback(

--- a/apps/web/hooks/projects/use-donation-stream.ts
+++ b/apps/web/hooks/projects/use-donation-stream.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { DonationStreamItem } from '~/lib/queries/projects/get-project-donation-stream'
 
 interface UseDonationStreamParams {
@@ -18,27 +18,48 @@ export function useDonationStream({
 	const [isLoading, setIsLoading] = useState(false)
 	const [error, setError] = useState<unknown>(null)
 
-	const fetchDonations = useCallback(
-		async (showLoading = true) => {
-			if (!projectSlug) return
+	const isFetchingRef = useRef(false)
+	const latestDonatedAtRef = useRef<string | undefined>(undefined)
 
+	const fetchDonations = useCallback(
+		async (showLoading = true, after?: string) => {
+			if (!projectSlug || isFetchingRef.current) return
+
+			isFetchingRef.current = true
 			try {
 				if (showLoading) setIsLoading(true)
 				setError(null)
 
-				const response = await fetch(
-					`/api/projects/${encodeURIComponent(projectSlug)}/donations/stream?limit=${limit}`,
+				const url = new URL(
+					`/api/projects/${encodeURIComponent(projectSlug)}/donations/stream`,
+					window.location.origin,
 				)
+				url.searchParams.set('limit', String(limit))
+				if (after) url.searchParams.set('after', after)
+
+				const response = await fetch(url.toString())
 
 				if (!response.ok) {
 					throw new Error('Failed to load donation stream')
 				}
 
 				const json = (await response.json()) as { data?: DonationStreamItem[] }
-				setDonations(json.data ?? [])
+				const incoming = json.data ?? []
+
+				if (incoming.length > 0) {
+					if (after) {
+						// Incremental poll: prepend new items, keep existing ones
+						setDonations((prev) => [...incoming, ...prev])
+					} else {
+						// Initial or manual full load
+						setDonations(incoming)
+					}
+					latestDonatedAtRef.current = incoming[0].donatedAt
+				}
 			} catch (fetchError) {
 				setError(fetchError)
 			} finally {
+				isFetchingRef.current = false
 				if (showLoading) setIsLoading(false)
 			}
 		},
@@ -51,15 +72,26 @@ export function useDonationStream({
 		fetchDonations(true)
 
 		const intervalId = setInterval(() => {
-			fetchDonations(false)
+			if (document.hidden) return
+			fetchDonations(false, latestDonatedAtRef.current)
 		}, pollIntervalMs)
+
+		function handleVisibilityChange() {
+			if (!document.hidden) {
+				fetchDonations(false, latestDonatedAtRef.current)
+			}
+		}
+
+		document.addEventListener('visibilitychange', handleVisibilityChange)
 
 		return () => {
 			clearInterval(intervalId)
+			document.removeEventListener('visibilitychange', handleVisibilityChange)
 		}
 	}, [projectSlug, fetchDonations, pollIntervalMs])
 
 	const refetch = useCallback(() => {
+		latestDonatedAtRef.current = undefined
 		return fetchDonations(true)
 	}, [fetchDonations])
 

--- a/apps/web/hooks/projects/use-paginated-projects.ts
+++ b/apps/web/hooks/projects/use-paginated-projects.ts
@@ -1,0 +1,52 @@
+'use client'
+
+import { createSupabaseBrowserClient } from '@packages/lib/supabase-client'
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { getAllProjects } from '~/lib/queries/projects/get-all-projects'
+import type { SupportedLocale } from '~/lib/schemas/locale.schemas'
+
+/** Number of projects fetched per page. */
+export const PROJECTS_PAGE_SIZE = 12
+
+export interface UsePaginatedProjectsOptions {
+	categorySlugs: string[]
+	sortSlug: string
+	language: SupportedLocale
+	pageSize?: number
+}
+
+/**
+ * Fetches projects in bounded pages using TanStack `useInfiniteQuery`.
+ *
+ * - Initial render: only the first page (up to `pageSize` items) is fetched.
+ * - Subsequent pages are fetched on demand via `fetchNextPage`.
+ * - Changing `categorySlugs`, `sortSlug`, or `language` resets to page 0.
+ * - Already-rendered cards are never remounted when loading additional pages.
+ */
+export function usePaginatedProjects({
+	categorySlugs,
+	sortSlug,
+	language,
+	pageSize = PROJECTS_PAGE_SIZE,
+}: UsePaginatedProjectsOptions) {
+	const categoryKey = categorySlugs.join(',')
+
+	return useInfiniteQuery({
+		queryKey: ['projects-paginated', categoryKey, sortSlug, language, pageSize] as const,
+		queryFn: async ({ pageParam = 0 }) => {
+			const supabase = createSupabaseBrowserClient()
+			return getAllProjects(
+				supabase,
+				categorySlugs,
+				sortSlug,
+				pageSize,
+				{ viewerLocale: language },
+				pageParam as number,
+			)
+		},
+		initialPageParam: 0,
+		getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+		staleTime: 1000 * 60 * 2, // 2 minutes — fresh enough for the catalog
+		gcTime: 1000 * 60 * 10,
+	})
+}

--- a/apps/web/hooks/projects/use-project-released-display.ts
+++ b/apps/web/hooks/projects/use-project-released-display.ts
@@ -1,8 +1,14 @@
 'use client'
 
+import { useQuery } from '@tanstack/react-query'
 import type { EscrowType, GetEscrowsFromIndexerResponse } from '@trustless-work/escrow'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useMemo, useRef } from 'react'
 import { useOptionalEscrow } from '~/hooks/contexts/use-escrow.context'
+import {
+	ESCROW_QUERY_POLL_MS,
+	ESCROW_QUERY_STALE_MS,
+	escrowReleasedQueryKey,
+} from '~/lib/constants/escrow-query.constants'
 import {
 	calculateReleasedAmountFromEscrow,
 	calculateReleasedProgressPercent,
@@ -29,62 +35,40 @@ export function useProjectReleasedDisplay({
 }: UseProjectReleasedDisplayParams) {
 	const escrow = useOptionalEscrow()
 	const getEscrowByContractIds = escrow?.getEscrowByContractIds
+	const getEscrowByContractIdsRef = useRef(getEscrowByContractIds)
+	getEscrowByContractIdsRef.current = getEscrowByContractIds
 
 	const hasEscrow = projectHasEscrow({ escrowContractAddress })
-	const [onChainReleasedAmount, setOnChainReleasedAmount] = useState<number | null>(null)
-	const [isLoading, setIsLoading] = useState(false)
+	const address = escrowContractAddress ?? ''
+
+	const { data: onChainReleasedAmount, isPending: isLoadingOnChain } = useQuery({
+		queryKey: escrowReleasedQueryKey(address),
+		queryFn: async () => {
+			const getEscrow = getEscrowByContractIdsRef.current
+			if (!address || !getEscrow) {
+				return null
+			}
+
+			const response = await getEscrow({
+				contractIds: [address],
+				validateOnChain: true,
+			})
+			const escrowData = Array.isArray(response) ? response[0] : response
+			return calculateReleasedAmountFromEscrow(escrowData)
+		},
+		enabled: hasEscrow && Boolean(getEscrowByContractIds) && !preloadedEscrowData,
+		staleTime: ESCROW_QUERY_STALE_MS,
+		refetchInterval: ESCROW_QUERY_POLL_MS,
+		refetchOnWindowFocus: false,
+		placeholderData: (previousData) => previousData,
+	})
 
 	const effectiveOnChainAmount = useMemo(() => {
 		if (preloadedEscrowData) {
 			return calculateReleasedAmountFromEscrow(preloadedEscrowData)
 		}
-		return onChainReleasedAmount
+		return onChainReleasedAmount ?? null
 	}, [preloadedEscrowData, onChainReleasedAmount])
-
-	const fetchReleasedAmount = useCallback(
-		async (showLoading = true) => {
-			if (!escrowContractAddress || !getEscrowByContractIds || preloadedEscrowData) {
-				return
-			}
-
-			try {
-				if (showLoading) setIsLoading(true)
-				const response = await getEscrowByContractIds({
-					contractIds: [escrowContractAddress],
-					validateOnChain: true,
-				})
-				const escrowData = Array.isArray(response) ? response[0] : response
-				setOnChainReleasedAmount(calculateReleasedAmountFromEscrow(escrowData))
-			} catch {
-				setOnChainReleasedAmount(null)
-			} finally {
-				if (showLoading) setIsLoading(false)
-			}
-		},
-		[escrowContractAddress, getEscrowByContractIds, preloadedEscrowData],
-	)
-
-	useEffect(() => {
-		if (!hasEscrow || preloadedEscrowData) {
-			setOnChainReleasedAmount(null)
-			setIsLoading(false)
-			return
-		}
-
-		if (!getEscrowByContractIds) {
-			return
-		}
-
-		fetchReleasedAmount(true)
-
-		const intervalId = setInterval(() => {
-			fetchReleasedAmount(false)
-		}, 10000)
-
-		return () => {
-			clearInterval(intervalId)
-		}
-	}, [fetchReleasedAmount, getEscrowByContractIds, hasEscrow, preloadedEscrowData])
 
 	const displayReleased = useMemo(
 		() =>
@@ -93,7 +77,7 @@ export function useProjectReleasedDisplay({
 				dbReleasedAmount,
 				escrowContractAddress,
 				onChainReleasedAmount: hasEscrow ? effectiveOnChainAmount : null,
-				isLoadingOnChain: hasEscrow && isLoading && effectiveOnChainAmount === null,
+				isLoadingOnChain: hasEscrow && isLoadingOnChain && effectiveOnChainAmount === null,
 			}),
 		[
 			dbMilestones,
@@ -101,7 +85,7 @@ export function useProjectReleasedDisplay({
 			escrowContractAddress,
 			effectiveOnChainAmount,
 			hasEscrow,
-			isLoading,
+			isLoadingOnChain,
 		],
 	)
 

--- a/apps/web/hooks/projects/use-projects-funding-balances.ts
+++ b/apps/web/hooks/projects/use-projects-funding-balances.ts
@@ -1,9 +1,14 @@
 'use client'
 
-import type { EscrowType } from '@trustless-work/escrow'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { logger } from '@/lib/logger'
+import { useQuery } from '@tanstack/react-query'
+import type {
+	EscrowType,
+	GetBalanceParams,
+	GetEscrowBalancesResponse,
+} from '@trustless-work/escrow'
+import { useCallback, useMemo, useRef } from 'react'
 import { useOptionalEscrow } from '~/hooks/contexts/use-escrow.context'
+import { ESCROW_QUERY_POLL_MS, ESCROW_QUERY_STALE_MS } from '~/lib/constants/escrow-query.constants'
 import {
 	getProjectDbRaised,
 	getProjectEscrowType,
@@ -14,76 +19,80 @@ import {
 
 const EMPTY_PROJECTS: ProjectFundingSource[] = []
 
-const buildProjectsEscrowKey = (projects: ProjectFundingSource[]): string =>
+export const projectsEscrowBalancesQueryKey = (escrowKey: string) =>
+	['projects-escrow-balances', escrowKey] as const
+
+export const buildProjectsEscrowKey = (projects: ProjectFundingSource[]): string =>
 	projects
 		.filter((project) => Boolean(project.escrowContractAddress))
 		.map((project) => `${project.escrowContractAddress as string}|${getProjectEscrowType(project)}`)
 		.sort()
 		.join(',')
 
+const fetchProjectsEscrowBalances = async (
+	projects: ProjectFundingSource[],
+	getBalances: (
+		payload: GetBalanceParams,
+		type: EscrowType,
+	) => Promise<GetEscrowBalancesResponse[]>,
+): Promise<Record<string, number>> => {
+	const projectsWithEscrow = projects.filter((project) => Boolean(project.escrowContractAddress))
+
+	if (projectsWithEscrow.length === 0) {
+		return {}
+	}
+
+	const byType = new Map<EscrowType, string[]>()
+	for (const project of projectsWithEscrow) {
+		const address = project.escrowContractAddress as string
+		const type = getProjectEscrowType(project)
+		const addresses = byType.get(type) ?? []
+		addresses.push(address)
+		byType.set(type, addresses)
+	}
+
+	const balanceMap: Record<string, number> = {}
+
+	for (const [type, addresses] of byType.entries()) {
+		const balances = await getBalances({ addresses }, type)
+		addresses.forEach((address, index) => {
+			const balanceResponse = balances[index]
+			if (balanceResponse?.balance !== undefined && balanceResponse.balance !== null) {
+				const numericBalance = Number(balanceResponse.balance)
+				if (Number.isFinite(numericBalance)) {
+					balanceMap[address] = numericBalance
+				}
+			}
+		})
+	}
+
+	return balanceMap
+}
+
 export function useProjectsFundingBalances(projects: ProjectFundingSource[] = EMPTY_PROJECTS) {
 	const escrow = useOptionalEscrow()
 	const getMultipleBalances = escrow?.getMultipleBalances
-	const [escrowBalances, setEscrowBalances] = useState<Record<string, number>>({})
-	const [isLoadingBalances, setIsLoadingBalances] = useState(false)
+	const getMultipleBalancesRef = useRef(getMultipleBalances)
+	getMultipleBalancesRef.current = getMultipleBalances
+
 	const projectsRef = useRef(projects)
 	projectsRef.current = projects
 
 	const projectsEscrowKey = useMemo(() => buildProjectsEscrowKey(projects), [projects])
 
-	const fetchBalances = useCallback(async () => {
-		const projectsWithEscrow = projectsRef.current.filter((project) =>
-			Boolean(project.escrowContractAddress),
-		)
-
-		if (projectsWithEscrow.length === 0 || !getMultipleBalances) {
-			setEscrowBalances((prev) => (Object.keys(prev).length === 0 ? prev : {}))
-			return
-		}
-
-		try {
-			setIsLoadingBalances(true)
-
-			const byType = new Map<EscrowType, string[]>()
-			for (const project of projectsWithEscrow) {
-				const address = project.escrowContractAddress as string
-				const type = getProjectEscrowType(project)
-				const addresses = byType.get(type) ?? []
-				addresses.push(address)
-				byType.set(type, addresses)
-			}
-
-			const balanceMap: Record<string, number> = {}
-
-			for (const [type, addresses] of byType.entries()) {
-				const balances = await getMultipleBalances({ addresses }, type)
-				addresses.forEach((address, index) => {
-					const balanceResponse = balances[index]
-					if (balanceResponse?.balance !== undefined && balanceResponse.balance !== null) {
-						const numericBalance = Number(balanceResponse.balance)
-						if (Number.isFinite(numericBalance)) {
-							balanceMap[address] = numericBalance
-						}
-					}
-				})
-			}
-
-			setEscrowBalances(balanceMap)
-		} catch (error) {
-			logger.error('Failed to fetch project escrow balances', error)
-		} finally {
-			setIsLoadingBalances(false)
-		}
-	}, [getMultipleBalances, projectsEscrowKey])
-
-	useEffect(() => {
-		void fetchBalances()
-		const intervalId = setInterval(() => {
-			void fetchBalances()
-		}, 10_000)
-
-		return () => clearInterval(intervalId)
-	}, [fetchBalances])
+	const { data: escrowBalances = {}, isLoading: isLoadingBalances } = useQuery({
+		queryKey: projectsEscrowBalancesQueryKey(projectsEscrowKey),
+		queryFn: () =>
+			fetchProjectsEscrowBalances(
+				projectsRef.current,
+				getMultipleBalancesRef.current as NonNullable<typeof getMultipleBalances>,
+			),
+		enabled: Boolean(projectsEscrowKey) && Boolean(getMultipleBalances),
+		staleTime: ESCROW_QUERY_STALE_MS,
+		refetchInterval: ESCROW_QUERY_POLL_MS,
+		refetchOnWindowFocus: false,
+		placeholderData: (previousData) => previousData,
+	})
 
 	const getDisplayRaised = useCallback(
 		(project: ProjectFundingSource): number | null => {
@@ -103,7 +112,7 @@ export function useProjectsFundingBalances(projects: ProjectFundingSource[] = EM
 
 	return {
 		escrowBalances,
-		isLoadingBalances,
+		isLoadingBalances: isLoadingBalances && Boolean(projectsEscrowKey),
 		getDisplayRaised,
 	}
 }

--- a/apps/web/hooks/use-didit-kyc.ts
+++ b/apps/web/hooks/use-didit-kyc.ts
@@ -1,6 +1,7 @@
 // hooks/use-didit-kyc.ts
 
-import { useCallback, useEffect, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useCallback } from 'react'
 import { logger } from '@/lib/logger'
 
 interface KYCStatus {
@@ -16,60 +17,57 @@ interface CreateSessionResponse {
 	error?: string
 }
 
+type KycStatusData = {
+	status: KYCStatus['status']
+}
+
+const KYC_STATUS_QUERY_KEY = (userId: string) => ['kyc-status', userId] as const
+
+const fetchKycStatus = async (): Promise<KycStatusData> => {
+	const response = await fetch('/api/kyc/status')
+
+	if (!response.ok) {
+		throw new Error(`Failed to fetch KYC status: ${response.statusText}`)
+	}
+
+	const result = await response.json()
+	return { status: result.status || null }
+}
+
+type UseDiditKYCOptions = {
+	/** When false, skips the initial status fetch (e.g. section not visible). */
+	enabled?: boolean
+}
+
 /**
- * Hook for managing Didit KYC verification
+ * Hook for managing Didit KYC verification.
+ * Fetches status once when enabled; use refreshStatus / checkStatusFromDidit after user actions.
  */
-export function useDiditKYC(userId: string) {
-	const [kycStatus, setKycStatus] = useState<KYCStatus>({
-		status: null,
-		isLoading: true,
-		error: null,
+export function useDiditKYC(userId: string, options: UseDiditKYCOptions = {}) {
+	const { enabled = true } = options
+	const queryClient = useQueryClient()
+
+	const { data, isLoading, error } = useQuery({
+		queryKey: KYC_STATUS_QUERY_KEY(userId),
+		queryFn: fetchKycStatus,
+		enabled: Boolean(userId) && enabled,
+		staleTime: Number.POSITIVE_INFINITY,
+		gcTime: 5 * 60 * 1000,
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
+		refetchOnMount: false,
 	})
 
+	const kycStatus: KYCStatus = {
+		status: data?.status ?? null,
+		isLoading: Boolean(userId) && isLoading,
+		error: error instanceof Error ? error.message : error ? String(error) : null,
+	}
+
 	const loadKYCStatus = useCallback(async () => {
-		try {
-			// Use API route instead of direct Supabase query to avoid RLS issues
-			const response = await fetch('/api/kyc/status')
-
-			if (!response.ok) {
-				throw new Error(`Failed to fetch KYC status: ${response.statusText}`)
-			}
-
-			const result = await response.json()
-			const status = result.status || null
-
-			setKycStatus({
-				status,
-				isLoading: false,
-				error: null,
-			})
-		} catch (error) {
-			logger.error('❌ Failed to load KYC status:', error)
-			setKycStatus({
-				status: null,
-				isLoading: false,
-				error: error instanceof Error ? error.message : 'Failed to load KYC status',
-			})
-		}
-	}, [])
-
-	useEffect(() => {
-		if (!userId) {
-			setKycStatus({ status: null, isLoading: false, error: null })
-			return
-		}
-
-		loadKYCStatus()
-
-		// Poll for status updates every 5 seconds if status is pending or null
-		// This helps catch webhook updates that might be delayed
-		const pollInterval = setInterval(() => {
-			loadKYCStatus()
-		}, 5000)
-
-		// Cleanup interval on unmount
-		return () => clearInterval(pollInterval)
-	}, [userId, loadKYCStatus])
+		if (!userId) return
+		await queryClient.invalidateQueries({ queryKey: KYC_STATUS_QUERY_KEY(userId) })
+	}, [queryClient, userId])
 
 	const checkStatusFromDidit = useCallback(async () => {
 		try {
@@ -81,34 +79,29 @@ export function useDiditKYC(userId: string) {
 			})
 
 			if (!response.ok) {
-				// If 404 or other error, just reload from database
 				if (response.status === 404) {
 					await loadKYCStatus()
 					return { success: false, message: 'No KYC session found' }
 				}
-				const error = await response.json()
-				throw new Error(error.error || 'Failed to check status')
+				const errorResponse = await response.json()
+				throw new Error(errorResponse.error || 'Failed to check status')
 			}
 
 			const result = await response.json()
 
-			// If no session found, that's okay - just reload from database
 			if (!result.success) {
 				await loadKYCStatus()
 				return result
 			}
 
-			// Reload status from database after checking Didit
 			await loadKYCStatus()
-
 			return result
-		} catch (error) {
-			logger.error('Failed to check status from Didit:', error)
-			// Fallback to loading from database
+		} catch (checkError) {
+			logger.error('Failed to check status from Didit:', checkError)
 			await loadKYCStatus()
 			return {
 				success: false,
-				error: error instanceof Error ? error.message : 'Unknown error',
+				error: checkError instanceof Error ? checkError.message : 'Unknown error',
 			}
 		}
 	}, [loadKYCStatus])
@@ -124,20 +117,17 @@ export function useDiditKYC(userId: string) {
 			})
 
 			if (!response.ok) {
-				const error = await response.json()
-				throw new Error(error.error || 'Failed to create verification session')
+				const errorResponse = await response.json()
+				throw new Error(errorResponse.error || 'Failed to create verification session')
 			}
 
 			const result = await response.json()
-
-			// Reload status after creating session
 			await loadKYCStatus()
-
 			return result
-		} catch (error) {
+		} catch (createError) {
 			return {
 				success: false,
-				error: error instanceof Error ? error.message : 'Unknown error',
+				error: createError instanceof Error ? createError.message : 'Unknown error',
 			}
 		}
 	}

--- a/apps/web/lib/auth/rate-limit.ts
+++ b/apps/web/lib/auth/rate-limit.ts
@@ -11,6 +11,14 @@ export class RateLimitExceededError extends Error {
 const logger = new Logger()
 const rateLimiter = new RateLimiter()
 
+/** Recovery sync is retried often when the Trustless Work indexer lags. */
+export const escrowSyncRateLimiter = new RateLimiter({
+	maxAttempts: 30,
+	windowSecs: 15 * 60,
+	blockSecs: 2 * 60,
+	configId: 'escrow-sync-v2',
+})
+
 const REDIS_TIMEOUT_MS = 3_000
 
 async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
@@ -30,9 +38,13 @@ async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
  * when the caller has exceeded the configured budget. When Redis is unavailable
  * or slow, logs a warning and allows the request so auth flows keep working.
  */
-export async function enforceRateLimit(identifier: string, action: string): Promise<void> {
+export async function enforceRateLimit(
+	identifier: string,
+	action: string,
+	limiter: RateLimiter = rateLimiter,
+): Promise<void> {
 	try {
-		const result = await withTimeout(rateLimiter.increment(identifier, action), REDIS_TIMEOUT_MS)
+		const result = await withTimeout(limiter.increment(identifier, action), REDIS_TIMEOUT_MS)
 
 		if (result.isBlocked) {
 			logger.warn({

--- a/apps/web/lib/auth/server-action-auth.ts
+++ b/apps/web/lib/auth/server-action-auth.ts
@@ -2,12 +2,16 @@ import type { Session } from 'next-auth'
 import { getServerSession } from 'next-auth'
 import { treeifyError, type ZodSchema } from 'zod'
 import { nextAuthOption } from '~/lib/auth/auth-options'
-import { enforceRateLimit, RateLimitExceededError } from '~/lib/auth/rate-limit'
+import {
+	enforceRateLimit,
+	escrowSyncRateLimiter,
+	RateLimitExceededError,
+} from '~/lib/auth/rate-limit'
 import { Logger } from '~/lib/logger'
 
 const logger = new Logger()
 
-export { enforceRateLimit, RateLimitExceededError }
+export { enforceRateLimit, escrowSyncRateLimiter, RateLimitExceededError }
 
 export type ServerActionErrorCode =
 	| 'UNAUTHORIZED'

--- a/apps/web/lib/constants/escrow-query.constants.ts
+++ b/apps/web/lib/constants/escrow-query.constants.ts
@@ -1,0 +1,12 @@
+import type { EscrowType } from '@trustless-work/escrow'
+
+/** Shared React Query timing for on-chain escrow reads (balances + released). */
+export const ESCROW_QUERY_STALE_MS = 30_000
+export const ESCROW_QUERY_POLL_MS = 30_000
+
+export const escrowBalanceQueryKey = (address: string, type: EscrowType) =>
+	['escrow-balance', address, type] as const
+
+export const escrowReleasedQueryKey = (address: string) => ['escrow-released', address] as const
+
+export const escrowDataQueryKey = (address: string) => ['escrow-data', address] as const

--- a/apps/web/lib/governance/vote-weight.ts
+++ b/apps/web/lib/governance/vote-weight.ts
@@ -35,6 +35,22 @@ export const getVoteWeight = (tier: NftTier): number => TIER_VOTE_WEIGHTS[tier] 
 export const getTierLabel = (tier: NftTier): string => TIER_LABELS[tier] ?? tier
 
 /**
+ * Aggregates vote weights per option from a flat list of vote rows.
+ * Returns a map of option_id → { up, down } totals.
+ */
+export function buildOptionWeightMap(
+	votes: { option_id: string; vote_type: string; vote_weight: number }[],
+): Record<string, { up: number; down: number }> {
+	const map: Record<string, { up: number; down: number }> = {}
+	for (const v of votes) {
+		if (!map[v.option_id]) map[v.option_id] = { up: 0, down: 0 }
+		if (v.vote_type === 'up') map[v.option_id].up += v.vote_weight
+		else map[v.option_id].down += v.vote_weight
+	}
+	return map
+}
+
+/**
  * Given a list of options and the current user's vote,
  * calculate the projected fund allocation percentage per option.
  */

--- a/apps/web/lib/i18n/translations/en/projects.ts
+++ b/apps/web/lib/i18n/translations/en/projects.ts
@@ -20,6 +20,7 @@ export const projects = {
 	filterHint: 'Tap one or more categories to narrow the list.',
 	resultsCountOne: '{count} cause found',
 	resultsCountMany: '{count} causes found',
+	resultsShowing: 'Showing {shown} of {total} projects',
 	emptyDescription:
 		'There are no projects available at the moment. Start a campaign or check back soon.',
 	emptyFilteredDescription:

--- a/apps/web/lib/i18n/translations/es/projects.ts
+++ b/apps/web/lib/i18n/translations/es/projects.ts
@@ -21,6 +21,7 @@ export const projects = {
 	filterHint: 'Toca una o más categorías para acotar la lista.',
 	resultsCountOne: '{count} causa encontrada',
 	resultsCountMany: '{count} causas encontradas',
+	resultsShowing: 'Mostrando {shown} de {total} proyectos',
 	emptyDescription: 'No hay proyectos disponibles por ahora. Crea una campaña o vuelve pronto.',
 	emptyFilteredDescription:
 		'Ningún proyecto coincide con las categorías seleccionadas. Prueba limpiar filtros o elegir otras categorías.',

--- a/apps/web/lib/queries/projects/get-all-projects.ts
+++ b/apps/web/lib/queries/projects/get-all-projects.ts
@@ -44,8 +44,8 @@ export type PaginatedProjectsResult = {
  */
 export async function getAllProjects(
 	client: TypedSupabaseClient,
-	categorySlugs: string[] = [],
-	sortSlug = 'most-popular',
+	categorySlugs?: string[],
+	sortSlug?: string,
 	limit?: number,
 	options?: GetAllProjectsOptions,
 ): Promise<ProjectListItem[]>

--- a/apps/web/lib/queries/projects/get-all-projects.ts
+++ b/apps/web/lib/queries/projects/get-all-projects.ts
@@ -22,13 +22,54 @@ export type GetAllProjectsOptions = LocalizeOptions & {
 	viewerLocale?: SupportedLocale
 }
 
+/**
+ * Result shape returned when using cursor-based pagination (`offset` provided).
+ * `total` is the full catalog count for the current filters so the client can
+ * display "X of Y" and determine whether more pages exist.
+ */
+export type PaginatedProjectsResult = {
+	items: ProjectListItem[]
+	total: number
+	nextOffset: number | null
+}
+
+/**
+ * Fetch a page of projects from Supabase.
+ *
+ * Pagination behaviour:
+ * - When `offset` is provided the function uses PostgREST `.range()` and
+ *   returns `PaginatedProjectsResult` (items + total + nextOffset).
+ * - When only `limit` is provided (legacy path) or neither is provided, the
+ *   function returns the flat `ProjectListItem[]` array for backward-compat.
+ */
 export async function getAllProjects(
 	client: TypedSupabaseClient,
 	categorySlugs: string[] = [],
 	sortSlug = 'most-popular',
 	limit?: number,
 	options?: GetAllProjectsOptions,
-): Promise<ProjectListItem[]> {
+): Promise<ProjectListItem[]>
+
+export async function getAllProjects(
+	client: TypedSupabaseClient,
+	categorySlugs: string[],
+	sortSlug: string,
+	limit: number,
+	options: GetAllProjectsOptions | undefined,
+	offset: number,
+): Promise<PaginatedProjectsResult>
+
+export async function getAllProjects(
+	client: TypedSupabaseClient,
+	categorySlugs: string[] = [],
+	sortSlug = 'most-popular',
+	limit?: number,
+	options?: GetAllProjectsOptions,
+	offset?: number,
+): Promise<ProjectListItem[] | PaginatedProjectsResult> {
+	const isPaginated = typeof offset === 'number'
+	const pageSize = limit ?? 12
+
 	const { column, ascending } = sortMap[sortSlug] ?? sortMap['most-popular']
 
 	let query = client
@@ -61,6 +102,7 @@ export async function getAllProjects(
         escrow_id
       )
     `,
+			isPaginated ? { count: 'exact' } : {},
 		)
 		.order(column, { ascending })
 
@@ -78,11 +120,15 @@ export async function getAllProjects(
 		}
 	}
 
-	if (limit) {
+	if (isPaginated) {
+		// Cursor-based pagination: fetch exactly one page
+		query = query.range(offset, offset + pageSize - 1)
+	} else if (limit) {
+		// Legacy limit-only path (hero, search, etc.)
 		query = query.limit(limit)
 	}
 
-	const { data, error } = await query
+	const { data, error, count } = await query
 
 	if (error) throw error
 
@@ -107,7 +153,7 @@ export async function getAllProjects(
 
 	const escrowContracts = await resolveProjectEscrowContracts(client, escrowRowIds)
 
-	return (
+	const items: ProjectListItem[] =
 		data?.map((project) => {
 			const sourceLocale = (project.source_locale as SupportedLocale | undefined) ?? 'en'
 			const localized = resolveLocalizedFields(
@@ -155,5 +201,12 @@ export async function getAllProjects(
 				),
 			} satisfies ProjectListItem
 		}) ?? []
-	)
+
+	if (isPaginated) {
+		const total = count ?? 0
+		const nextOffset = offset + items.length < total ? offset + pageSize : null
+		return { items, total, nextOffset }
+	}
+
+	return items
 }

--- a/apps/web/lib/queries/projects/get-project-donation-stream.ts
+++ b/apps/web/lib/queries/projects/get-project-donation-stream.ts
@@ -13,16 +13,23 @@ export async function getProjectDonationStream(
 	client: TypedSupabaseClient,
 	projectId: string,
 	limit = DEFAULT_LIMIT,
+	after?: string,
 ): Promise<DonationStreamItem[]> {
 	const safeLimit = Math.min(Math.max(1, limit), MAX_LIMIT)
 
-	const { data, error } = await client
+	let query = client
 		.from('contributions')
 		.select('id, amount, created_at')
 		.eq('project_id', projectId)
 		.gt('amount', 0)
 		.order('created_at', { ascending: false })
 		.limit(safeLimit)
+
+	if (after) {
+		query = query.gt('created_at', after)
+	}
+
+	const { data, error } = await query
 
 	if (error) throw error
 

--- a/apps/web/lib/schemas/server-actions.schemas.ts
+++ b/apps/web/lib/schemas/server-actions.schemas.ts
@@ -123,6 +123,10 @@ export const syncEscrowToDatabaseInputSchema = z.object({
 	projectId: z.string().uuid('Invalid projectId'),
 	contractId: stellarContractIdSchema,
 	escrowSnapshot: escrowDataSchema.optional(),
+	txHash: z
+		.string()
+		.regex(/^[A-Fa-f0-9]{64}$/, 'Invalid transaction hash')
+		.optional(),
 })
 
 export const createFoundationInputSchema = z.object({

--- a/apps/web/lib/services/escrow-indexer.service.ts
+++ b/apps/web/lib/services/escrow-indexer.service.ts
@@ -2,6 +2,9 @@ import type { GetEscrowsFromIndexerResponse } from '@trustless-work/escrow'
 import { logger } from '@/lib/logger'
 import { getTrustlessWorkApiConfig } from '~/lib/services/trustless-work-api.config'
 
+const INDEXER_NOT_FOUND_ERROR =
+	'Trustless Work has not indexed this contract yet. Paste the deployment transaction hash and try again.'
+
 export type EscrowIndexerFetchResult =
 	| { ok: true; escrow: GetEscrowsFromIndexerResponse }
 	| { ok: false; error: string }
@@ -56,7 +59,7 @@ const fetchEscrowFromBaseUrl = async ({
 
 	const escrow = parseIndexerPayload(await res.json())
 	if (!escrow?.engagementId) {
-		return { ok: false, error: 'Escrow not found for this contract ID' }
+		return { ok: false, error: INDEXER_NOT_FOUND_ERROR }
 	}
 
 	return { ok: true, escrow }
@@ -78,14 +81,93 @@ export async function getEscrowByContractIdFromIndexer(
 	}
 
 	try {
-		return await fetchEscrowFromBaseUrl({
+		const result = await fetchEscrowFromBaseUrl({
 			baseUrl,
 			apiKey,
 			contractId,
 			validateOnChain,
 		})
+
+		if (result.ok || !validateOnChain) {
+			return result
+		}
+
+		return await fetchEscrowFromBaseUrl({
+			baseUrl,
+			apiKey,
+			contractId,
+			validateOnChain: false,
+		})
 	} catch (error) {
 		logger.error('Failed to fetch escrow from indexer:', error)
+		return {
+			ok: false,
+			error: error instanceof Error ? error.message : 'Failed to reach Trustless Work',
+		}
+	}
+}
+
+const parseIndexerUpdatePayload = (payload: unknown): GetEscrowsFromIndexerResponse | null => {
+	if (!payload || typeof payload !== 'object') {
+		return null
+	}
+
+	const record = payload as Record<string, unknown>
+	const nested = record.escrow ?? record.data ?? payload
+	return parseIndexerPayload(nested)
+}
+
+export async function updateIndexerFromTxHash(txHash: string): Promise<EscrowIndexerFetchResult> {
+	const { apiKey, baseUrl } = getTrustlessWorkApiConfig()
+
+	if (!apiKey) {
+		return { ok: false, error: 'Trustless Work API key is not configured on the server' }
+	}
+
+	const headers = {
+		'x-api-key': apiKey,
+		'Content-Type': 'application/json',
+		Accept: 'application/json',
+	}
+	const body = JSON.stringify({ txHash })
+	const paths = ['/indexer/update-from-txHash', '/indexer/update-from-txhash']
+
+	try {
+		let receivedEmptySuccess = false
+
+		for (const path of paths) {
+			for (const method of ['POST', 'PUT'] as const) {
+				const res = await fetch(`${baseUrl}${path}`, {
+					method,
+					headers,
+					body,
+					cache: 'no-store',
+				})
+
+				if (!res.ok) {
+					continue
+				}
+
+				const escrow = parseIndexerUpdatePayload(await res.json())
+				if (escrow?.engagementId) {
+					return { ok: true, escrow }
+				}
+
+				receivedEmptySuccess = true
+			}
+		}
+
+		if (receivedEmptySuccess) {
+			return { ok: false, error: INDEXER_NOT_FOUND_ERROR }
+		}
+
+		return {
+			ok: false,
+			error:
+				'Could not refresh the Trustless Work indexer from this transaction hash. Confirm the hash is from the escrow deploy transaction.',
+		}
+	} catch (error) {
+		logger.error('Failed to update Trustless Work indexer from tx hash:', error)
 		return {
 			ok: false,
 			error: error instanceof Error ? error.message : 'Failed to reach Trustless Work',

--- a/apps/web/lib/services/project-matching/build-matching-context.test.ts
+++ b/apps/web/lib/services/project-matching/build-matching-context.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test'
+import type { UserMatchingContext } from './build-matching-context'
+import { buildMatchingPrompt, preRankCandidates } from './build-matching-context'
+import type { MatchingCandidateProject } from './schemas'
+import { MAX_PROMPT_CANDIDATES } from './schemas'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeCandidate = (
+	id: string,
+	overrides: Partial<MatchingCandidateProject> = {},
+): MatchingCandidateProject => ({
+	id,
+	slug: id,
+	title: `Project ${id}`,
+	description: `Description for ${id}`,
+	projectLocation: 'United States',
+	category: { id: 'cat-1', name: 'Education', slug: 'education', color: '#fff' },
+	tags: [{ name: 'youth', color: null }],
+	goal: 10000,
+	raised: 5000,
+	investors: 10,
+	percentageComplete: 50,
+	image: null,
+	...overrides,
+})
+
+const coldStartContext: UserMatchingContext = {
+	displayName: 'Alice',
+	bio: null,
+	country: 'US',
+	role: 'donor',
+	donationHistory: [],
+	stats: { donationCount: 0, totalAmount: 0, questsCompleted: 0, streakDays: 0, referralCount: 0 },
+	derivedPreferences: { topCategories: [], topRegions: [], topTags: [] },
+}
+
+const contextWithPreferences: UserMatchingContext = {
+	...coldStartContext,
+	derivedPreferences: {
+		topCategories: ['Education'],
+		topRegions: ['Mexico'],
+		topTags: ['youth', 'literacy'],
+	},
+}
+
+// ---------------------------------------------------------------------------
+// preRankCandidates — truncation
+// ---------------------------------------------------------------------------
+
+describe('preRankCandidates — truncation', () => {
+	test('returns at most MAX_PROMPT_CANDIDATES items when given more candidates', () => {
+		const candidates = Array.from({ length: 50 }, (_, i) => makeCandidate(`p${i}`))
+		const result = preRankCandidates(coldStartContext, candidates)
+		expect(result.length).toBe(MAX_PROMPT_CANDIDATES)
+	})
+
+	test('returns all candidates when fewer than MAX_PROMPT_CANDIDATES exist', () => {
+		const candidates = [makeCandidate('a'), makeCandidate('b')]
+		const result = preRankCandidates(coldStartContext, candidates)
+		expect(result.length).toBe(2)
+	})
+
+	test('respects a custom limit override', () => {
+		const candidates = Array.from({ length: 30 }, (_, i) => makeCandidate(`p${i}`))
+		const result = preRankCandidates(coldStartContext, candidates, 5)
+		expect(result.length).toBe(5)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// preRankCandidates — scoring
+// ---------------------------------------------------------------------------
+
+describe('preRankCandidates — scoring', () => {
+	test('candidate matching category + region + tags ranks first', () => {
+		const best = makeCandidate('best', {
+			category: { id: 'c1', name: 'Education', slug: 'edu', color: '#fff' },
+			projectLocation: 'Mexico',
+			tags: [
+				{ name: 'youth', color: null },
+				{ name: 'literacy', color: null },
+			],
+		})
+		const worst = makeCandidate('worst', {
+			category: { id: 'c2', name: 'Health', slug: 'health', color: '#fff' },
+			projectLocation: 'Brazil',
+			tags: [{ name: 'medicine', color: null }],
+		})
+		const result = preRankCandidates(contextWithPreferences, [worst, best])
+		expect(result[0].id).toBe('best')
+	})
+
+	test('category match alone outranks no-match candidate', () => {
+		const withCategory = makeCandidate('cat-match', {
+			category: { id: 'c1', name: 'Education', slug: 'edu', color: '#fff' },
+			projectLocation: 'Brazil',
+			tags: [],
+		})
+		const noMatch = makeCandidate('no-match', {
+			category: { id: 'c2', name: 'Health', slug: 'health', color: '#fff' },
+			projectLocation: 'Brazil',
+			tags: [],
+		})
+		const result = preRankCandidates(contextWithPreferences, [noMatch, withCategory])
+		expect(result[0].id).toBe('cat-match')
+	})
+
+	test('maps candidates to PromptCandidateProject shape with truncated description', () => {
+		const longDesc = 'x'.repeat(300)
+		const candidate = makeCandidate('p1', { description: longDesc })
+		const result = preRankCandidates(coldStartContext, [candidate])
+		expect(result[0].description.length).toBeLessThanOrEqual(150)
+		expect(result[0]).toHaveProperty('id', 'p1')
+		expect(result[0]).toHaveProperty('category')
+		expect(result[0]).toHaveProperty('tags')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// preRankCandidates — cold-start
+// ---------------------------------------------------------------------------
+
+describe('preRankCandidates — cold-start', () => {
+	test('returns results without error when user has no preferences', () => {
+		const candidates = Array.from({ length: 10 }, (_, i) => makeCandidate(`p${i}`))
+		expect(() => preRankCandidates(coldStartContext, candidates)).not.toThrow()
+	})
+
+	test('preserves original order for cold-start users (all scores equal zero)', () => {
+		const candidates = ['first', 'second', 'third'].map((id) => makeCandidate(id))
+		const result = preRankCandidates(coldStartContext, candidates, 3)
+		expect(result.map((r) => r.id)).toEqual(['first', 'second', 'third'])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// buildMatchingPrompt — bounded size
+// ---------------------------------------------------------------------------
+
+describe('buildMatchingPrompt — bounded size', () => {
+	test('prompt with MAX_PROMPT_CANDIDATES candidates stays within character budget', () => {
+		const candidates = Array.from({ length: MAX_PROMPT_CANDIDATES }, (_, i) =>
+			makeCandidate(`p${i}`),
+		)
+		const promptCandidates = preRankCandidates(coldStartContext, candidates)
+		const prompt = buildMatchingPrompt(coldStartContext, promptCandidates)
+		// Generous upper bound: 20 candidates × ~300 chars each + ~1500 for user section
+		expect(prompt.length).toBeLessThan(20 * 300 + 1500)
+	})
+
+	test('each candidate id appears exactly once in the prompt', () => {
+		const candidates = [makeCandidate('alpha'), makeCandidate('beta')]
+		const promptCandidates = preRankCandidates(coldStartContext, candidates)
+		const prompt = buildMatchingPrompt(coldStartContext, promptCandidates)
+		expect(prompt).toContain('[alpha]')
+		expect(prompt).toContain('[beta]')
+	})
+})

--- a/apps/web/lib/services/project-matching/build-matching-context.ts
+++ b/apps/web/lib/services/project-matching/build-matching-context.ts
@@ -1,6 +1,10 @@
 import type { TypedSupabaseClient } from '@packages/lib/types'
 import { getUserStats } from '~/lib/services/user-stats'
-import type { MatchingCandidateProject } from './schemas'
+import {
+	MAX_PROMPT_CANDIDATES,
+	type MatchingCandidateProject,
+	type PromptCandidateProject,
+} from './schemas'
 
 type CategoryRef = { id: string; name: string; slug: string | null; color: string } | null
 
@@ -215,20 +219,64 @@ export async function fetchMatchingCandidates(
 		}))
 }
 
-export const buildMatchingPrompt = (
+/**
+ * Pre-ranks candidates by relevance to the user's derived preferences and
+ * returns a compact slice bounded to `limit` (default MAX_PROMPT_CANDIDATES).
+ *
+ * Scoring (additive):
+ *   +3  category matches a topCategory
+ *   +2  region matches a topRegion
+ *   +1  per tag matching a topTag (capped at 3)
+ *   +0.5 proportional to percentageComplete (momentum signal)
+ *
+ * Cold-start users (no preferences) get score 0 for all candidates, so the
+ * original Supabase kinder_count ordering is preserved.
+ */
+export function preRankCandidates(
 	userContext: UserMatchingContext,
 	candidates: MatchingCandidateProject[],
+	limit = MAX_PROMPT_CANDIDATES,
+): PromptCandidateProject[] {
+	const { topCategories, topRegions, topTags } = userContext.derivedPreferences
+	const categorySet = new Set(topCategories)
+	const regionSet = new Set(topRegions)
+	const tagSet = new Set(topTags)
+
+	const scored = candidates.map((project) => {
+		let score = 0
+		if (project.category?.name && categorySet.has(project.category.name)) score += 3
+		if (project.projectLocation && regionSet.has(project.projectLocation)) score += 2
+		const tagMatches = project.tags.filter((t) => tagSet.has(t.name)).length
+		score += Math.min(tagMatches, 3)
+		score += ((project.percentageComplete ?? 0) / 100) * 0.5
+		return { project, score }
+	})
+
+	return scored
+		.sort((a, b) => b.score - a.score)
+		.slice(0, limit)
+		.map(({ project }) => ({
+			id: project.id,
+			title: project.title,
+			description: project.description?.slice(0, 150) ?? '',
+			category: project.category?.name ?? 'Uncategorized',
+			region: project.projectLocation ?? null,
+			tags: project.tags.map((t) => t.name),
+			fundingProgress: project.percentageComplete ?? 0,
+			supporters: project.investors,
+		}))
+}
+
+export const buildMatchingPrompt = (
+	userContext: UserMatchingContext,
+	candidates: PromptCandidateProject[],
 ): string => {
-	const candidateList = candidates.map((project) => ({
-		id: project.id,
-		title: project.title,
-		description: project.description?.slice(0, 280) ?? '',
-		category: project.category?.name ?? 'Uncategorized',
-		region: project.projectLocation,
-		tags: project.tags.map((tag) => tag.name),
-		fundingProgress: project.percentageComplete ?? 0,
-		supporters: project.investors,
-	}))
+	const candidateLines = candidates
+		.map(
+			(p) =>
+				`[${p.id}] ${p.title} | ${p.category} | ${p.region ?? 'global'} | tags: ${p.tags.join(',') || 'none'} | ${p.fundingProgress}% funded | ${p.supporters} supporters | ${p.description}`,
+		)
+		.join('\n')
 
 	return `Recommend 3 to 5 projects from the candidate list that best match this KindFi user.
 
@@ -263,7 +311,7 @@ ${
 }
 
 ## Candidate projects (only recommend from this list)
-${JSON.stringify(candidateList, null, 2)}
+${candidateLines}
 
 Rules:
 - Only use project ids from the candidate list.

--- a/apps/web/lib/services/project-matching/schemas.ts
+++ b/apps/web/lib/services/project-matching/schemas.ts
@@ -1,5 +1,24 @@
 import { z } from 'zod'
 
+/** Maximum number of pre-ranked candidates sent to the AI model. */
+export const MAX_PROMPT_CANDIDATES = 20
+
+/**
+ * Compact representation of a candidate project used inside the AI prompt.
+ * Excludes fields not needed for matching (image, raised amounts, etc.)
+ * to keep prompt size bounded.
+ */
+export interface PromptCandidateProject {
+	id: string
+	title: string
+	description: string
+	category: string
+	region: string | null
+	tags: string[]
+	fundingProgress: number
+	supporters: number
+}
+
 export const matchingAiResponseSchema = z.object({
 	summary: z
 		.string()

--- a/apps/web/lib/services/trustless-work-proxy.service.ts
+++ b/apps/web/lib/services/trustless-work-proxy.service.ts
@@ -44,16 +44,28 @@ const notifyTrustlessWorkIndexer = async (txHash: string): Promise<void> => {
 	if (!apiKey) return
 
 	try {
-		await fetch(`${getTrustlessWorkApiBaseUrl()}/indexer/update-from-txHash`, {
-			method: 'POST',
-			headers: {
-				'x-api-key': apiKey,
-				'Content-Type': 'application/json',
-				Accept: 'application/json',
-			},
-			body: JSON.stringify({ txHash }),
-			cache: 'no-store',
-		})
+		const indexerHeaders = {
+			'x-api-key': apiKey,
+			'Content-Type': 'application/json',
+			Accept: 'application/json',
+		}
+		const indexerBody = JSON.stringify({ txHash })
+		const indexerPaths = ['/indexer/update-from-txHash', '/indexer/update-from-txhash']
+
+		for (const path of indexerPaths) {
+			for (const method of ['POST', 'PUT'] as const) {
+				const response = await fetch(`${getTrustlessWorkApiBaseUrl()}${path}`, {
+					method,
+					headers: indexerHeaders,
+					body: indexerBody,
+					cache: 'no-store',
+				})
+
+				if (response.ok) {
+					return
+				}
+			}
+		}
 	} catch (error) {
 		logger.error('Trustless Work indexer update failed after local submit:', error)
 	}

--- a/apps/web/lib/utils/escrow/map-indexer-escrow-to-save-data.test.ts
+++ b/apps/web/lib/utils/escrow/map-indexer-escrow-to-save-data.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+import type { GetEscrowsFromIndexerResponse } from '@trustless-work/escrow'
+import { KINDFI_PLATFORM_FEE_PERCENT } from '~/lib/utils/escrow/platform-fee'
+import { mapIndexerEscrowToSaveData } from './map-indexer-escrow-to-save-data'
+
+const gAddress = (label: string) => `G${label.padEnd(55, 'A')}`
+
+const baseRoles = {
+	approver: gAddress('APPROVER'),
+	serviceProvider: gAddress('SERVICE'),
+	disputeResolver: gAddress('DISPUTE'),
+	platformAddress: gAddress('PLATFORM'),
+	releaseSigner: gAddress('RELEASE'),
+	receiver: gAddress('RECEIVER'),
+}
+
+describe('mapIndexerEscrowToSaveData', () => {
+	test('coerces string milestone amounts and fills empty description', () => {
+		const escrow = {
+			type: 'multi-release',
+			engagementId: 'project-1',
+			title: 'Ailani escrow',
+			description: '   ',
+			roles: baseRoles,
+			milestones: [
+				{
+					amount: '250',
+					receiver: baseRoles.receiver,
+					description: 'Surgery',
+				},
+			],
+		} as unknown as GetEscrowsFromIndexerResponse
+
+		const result = mapIndexerEscrowToSaveData(escrow)
+
+		expect(result.description).toBe('Ailani escrow')
+		expect(result.platformFee).toBe(KINDFI_PLATFORM_FEE_PERCENT)
+		expect(result.milestones).toEqual([
+			{
+				amount: 250,
+				receiver: baseRoles.receiver,
+			},
+		])
+	})
+})

--- a/apps/web/lib/utils/escrow/map-indexer-escrow-to-save-data.ts
+++ b/apps/web/lib/utils/escrow/map-indexer-escrow-to-save-data.ts
@@ -4,17 +4,27 @@ import { KINDFI_PLATFORM_FEE_PERCENT } from '~/lib/utils/escrow/platform-fee'
 
 type EscrowSaveData = SaveEscrowContractParams['escrowData']
 
+const toPositiveNumber = (value: unknown): number | null => {
+	const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		return null
+	}
+
+	return parsed
+}
+
 const hasPaymentMilestone = (
 	milestone: GetEscrowsFromIndexerResponse['milestones'][number],
 ): milestone is MultiReleaseMilestone => {
-	return (
-		typeof milestone === 'object' &&
-		milestone !== null &&
-		'amount' in milestone &&
-		'receiver' in milestone &&
-		typeof milestone.amount === 'number' &&
-		typeof milestone.receiver === 'string'
-	)
+	if (typeof milestone !== 'object' || milestone === null) {
+		return false
+	}
+
+	if (!('amount' in milestone) || !('receiver' in milestone)) {
+		return false
+	}
+
+	return toPositiveNumber(milestone.amount) !== null && typeof milestone.receiver === 'string'
 }
 
 export const mapIndexerEscrowToSaveData = (
@@ -28,10 +38,13 @@ export const mapIndexerEscrowToSaveData = (
 		releaseSigner: escrow.roles.releaseSigner,
 	}
 
+	const title = escrow.title?.trim() || 'Untitled Escrow'
+	const description = escrow.description?.trim() || title
+
 	const base = {
 		engagementId: escrow.engagementId,
-		title: escrow.title,
-		description: escrow.description,
+		title,
+		description,
 		roles,
 		platformFee: KINDFI_PLATFORM_FEE_PERCENT,
 	}
@@ -42,15 +55,20 @@ export const mapIndexerEscrowToSaveData = (
 			throw new Error('Indexer escrow is missing receiver address')
 		}
 
+		const amount = toPositiveNumber(escrow.amount)
+		if (amount === null) {
+			throw new Error('Indexer escrow is missing a positive amount')
+		}
+
 		return {
 			...base,
-			amount: escrow.amount,
+			amount,
 			receiver,
 		}
 	}
 
 	const milestones = escrow.milestones.filter(hasPaymentMilestone).map((milestone) => ({
-		amount: milestone.amount,
+		amount: toPositiveNumber(milestone.amount) as number,
 		receiver: milestone.receiver,
 	}))
 

--- a/apps/web/lib/utils/soroban-native.ts
+++ b/apps/web/lib/utils/soroban-native.ts
@@ -1,0 +1,119 @@
+/** Unwrap Soroban Option values decoded by scValToNative (`{ tag: 'Some', values: [T] }`). */
+export const unwrapScValOption = <T>(value: unknown): T | null => {
+	if (value === null || value === undefined) {
+		return null
+	}
+
+	if (typeof value === 'object') {
+		const tagged = value as { tag?: string; values?: unknown[] }
+		if (tagged.tag === 'None') {
+			return null
+		}
+		if (tagged.tag === 'Some' && tagged.values?.[0] !== undefined) {
+			return tagged.values[0] as T
+		}
+	}
+
+	return value as T
+}
+
+export type NormalizedNftAttribute = {
+	trait_type: string
+	value: string
+	display_type?: string
+	max_value?: string
+}
+
+export type NormalizedNftMetadata = {
+	name: string
+	description: string
+	image_uri: string
+	external_url: string
+	attributes: NormalizedNftAttribute[]
+}
+
+const asString = (value: unknown): string => {
+	if (value === null || value === undefined) {
+		return ''
+	}
+	return String(value).trim()
+}
+
+/** Normalize Address values returned by scValToNative. */
+export const normalizeStellarAddress = (value: unknown): string | null => {
+	if (!value) {
+		return null
+	}
+
+	if (typeof value === 'string') {
+		return value
+	}
+
+	if (typeof value === 'object') {
+		const record = value as Record<string, unknown>
+		for (const key of ['address', 'value', 'accountId', 'contractId']) {
+			const candidate = record[key]
+			if (typeof candidate === 'string' && candidate.length > 0) {
+				return candidate
+			}
+		}
+	}
+
+	const fallback = String(value)
+	return fallback && fallback !== '[object Object]' ? fallback : null
+}
+
+const normalizeAttribute = (raw: unknown): NormalizedNftAttribute | null => {
+	if (!raw || typeof raw !== 'object') {
+		return null
+	}
+
+	const record = raw as Record<string, unknown>
+	const traitType = asString(record.trait_type ?? record.traitType)
+	const value = asString(record.value)
+
+	if (!traitType) {
+		return null
+	}
+
+	const displayType = asString(record.display_type ?? record.displayType)
+	const maxValue = asString(record.max_value ?? record.maxValue)
+
+	return {
+		trait_type: traitType,
+		value,
+		...(displayType ? { display_type: displayType } : {}),
+		...(maxValue ? { max_value: maxValue } : {}),
+	}
+}
+
+/** Normalize NFT metadata from scValToNative (handles Option wrapper and field aliases). */
+export const normalizeNftMetadata = (
+	raw: unknown,
+	fallbackTokenId: number,
+): NormalizedNftMetadata => {
+	const unwrapped = unwrapScValOption<Record<string, unknown>>(raw) ?? {}
+	const record =
+		unwrapped && typeof unwrapped === 'object'
+			? unwrapped
+			: typeof raw === 'object' && raw !== null
+				? (raw as Record<string, unknown>)
+				: {}
+
+	const attributesRaw = record.attributes
+	const attributes: NormalizedNftAttribute[] = Array.isArray(attributesRaw)
+		? attributesRaw
+				.map(normalizeAttribute)
+				.filter((attr): attr is NormalizedNftAttribute => attr !== null)
+		: []
+
+	const imageUri = asString(record.image_uri ?? record.imageUri ?? record.image)
+
+	return {
+		name: asString(record.name) || `Kinder NFT #${fallbackTokenId}`,
+		description: asString(record.description),
+		image_uri: imageUri,
+		external_url: asString(record.external_url ?? record.externalUrl),
+		attributes,
+	}
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -52,6 +52,16 @@ const nextConfig: NextConfig = {
 			},
 			{
 				protocol: 'https',
+				hostname: 'gateway.pinata.cloud',
+				pathname: '/ipfs/**',
+			},
+			{
+				protocol: 'https',
+				hostname: 'kindfi.org',
+				pathname: '/images/**',
+			},
+			{
+				protocol: 'https',
 				hostname: '*.mypinata.cloud',
 				pathname: '/ipfs/**',
 			},
@@ -83,7 +93,7 @@ const nextConfig: NextConfig = {
 			? `'self' https://flagcdn.com https://apis.google.com https://friendbot-futurenet.stellar.org https://www.google-analytics.com https://www.googletagmanager.com https://rpc-futurenet.stellar.org https://horizon-futurenet.stellar.org https://soroban-testnet.stellar.org https://horizon-testnet.stellar.org https://*.kindfi.org https://dev-api.dashboard.kindfi.org https://*.supabase.co wss://*.supabase.co https://*.vercel.app https://dev.api.trustlesswork.com https://api.trustlesswork.com https://api.pollar.xyz https://sdk.api.pollar.xyz`
 			: `'self' https://friendbot-futurenet.stellar.org http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:* wss://localhost:* wss://127.0.0.1:* https://flagcdn.com https://apis.google.com https://www.google-analytics.com https://www.googletagmanager.com https://rpc-futurenet.stellar.org https://horizon-futurenet.stellar.org https://soroban-testnet.stellar.org https://horizon-testnet.stellar.org https://*.kindfi.org https://dev-api.dashboard.kindfi.org https://*.supabase.co wss://*.supabase.co https://*.vercel.app https://dev.api.trustlesswork.com https://api.trustlesswork.com https://api.pollar.xyz https://sdk.api.pollar.xyz`
 
-		const imgSrc = `'self' data: blob: https://flagcdn.com https://pollar.xyz https://*.pollar.xyz https://*.googleusercontent.com https://*.jsdelivr.net https://cdn.jsdelivr.net https://unpkg.com https://*.unpkg.com https://raw.githubusercontent.com https://*.githubusercontent.com https://freighter.app https://albedo.link https://rabet.io https://xbull.app https://walletconnect.org https://*.walletconnect.org https://*.walletconnect.com https://stellar.creit.tech https://*.mypinata.cloud`
+		const imgSrc = `'self' data: blob: https://flagcdn.com https://pollar.xyz https://*.pollar.xyz https://gateway.pinata.cloud https://kindfi.org https://*.googleusercontent.com https://*.jsdelivr.net https://cdn.jsdelivr.net https://unpkg.com https://*.unpkg.com https://raw.githubusercontent.com https://*.githubusercontent.com https://freighter.app https://albedo.link https://rabet.io https://xbull.app https://walletconnect.org https://*.walletconnect.org https://*.walletconnect.com https://stellar.creit.tech https://*.mypinata.cloud`
 		const imgSrcDev = `${imgSrc} https://randomuser.me http://127.0.0.1:54321`
 
 		if (isProduction) {

--- a/apps/web/test/api-governance-rounds.test.ts
+++ b/apps/web/test/api-governance-rounds.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ── Environment (must be set before any module that touches Supabase loads) ──
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key'
+process.env.NEXTAUTH_SECRET = 'test-secret'
+
+// ── Mutable mock state (reset per test) ─────────────────────────────────────
+
+let mockRoundsResult: { data: unknown; error: unknown; count: number } = {
+	data: [],
+	error: null,
+	count: 0,
+}
+let mockVotesResult: { data: unknown; error: unknown } = { data: [], error: null }
+
+// ── Module mocks (must precede route import) ─────────────────────────────────
+
+mock.module('next/server', () => ({
+	NextResponse: {
+		json: (body: unknown, init?: { status?: number }) =>
+			new Response(JSON.stringify(body), {
+				status: init?.status ?? 200,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+	},
+}))
+
+mock.module('next-auth', () => ({ getServerSession: mock(async () => null) }))
+mock.module('~/lib/auth/auth-options', () => ({ nextAuthOption: {} }))
+mock.module('@/lib/logger', () => ({
+	logger: { error: mock(() => {}), warn: mock(() => {}), info: mock(() => {}) },
+}))
+mock.module('~/lib/stellar/governance-contract', () => ({ GovernanceContractService: class {} }))
+
+mock.module('@packages/lib/supabase', () => {
+	function createChain(result: unknown): unknown {
+		const chain: Record<string, unknown> = {
+			then: (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+				Promise.resolve(result).then(res, rej),
+			catch: (fn: (e: unknown) => unknown) => Promise.resolve(result).catch(fn),
+		}
+		for (const m of [
+			'select',
+			'order',
+			'eq',
+			'in',
+			'range',
+			'single',
+			'maybeSingle',
+			'insert',
+			'update',
+		]) {
+			chain[m] = () => createChain(result)
+		}
+		return chain
+	}
+
+	return {
+		supabase: {
+			rpc: mock(async () => ({ data: null, error: null })),
+			from: (table: string) => {
+				if (table === 'governance_rounds') return createChain(mockRoundsResult)
+				if (table === 'governance_votes') return createChain(mockVotesResult)
+				return createChain({ data: null, error: null })
+			},
+		},
+	}
+})
+
+// Dynamic import AFTER all mocks are registered (static imports are hoisted and
+// would run before mock.module calls, preventing the mocks from taking effect)
+const { GET } = await import('../app/api/governance/rounds/route')
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(params: Record<string, string> = {}): unknown {
+	const defaults = { limit: '10', offset: '0' }
+	const merged = { ...defaults, ...params }
+	const url = new URL('http://localhost/api/governance/rounds')
+	for (const [k, v] of Object.entries(merged)) url.searchParams.set(k, v)
+	return { nextUrl: url }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GET /api/governance/rounds', () => {
+	beforeEach(() => {
+		mockRoundsResult = { data: [], error: null, count: 0 }
+		mockVotesResult = { data: [], error: null }
+	})
+
+	test('returns 200 with enriched options for multiple rounds and options', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [
+						{ id: 'opt-a', title: 'Option A' },
+						{ id: 'opt-b', title: 'Option B' },
+					],
+				},
+				{
+					id: 'round-2',
+					title: 'Round 2',
+					status: 'active',
+					options: [{ id: 'opt-c', title: 'Option C' }],
+				},
+			],
+			error: null,
+			count: 2,
+		}
+		mockVotesResult = {
+			data: [
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 5 },
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'down', vote_weight: 2 },
+				{ round_id: 'round-1', option_id: 'opt-b', vote_type: 'up', vote_weight: 3 },
+				{ round_id: 'round-2', option_id: 'opt-c', vote_type: 'up', vote_weight: 10 },
+			],
+			error: null,
+		}
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(body.success).toBe(true)
+		expect(body.pagination).toEqual({ limit: 10, offset: 0, total: 2 })
+
+		const [r1, r2] = body.data
+		const optA = r1.options.find((o: { id: string }) => o.id === 'opt-a')
+		const optB = r1.options.find((o: { id: string }) => o.id === 'opt-b')
+		const optC = r2.options.find((o: { id: string }) => o.id === 'opt-c')
+
+		expect(optA).toMatchObject({ weighted_upvotes: 5, weighted_downvotes: 2 })
+		expect(optB).toMatchObject({ weighted_upvotes: 3, weighted_downvotes: 0 })
+		expect(optC).toMatchObject({ weighted_upvotes: 10, weighted_downvotes: 0 })
+	})
+
+	test('returns zero weights when a round has no votes', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [
+						{ id: 'opt-a', title: 'Option A' },
+						{ id: 'opt-b', title: 'Option B' },
+					],
+				},
+			],
+			error: null,
+			count: 1,
+		}
+		mockVotesResult = { data: [], error: null }
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		for (const opt of body.data[0].options) {
+			expect(opt.weighted_upvotes).toBe(0)
+			expect(opt.weighted_downvotes).toBe(0)
+		}
+	})
+
+	test('separates up and down vote weights on the same option', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [{ id: 'opt-a', title: 'Option A' }],
+				},
+			],
+			error: null,
+			count: 1,
+		}
+		mockVotesResult = {
+			data: [
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 7 },
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'down', vote_weight: 4 },
+			],
+			error: null,
+		}
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+		const opt = body.data[0].options[0]
+
+		expect(opt.weighted_upvotes).toBe(7)
+		expect(opt.weighted_downvotes).toBe(4)
+	})
+
+	test('returns 200 with empty data when no rounds exist', async () => {
+		mockRoundsResult = { data: [], error: null, count: 0 }
+		mockVotesResult = { data: [], error: null }
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(body.success).toBe(true)
+		expect(body.data).toEqual([])
+		expect(body.pagination.total).toBe(0)
+	})
+
+	test('respects pagination parameters in the response', async () => {
+		mockRoundsResult = { data: [], error: null, count: 42 }
+
+		const res = await GET(makeReq({ limit: '5', offset: '15' }) as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(body.pagination).toEqual({ limit: 5, offset: 15, total: 42 })
+	})
+
+	test('returns 500 when the database returns an error', async () => {
+		mockRoundsResult = { data: null, error: { message: 'connection refused' }, count: 0 }
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(res.status).toBe(500)
+		expect(body).toEqual({ error: 'Failed to fetch rounds' })
+	})
+
+	test('accumulates vote weights from multiple tiers on the same option', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [{ id: 'opt-a', title: 'Option A' }],
+				},
+			],
+			error: null,
+			count: 1,
+		}
+		// bronze=1, diamond=10 both upvoting → total 11
+		mockVotesResult = {
+			data: [
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 1 },
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 10 },
+			],
+			error: null,
+		}
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+		const opt = body.data[0].options[0]
+
+		expect(opt.weighted_upvotes).toBe(11)
+		expect(opt.weighted_downvotes).toBe(0)
+	})
+
+	test('votes from other rounds do not bleed into the wrong round', async () => {
+		mockRoundsResult = {
+			data: [
+				{
+					id: 'round-1',
+					title: 'Round 1',
+					status: 'active',
+					options: [{ id: 'opt-a', title: 'Option A' }],
+				},
+				{
+					id: 'round-2',
+					title: 'Round 2',
+					status: 'active',
+					options: [{ id: 'opt-a', title: 'Option A (round 2)' }],
+				},
+			],
+			error: null,
+			count: 2,
+		}
+		// opt-a exists in both rounds but with different weights per round
+		mockVotesResult = {
+			data: [
+				{ round_id: 'round-1', option_id: 'opt-a', vote_type: 'up', vote_weight: 3 },
+				{ round_id: 'round-2', option_id: 'opt-a', vote_type: 'up', vote_weight: 8 },
+			],
+			error: null,
+		}
+
+		const res = await GET(makeReq() as any)
+		const body = await res.json()
+
+		expect(body.data[0].options[0].weighted_upvotes).toBe(3)
+		expect(body.data[1].options[0].weighted_upvotes).toBe(8)
+	})
+})

--- a/apps/web/test/projects-pagination.test.ts
+++ b/apps/web/test/projects-pagination.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Performance-oriented tests for the projects pagination logic.
+ *
+ * These tests verify that:
+ * 1. The pagination slice (getAllProjects with offset) returns only `pageSize` items.
+ * 2. Pages do not overlap — page 2 does not re-return IDs from page 1.
+ * 3. `newIds` set tracking only marks the IDs added in the latest page.
+ * 4. When the catalog is exactly `pageSize` items, `nextOffset` is null (no more pages).
+ * 5. DOM size grows proportional to page size, not total catalog size.
+ *
+ * NOTE: The Supabase client is mocked — these tests exercise the pagination
+ * calculation logic only, not network I/O.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import type { PaginatedProjectsResult } from '~/lib/queries/projects/get-all-projects'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal fake project row for a given index.
+ */
+function fakeRow(index: number) {
+	return {
+		id: `project-${index}`,
+		title: `Project ${index}`,
+		slug: `project-${index}`,
+		description: `Description ${index}`,
+		image_url: null,
+		created_at: new Date(Date.now() - index * 1000).toISOString(),
+		current_amount: 0,
+		target_amount: 1000,
+		min_investment: 10,
+		percentage_complete: 0,
+		kinder_count: 0,
+		status: 'active',
+		development_only: false,
+		source_locale: 'en',
+		category: null,
+		project_tag_relationships: [],
+		milestones: [],
+		project_escrows: null,
+	}
+}
+
+/**
+ * Simulate the offset+range slicing that PostgREST performs on the server.
+ * Used to test the nextOffset calculation logic without a real DB.
+ */
+function simulatePage(
+	allRows: ReturnType<typeof fakeRow>[],
+	offset: number,
+	pageSize: number,
+): PaginatedProjectsResult {
+	const slice = allRows.slice(offset, offset + pageSize)
+	const total = allRows.length
+	const nextOffset = offset + slice.length < total ? offset + pageSize : null
+
+	const items = slice.map((row) => ({
+		id: row.id,
+		title: row.title,
+		slug: row.slug,
+		description: row.description,
+		image: row.image_url,
+		createdAt: row.created_at,
+		goal: row.target_amount,
+		raised: row.current_amount,
+		investors: row.kinder_count,
+		minInvestment: row.min_investment,
+		tags: [],
+		category: null,
+		developmentOnly: false,
+	}))
+
+	return { items, total, nextOffset }
+}
+
+// ─── Catalog data ─────────────────────────────────────────────────────────────
+
+const PAGE_SIZE = 12
+const CATALOG_SIZE = 50
+const allRows = Array.from({ length: CATALOG_SIZE }, (_, i) => fakeRow(i))
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Projects pagination — page slicing', () => {
+	test('first page returns exactly PAGE_SIZE items', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		expect(page1.items).toHaveLength(PAGE_SIZE)
+	})
+
+	test('first page total equals full catalog size', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		expect(page1.total).toBe(CATALOG_SIZE)
+	})
+
+	test('first page nextOffset points to PAGE_SIZE', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		expect(page1.nextOffset).toBe(PAGE_SIZE)
+	})
+
+	test('second page returns the next PAGE_SIZE items', () => {
+		const page2 = simulatePage(allRows, PAGE_SIZE, PAGE_SIZE)
+		expect(page2.items).toHaveLength(PAGE_SIZE)
+		expect(page2.items[0].id).toBe(`project-${PAGE_SIZE}`)
+	})
+
+	test('pages do not overlap — no shared IDs between page 1 and page 2', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		const page2 = simulatePage(allRows, PAGE_SIZE, PAGE_SIZE)
+		const ids1 = new Set(page1.items.map((p) => p.id))
+		for (const item of page2.items) {
+			expect(ids1.has(item.id)).toBe(false)
+		}
+	})
+
+	test('last partial page returns remaining items', () => {
+		// CATALOG_SIZE=50, PAGE_SIZE=12: pages 0–3 full, page 4 has 50-(4*12)=2 items
+		const offset = Math.floor(CATALOG_SIZE / PAGE_SIZE) * PAGE_SIZE
+		const remaining = CATALOG_SIZE - offset
+		const lastPage = simulatePage(allRows, offset, PAGE_SIZE)
+		expect(lastPage.items).toHaveLength(remaining)
+	})
+
+	test('last page nextOffset is null', () => {
+		const offset = Math.floor(CATALOG_SIZE / PAGE_SIZE) * PAGE_SIZE
+		const lastPage = simulatePage(allRows, offset, PAGE_SIZE)
+		expect(lastPage.nextOffset).toBeNull()
+	})
+
+	test('exact-fit catalog (total === PAGE_SIZE) nextOffset is null', () => {
+		const exactRows = Array.from({ length: PAGE_SIZE }, (_, i) => fakeRow(i))
+		const page = simulatePage(exactRows, 0, PAGE_SIZE)
+		expect(page.items).toHaveLength(PAGE_SIZE)
+		expect(page.nextOffset).toBeNull()
+	})
+})
+
+describe('Projects pagination — newIds tracking', () => {
+	/**
+	 * Simulate the client-side newIds Set logic from projects-client-wrapper:
+	 * - First page: all IDs are "new" (animate in).
+	 * - Subsequent pages: only the latest page's IDs are "new".
+	 */
+	function buildNewIds(pages: PaginatedProjectsResult[], pageIndex: number): Set<string> {
+		const lastPage = pages[pageIndex]
+		if (!lastPage) return new Set()
+		return new Set(lastPage.items.map((p) => p.id))
+	}
+
+	test('first page — all returned IDs are in newIds', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		const newIds = buildNewIds([page1], 0)
+		for (const item of page1.items) {
+			expect(newIds.has(item.id)).toBe(true)
+		}
+	})
+
+	test('second page — only new IDs in newIds, not IDs from page 1', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		const page2 = simulatePage(allRows, PAGE_SIZE, PAGE_SIZE)
+		const newIds = buildNewIds([page1, page2], 1)
+
+		// page2 IDs should be in newIds
+		for (const item of page2.items) {
+			expect(newIds.has(item.id)).toBe(true)
+		}
+		// page1 IDs should NOT be in newIds (already rendered, no remount)
+		for (const item of page1.items) {
+			expect(newIds.has(item.id)).toBe(false)
+		}
+	})
+
+	test('newIds size equals the last page item count, not total rendered', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		const page2 = simulatePage(allRows, PAGE_SIZE, PAGE_SIZE)
+		const newIds = buildNewIds([page1, page2], 1)
+
+		expect(newIds.size).toBe(page2.items.length)
+		expect(newIds.size).toBeLessThan(page1.items.length + page2.items.length)
+	})
+})
+
+describe('Projects pagination — DOM size bound', () => {
+	test('DOM node count is bounded by pages loaded, not total catalog', () => {
+		/**
+		 * With N pages loaded, the DOM should contain at most N * PAGE_SIZE nodes —
+		 * never the entire CATALOG_SIZE at once.
+		 */
+		const pagesLoaded = 2
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		const page2 = simulatePage(allRows, PAGE_SIZE, PAGE_SIZE)
+		const rendered = [...page1.items, ...page2.items]
+
+		expect(rendered.length).toBe(pagesLoaded * PAGE_SIZE)
+		expect(rendered.length).toBeLessThan(CATALOG_SIZE)
+	})
+
+	test('loading a new page does not re-include existing IDs', () => {
+		const page1 = simulatePage(allRows, 0, PAGE_SIZE)
+		const page2 = simulatePage(allRows, PAGE_SIZE, PAGE_SIZE)
+		const allRendered = [...page1.items, ...page2.items]
+		const idSet = new Set(allRendered.map((p) => p.id))
+
+		// No duplicates — IDs are unique across pages
+		expect(idSet.size).toBe(allRendered.length)
+	})
+})


### PR DESCRIPTION
## Summary
- Adds escrow sync recovery when a contract exists on-chain but Trustless Work has not indexed it yet, including optional deploy transaction hash input to refresh the indexer before linking the contract to a campaign.
- Relaxes escrow sync rate limits and extends the Trustless Work proxy timeout to reduce failed recovery attempts during admin recovery flows.
- Includes other `develop` changes already ahead of `main`: project discovery pagination, donation stream polling improvements, governance rounds N+1 fix, project matching cache/prerank, and build normalization.

## Test plan
- [ ] Open a campaign manage settings page and use **Link Existing Escrow** with a contract ID that is on-chain but not indexed; confirm the UI prompts for a deploy tx hash.
- [ ] Paste the deploy transaction hash and verify the escrow links to the campaign successfully.
- [ ] Confirm repeated sync attempts are no longer blocked after a few retries.
- [ ] Smoke test project discovery pagination and donation stream on the projects page.
- [ ] Verify governance rounds API still loads without regressions.


Made with [Cursor](https://cursor.com)