### PR TITLE
fix(web): harden escrow deploy signing and on-chain sync fallback

### DIFF
--- a/apps/web/components/sections/projects/manage/escrow/hooks/use-escrow-transaction.ts
+++ b/apps/web/components/sections/projects/manage/escrow/hooks/use-escrow-transaction.ts
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import { toast } from 'sonner'
 import { useEscrow } from '~/hooks/contexts/use-escrow.context'
 import { useTrustlessSigner } from '~/hooks/escrow/use-trustless-signer'
 import { Logger } from '~/lib/logger'
@@ -62,10 +63,12 @@ export function useEscrowTransaction({ projectId, projectSlug }: UseEscrowTransa
 				})
 			}
 		} catch (e) {
+			const message = e instanceof Error ? e.message : 'Failed to create escrow'
 			logger.error({
 				eventType: 'escrow.create.error',
-				error: e instanceof Error ? e.message : String(e),
+				error: message,
 			})
+			toast.error('Failed to create escrow', { description: message })
 		} finally {
 			setIsSubmitting(false)
 		}

--- a/apps/web/hooks/contexts/use-stellar-wallet.context.tsx
+++ b/apps/web/hooks/contexts/use-stellar-wallet.context.tsx
@@ -16,6 +16,11 @@ import {
 	safeLocalStorageRemove,
 	safeLocalStorageSet,
 } from '~/lib/utils/safe-storage'
+import {
+	getWalletSessionErrorMessage,
+	isStaleWalletSessionError,
+	WALLET_SESSION_EXPIRED_MESSAGE,
+} from '~/lib/utils/wallet/wallet-session-error'
 
 /** Loaded only in the browser so kit state does not touch Node's broken `localStorage` polyfill. */
 type StellarWalletsKitModules = {
@@ -296,25 +301,52 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 		if (!isInitialized || !StellarWalletsKit || !Networks) {
 			throw new Error('Wallet kit not initialized')
 		}
-		const signingAddress = signerAddress ?? address
-		if (!signingAddress) {
-			throw new Error('Wallet not connected')
-		}
 
-		const signerError = getTrustlessSignerError(signingAddress)
-		if (signerError) {
-			throw new Error(signerError)
-		}
+		const signWithAddress = async (activeAddress: string): Promise<string> => {
+			const signerError = getTrustlessSignerError(activeAddress)
+			if (signerError) {
+				throw new Error(signerError)
+			}
 
-		try {
 			const { signedTxXdr } = await StellarWalletsKit.signTransaction(unsignedXdr, {
-				address: signingAddress,
+				address: activeAddress,
 				networkPassphrase,
 			})
 			return signedTxXdr
+		}
+
+		const initialAddress = signerAddress ?? address
+		if (!initialAddress) {
+			throw new Error('Wallet not connected')
+		}
+
+		try {
+			return await signWithAddress(initialAddress)
 		} catch (error) {
-			logger.error('Failed to sign transaction:', error)
-			throw error
+			if (!isStaleWalletSessionError(error)) {
+				logger.error('Failed to sign transaction:', error)
+				throw new Error(getWalletSessionErrorMessage(error) ?? 'Failed to sign transaction')
+			}
+
+			logger.warn('Stale Stellar wallet session detected; prompting reconnect before retrying sign')
+			disconnect()
+
+			try {
+				await StellarWalletsKit.refreshSupportedWallets()
+				const { address: reconnectedAddress } = await StellarWalletsKit.authModal()
+				if (!reconnectedAddress || !isExternalStellarWalletAddress(reconnectedAddress)) {
+					throw new Error(WALLET_SESSION_EXPIRED_MESSAGE)
+				}
+
+				setAddress(reconnectedAddress)
+				safeLocalStorageSet('stellar_wallet_address', reconnectedAddress)
+				syncLinkedWalletIfAuthenticatedRef.current(reconnectedAddress)
+
+				return await signWithAddress(signerAddress ?? reconnectedAddress)
+			} catch (reconnectError) {
+				logger.error('Failed to reconnect wallet after stale session:', reconnectError)
+				throw new Error(WALLET_SESSION_EXPIRED_MESSAGE)
+			}
 		}
 	}
 

--- a/apps/web/hooks/escrow/use-trustless-signer.ts
+++ b/apps/web/hooks/escrow/use-trustless-signer.ts
@@ -23,9 +23,26 @@ export function useTrustlessSigner() {
 	const wallet = useWallet()
 	const { networkId, networkPassphrase } = useStellarNetworkConfig()
 	const { t } = useI18n()
-	const { isPollarReady, pollarAddress, signAndSubmitTrustless } = usePollarSigner()
+	const { isPollarReady, isPollarUser, pollarAddress, signAndSubmitTrustless } = usePollarSigner()
+
+	const assertPollarReady = (): void => {
+		if (!isPollarUser) {
+			return
+		}
+
+		if (!isPollarReady || !pollarAddress) {
+			throw new Error(
+				'Pollar wallet session is not ready. Refresh the page, sign in again, and wait for your wallet to finish loading before deploying escrow.',
+			)
+		}
+	}
 
 	const ensureTrustlessSigner = async (): Promise<string> => {
+		if (isPollarUser) {
+			assertPollarReady()
+			return pollarAddress as string
+		}
+
 		if (isPollarReady && pollarAddress) {
 			return pollarAddress
 		}
@@ -49,6 +66,10 @@ export function useTrustlessSigner() {
 		unsignedXdr: string,
 		requiredSigner?: string,
 	): Promise<string> => {
+		if (isPollarUser) {
+			assertPollarReady()
+		}
+
 		if (isPollarReady) {
 			const result = await signAndSubmitTrustless(unsignedXdr)
 			if (!result.alreadySubmitted) {
@@ -77,6 +98,10 @@ export function useTrustlessSigner() {
 		unsignedXdr: string,
 		requiredSigner?: string,
 	): Promise<TrustlessSubmitResult> => {
+		if (isPollarUser) {
+			assertPollarReady()
+		}
+
 		if (isPollarReady) {
 			if (requiredSigner && pollarAddress) {
 				assertTrustlessSignerMatches(pollarAddress, requiredSigner, 'platform')
@@ -116,6 +141,7 @@ export function useTrustlessSigner() {
 		signAndSendTrustless,
 		isTrustlessReady: isPollarReady || isExternalStellarWalletAddress(wallet.address),
 		isPollarSigner: isPollarReady,
+		isPollarUser,
 		pollarAddress,
 	}
 }

--- a/apps/web/lib/services/escrow-indexer.service.ts
+++ b/apps/web/lib/services/escrow-indexer.service.ts
@@ -1,6 +1,10 @@
 import type { GetEscrowsFromIndexerResponse } from '@trustless-work/escrow'
 import { logger } from '@/lib/logger'
 import { getTrustlessWorkApiConfig } from '~/lib/services/trustless-work-api.config'
+import {
+	mapMultiReleaseV2EscrowToIndexer,
+	mapSingleReleaseV2EscrowToIndexer,
+} from '~/lib/utils/escrow/map-trustless-on-chain-escrow'
 
 const INDEXER_NOT_FOUND_ERROR =
 	'Trustless Work has not indexed this contract yet. Paste the deployment transaction hash and try again.'
@@ -65,6 +69,58 @@ const fetchEscrowFromBaseUrl = async ({
 	return { ok: true, escrow }
 }
 
+const fetchEscrowOnChainFromTrustlessWork = async ({
+	baseUrl,
+	apiKey,
+	contractId,
+}: {
+	baseUrl: string
+	apiKey: string
+	contractId: string
+}): Promise<EscrowIndexerFetchResult> => {
+	const candidates = [
+		{
+			path: `escrow/single-release/v2/${contractId}`,
+			map: mapSingleReleaseV2EscrowToIndexer,
+		},
+		{
+			path: `escrow/multi-release/v2/${contractId}`,
+			map: mapMultiReleaseV2EscrowToIndexer,
+		},
+	] as const
+
+	for (const candidate of candidates) {
+		const res = await fetch(`${baseUrl}/${candidate.path}`, {
+			headers: { 'x-api-key': apiKey, Accept: 'application/json' },
+			cache: 'no-store',
+		})
+
+		if (!res.ok) {
+			continue
+		}
+
+		const payload = await res.json()
+		if (!payload || typeof payload !== 'object' || !('engagementId' in payload)) {
+			continue
+		}
+
+		try {
+			const escrow = candidate.map(payload as never)
+			if (escrow.engagementId) {
+				return { ok: true, escrow }
+			}
+		} catch (error) {
+			logger.warn('Failed to map on-chain Trustless Work escrow payload:', error)
+		}
+	}
+
+	return {
+		ok: false,
+		error:
+			'Could not read escrow state from Trustless Work. Confirm the contract ID is a deployed Trustless Work escrow on the active network.',
+	}
+}
+
 export async function getEscrowByContractIdFromIndexer(
 	contractId: string,
 	options?: { validateOnChain?: boolean },
@@ -88,15 +144,27 @@ export async function getEscrowByContractIdFromIndexer(
 			validateOnChain,
 		})
 
-		if (result.ok || !validateOnChain) {
+		if (result.ok) {
 			return result
 		}
 
-		return await fetchEscrowFromBaseUrl({
+		if (validateOnChain) {
+			const cachedResult = await fetchEscrowFromBaseUrl({
+				baseUrl,
+				apiKey,
+				contractId,
+				validateOnChain: false,
+			})
+
+			if (cachedResult.ok) {
+				return cachedResult
+			}
+		}
+
+		return await fetchEscrowOnChainFromTrustlessWork({
 			baseUrl,
 			apiKey,
 			contractId,
-			validateOnChain: false,
 		})
 	} catch (error) {
 		logger.error('Failed to fetch escrow from indexer:', error)

--- a/apps/web/lib/utils/escrow/escrow-transaction-helpers.ts
+++ b/apps/web/lib/utils/escrow/escrow-transaction-helpers.ts
@@ -99,7 +99,7 @@ export const deployAndSign = async ({
 			sendResult = await sendTransaction(signedXdr)
 		}
 	} catch (error) {
-		const msg = error instanceof Error ? error.message : 'Failed to send transaction'
+		const msg = getTrustlessWorkApiErrorMessage(error, 'Failed to send transaction')
 		toast.error('Failed to send transaction', { description: msg })
 		throw new Error(msg)
 	}

--- a/apps/web/lib/utils/escrow/map-trustless-on-chain-escrow.test.ts
+++ b/apps/web/lib/utils/escrow/map-trustless-on-chain-escrow.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test'
+import {
+	mapMultiReleaseV2EscrowToIndexer,
+	mapSingleReleaseV2EscrowToIndexer,
+} from './map-trustless-on-chain-escrow'
+
+const gAddress = (label: string) => `G${label.padEnd(55, 'A')}`
+
+describe('mapTrustlessOnChainEscrow', () => {
+	test('maps single-release v2 roles arrays to indexer shape', () => {
+		const escrow = mapSingleReleaseV2EscrowToIndexer({
+			contractId: 'CAC4IETJ35MM2C5AIYZRAIXZ5M3RJANKHVI4JLYMLXXTBJDFLGXJGAS3',
+			engagementId: 'project-1',
+			title: 'Ailani',
+			description: 'Medical support',
+			amount: 1000,
+			platformFee: 1,
+			roles: {
+				approvers: [gAddress('APPROVER')],
+				serviceProviders: [gAddress('SERVICE')],
+				disputeResolvers: [gAddress('DISPUTE')],
+				platform: gAddress('PLATFORM'),
+				releaseSigners: [gAddress('RELEASE')],
+				receiver: gAddress('RECEIVER'),
+			},
+			milestones: [],
+		})
+
+		expect(escrow.type).toBe('single-release')
+		expect(escrow.roles.approver).toBe(gAddress('APPROVER'))
+		expect(escrow.roles.receiver).toBe(gAddress('RECEIVER'))
+	})
+
+	test('maps multi-release v2 milestones with per-milestone receivers', () => {
+		const escrow = mapMultiReleaseV2EscrowToIndexer({
+			contractId: 'CAC4IETJ35MM2C5AIYZRAIXZ5M3RJANKHVI4JLYMLXXTBJDFLGXJGAS3',
+			engagementId: 'project-1',
+			title: 'Ailani',
+			description: 'Medical support',
+			platformFee: 1,
+			roles: {
+				approvers: [gAddress('APPROVER')],
+				serviceProviders: [gAddress('SERVICE')],
+				disputeResolvers: [gAddress('DISPUTE')],
+				platform: gAddress('PLATFORM'),
+				releaseSigners: [gAddress('RELEASE')],
+			},
+			milestones: [
+				{
+					description: 'Surgery',
+					amount: 500,
+					receiver: gAddress('RECEIVER'),
+				},
+			],
+		})
+
+		expect(escrow.type).toBe('multi-release')
+		expect(escrow.milestones).toEqual([
+			{
+				description: 'Surgery',
+				amount: 500,
+				receiver: gAddress('RECEIVER'),
+			},
+		])
+	})
+})

--- a/apps/web/lib/utils/escrow/map-trustless-on-chain-escrow.ts
+++ b/apps/web/lib/utils/escrow/map-trustless-on-chain-escrow.ts
@@ -1,0 +1,96 @@
+import type { GetEscrowsFromIndexerResponse } from '@trustless-work/escrow'
+
+const firstRole = (roles: string[] | undefined): string => roles?.[0] ?? ''
+
+type V2RoleBundle = {
+	approvers?: string[]
+	serviceProviders?: string[]
+	platform?: string
+	releaseSigners?: string[]
+	disputeResolvers?: string[]
+	receiver?: string
+}
+
+const mapV2Roles = (roles: V2RoleBundle) => ({
+	approver: firstRole(roles.approvers),
+	serviceProvider: firstRole(roles.serviceProviders),
+	disputeResolver: firstRole(roles.disputeResolvers),
+	platformAddress: roles.platform ?? '',
+	releaseSigner: firstRole(roles.releaseSigners),
+	...(roles.receiver ? { receiver: roles.receiver } : {}),
+})
+
+type SingleReleaseV2Escrow = {
+	type?: string
+	contractId: string
+	engagementId: string
+	title: string
+	description: string
+	amount: number
+	platformFee: number
+	roles: V2RoleBundle
+	milestones?: unknown[]
+}
+
+type MultiReleaseV2Milestone = {
+	description?: string
+	amount?: number
+	receiver?: string
+}
+
+type MultiReleaseV2Escrow = {
+	type?: string
+	contractId: string
+	engagementId: string
+	title: string
+	description: string
+	platformFee: number
+	roles: V2RoleBundle
+	milestones?: MultiReleaseV2Milestone[]
+	amount?: number
+}
+
+export const mapSingleReleaseV2EscrowToIndexer = (
+	escrow: SingleReleaseV2Escrow,
+): GetEscrowsFromIndexerResponse => {
+	return {
+		type: 'single-release',
+		contractId: escrow.contractId,
+		engagementId: escrow.engagementId,
+		title: escrow.title,
+		description: escrow.description,
+		amount: escrow.amount,
+		platformFee: escrow.platformFee,
+		roles: mapV2Roles(escrow.roles),
+		milestones: Array.isArray(escrow.milestones) ? escrow.milestones : [],
+	} as GetEscrowsFromIndexerResponse
+}
+
+export const mapMultiReleaseV2EscrowToIndexer = (
+	escrow: MultiReleaseV2Escrow,
+): GetEscrowsFromIndexerResponse => {
+	const milestones = (escrow.milestones ?? [])
+		.filter(
+			(milestone): milestone is MultiReleaseV2Milestone & { amount: number; receiver: string } =>
+				typeof milestone.amount === 'number' &&
+				milestone.amount > 0 &&
+				typeof milestone.receiver === 'string',
+		)
+		.map((milestone) => ({
+			amount: milestone.amount,
+			receiver: milestone.receiver,
+			description: milestone.description ?? '',
+		}))
+
+	return {
+		type: 'multi-release',
+		contractId: escrow.contractId,
+		engagementId: escrow.engagementId,
+		title: escrow.title,
+		description: escrow.description,
+		amount: escrow.amount ?? milestones.reduce((sum, milestone) => sum + milestone.amount, 0),
+		platformFee: escrow.platformFee,
+		roles: mapV2Roles(escrow.roles),
+		milestones,
+	} as GetEscrowsFromIndexerResponse
+}

--- a/apps/web/lib/utils/escrow/trustless-work-api-error.ts
+++ b/apps/web/lib/utils/escrow/trustless-work-api-error.ts
@@ -1,3 +1,8 @@
+import {
+	getWalletSessionErrorMessage,
+	isStaleWalletSessionError,
+	WALLET_SESSION_EXPIRED_MESSAGE,
+} from '~/lib/utils/wallet/wallet-session-error'
 import { getTxBadAuthMessage } from './trustless-transaction-signing'
 
 type TrustlessWorkErrorBody = {
@@ -45,12 +50,13 @@ const formatTrustlessWorkErrorBody = (body: TrustlessWorkErrorBody | null): stri
 
 /** Extract a user-facing message from Trustless Work SDK / proxy errors. */
 export const getTrustlessWorkApiErrorMessage = (error: unknown, fallback: string): string => {
-	if (
-		error instanceof Error &&
-		error.message.trim().length > 0 &&
-		!error.message.startsWith('Request failed with status code')
-	) {
-		return error.message
+	if (error instanceof Error && error.message.trim().length > 0) {
+		if (isStaleWalletSessionError(error)) {
+			return WALLET_SESSION_EXPIRED_MESSAGE
+		}
+		if (!error.message.startsWith('Request failed with status code')) {
+			return error.message
+		}
 	}
 
 	if (!isRecord(error)) return fallback
@@ -67,7 +73,7 @@ export const getTrustlessWorkApiErrorMessage = (error: unknown, fallback: string
 			return 'Escrow data is out of sync with the blockchain. Refresh the page and try again. If it persists, contact support.'
 		}
 		if (axiosData.toLowerCase().includes('connection key is missing')) {
-			return 'Wallet session expired. Disconnect and reconnect your Stellar wallet (Freighter), then try again.'
+			return WALLET_SESSION_EXPIRED_MESSAGE
 		}
 		return axiosData
 	}
@@ -76,7 +82,7 @@ export const getTrustlessWorkApiErrorMessage = (error: unknown, fallback: string
 	if (directData) return directData
 
 	if (error instanceof Error && error.message.trim().length > 0) {
-		return error.message
+		return getWalletSessionErrorMessage(error) ?? error.message
 	}
 
 	return fallback

--- a/apps/web/lib/utils/wallet/wallet-session-error.ts
+++ b/apps/web/lib/utils/wallet/wallet-session-error.ts
@@ -1,0 +1,34 @@
+export const WALLET_SESSION_EXPIRED_MESSAGE =
+	'Wallet session expired. Disconnect and reconnect your Stellar wallet (Freighter), then try again.'
+
+const readErrorMessage = (error: unknown): string | undefined => {
+	if (typeof error === 'string' && error.trim().length > 0) {
+		return error
+	}
+
+	if (error instanceof Error && error.message.trim().length > 0) {
+		return error.message
+	}
+
+	if (typeof error === 'object' && error !== null && 'message' in error) {
+		const message = (error as { message?: unknown }).message
+		if (typeof message === 'string' && message.trim().length > 0) {
+			return message
+		}
+	}
+
+	return undefined
+}
+
+export const isStaleWalletSessionError = (error: unknown): boolean => {
+	const message = readErrorMessage(error)?.toLowerCase() ?? ''
+	return message.includes('connection key is missing')
+}
+
+export const getWalletSessionErrorMessage = (error: unknown): string | undefined => {
+	if (isStaleWalletSessionError(error)) {
+		return WALLET_SESSION_EXPIRED_MESSAGE
+	}
+
+	return readErrorMessage(error)
+}


### PR DESCRIPTION
## Summary
- Recover from stale Stellar Wallet Kit sessions (`connection key is missing`) by prompting reconnect and retrying the sign flow
- Keep Pollar onboarding users on the custodial signer path instead of falling through to an external wallet when the Pollar session is not ready
- Add Trustless Work v2 on-chain escrow reads as a fallback when the indexer has not indexed a deployed contract yet
- Improve escrow deploy/create error toasts and wallet-session messaging

## Context
- Ailani campaign escrow uses **$1,000 initial-release milestones** toward an **$80k** goal (80 milestones × $1k)
- Prior PR #1010 (indexer sync recovery) is already on `main`; this PR adds the remaining deploy/signing hardening work

## Test plan
- [ ] Deploy escrow with Pollar wallet on mainnet (session ready)
- [ ] Deploy escrow with Freighter after letting the extension session expire; confirm reconnect prompt works
- [ ] Sync an existing contract ID when TW indexer returns empty (on-chain v2 fallback)
- [ ] Verify Ailani manage settings shows linked escrow `CAC4IETJ35MM2C5AIYZRAIXZ5M3RJANKHVI4JLYMLXXTBJDFLGXJGAS3`

## Note
`develop` was rebased onto `main` locally (diverged history). This branch is `main` + one commit. After merge, run `git checkout develop && git reset --hard origin/main` (or force-push develop) to realign.

Made with [Cursor](https://cursor.com)