### PR TITLE
fix(web): sync Trustless Work indexer before escrow donations

### DIFF
--- a/apps/web/app/actions/escrow/persist-escrow-contract.ts
+++ b/apps/web/app/actions/escrow/persist-escrow-contract.ts
@@ -3,6 +3,7 @@ import type { EscrowType } from '@trustless-work/escrow'
 import { revalidatePath } from 'next/cache'
 import { Logger } from '~/lib/logger'
 import type { EscrowApiVersion } from '~/lib/utils/escrow/resolve-escrow-api-version'
+import { readDeployTxHashFromMetadata } from '~/lib/utils/escrow/resolve-escrow-api-version'
 import { inferEscrowTypeFromSaveData } from '~/lib/utils/escrow/resolve-escrow-type'
 import type { SaveEscrowContractParams } from './save-escrow-contract.types'
 
@@ -52,6 +53,7 @@ export async function persistEscrowContract({
 	escrowData,
 	escrowType,
 	escrowApiVersion,
+	deployTxHash,
 }: {
 	userId: string
 	projectId: string
@@ -59,6 +61,7 @@ export async function persistEscrowContract({
 	escrowData: SaveEscrowContractParams['escrowData']
 	escrowType?: EscrowType
 	escrowApiVersion?: EscrowApiVersion
+	deployTxHash?: string
 }): Promise<{ success: boolean; error?: string }> {
 	const supabase = supabaseServiceRole
 	const engagementId = escrowData.engagementId
@@ -127,6 +130,20 @@ export async function persistEscrowContract({
 		contributionId = newContribution.id
 	}
 
+	const { data: existingEscrowRow } = await supabase
+		.from('escrow_contracts')
+		.select('metadata')
+		.eq('contract_id', contractId)
+		.maybeSingle()
+
+	const existingMetadata =
+		existingEscrowRow?.metadata && typeof existingEscrowRow.metadata === 'object'
+			? (existingEscrowRow.metadata as Record<string, unknown>)
+			: {}
+
+	const resolvedDeployTxHash =
+		deployTxHash?.trim().replace(/^0x/i, '') || readDeployTxHashFromMetadata(existingMetadata)
+
 	const { data: upsertedEscrow, error: escrowUpsertError } = await supabase
 		.from('escrow_contracts')
 		.upsert(
@@ -141,8 +158,10 @@ export async function persistEscrowContract({
 				platform_fee: platformFee,
 				current_state: 'NEW',
 				metadata: {
+					...existingMetadata,
 					escrow_type: resolvedEscrowType,
 					escrow_api_version: escrowApiVersion ?? 'v1',
+					...(resolvedDeployTxHash ? { deploy_tx_hash: resolvedDeployTxHash } : {}),
 				},
 				updated_at: new Date().toISOString(),
 			},

--- a/apps/web/app/actions/escrow/save-escrow-contract.ts
+++ b/apps/web/app/actions/escrow/save-escrow-contract.ts
@@ -58,6 +58,7 @@ export async function saveEscrowContractAction(
 			projectId: validated.projectId,
 			contractId: validated.contractId,
 			escrowData: validated.escrowData,
+			deployTxHash: validated.deployTxHash,
 		})
 	} catch (error) {
 		logger.error({

--- a/apps/web/app/actions/escrow/save-escrow-contract.types.ts
+++ b/apps/web/app/actions/escrow/save-escrow-contract.types.ts
@@ -22,4 +22,5 @@ export interface SaveEscrowContractParams {
 		receiver?: string
 		receiverMemo?: number
 	}
+	deployTxHash?: string
 }

--- a/apps/web/app/actions/escrow/sync-escrow-to-database.ts
+++ b/apps/web/app/actions/escrow/sync-escrow-to-database.ts
@@ -161,6 +161,7 @@ export async function syncEscrowToDatabaseAction(
 			escrowData,
 			escrowType,
 			escrowApiVersion,
+			deployTxHash: validated.txHash,
 		})
 
 		if (!saveResult.success) {

--- a/apps/web/app/api/escrow/prepare-fund/route.ts
+++ b/apps/web/app/api/escrow/prepare-fund/route.ts
@@ -1,0 +1,101 @@
+import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import type { EscrowType, FundEscrowPayload } from '@trustless-work/escrow'
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { z } from 'zod'
+import { nextAuthOption } from '~/lib/auth/auth-options'
+import { RateLimiter } from '~/lib/auth/rate-limiter'
+import { ensureEscrowIndexedForContract } from '~/lib/services/escrow-indexer.service'
+import { fundEscrowViaTrustlessWorkServer } from '~/lib/services/trustless-fund-escrow.server'
+import {
+	type EscrowApiVersion,
+	readDeployTxHashFromMetadata,
+} from '~/lib/utils/escrow/resolve-escrow-api-version'
+
+const fundLimiter = new RateLimiter({
+	maxAttempts: 30,
+	windowSecs: 60,
+	blockSecs: 300,
+	configId: 'escrow-prepare-fund',
+})
+
+const prepareFundSchema = z.object({
+	payload: z.object({
+		contractId: z.string().min(1),
+		signer: z.string().min(1),
+		amount: z.number().positive(),
+	}),
+	escrowType: z.enum(['single-release', 'multi-release']),
+	contractApiVersion: z.enum(['v1', 'v2']).optional(),
+})
+
+const getClientIp = (request: Request): string =>
+	request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'anonymous'
+
+export async function POST(request: Request) {
+	const session = await getServerSession(nextAuthOption)
+	if (!session?.user?.id) {
+		return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+	}
+
+	const rateLimit = await fundLimiter.increment(getClientIp(request), 'escrow-prepare-fund')
+	if (rateLimit.isBlocked) {
+		return NextResponse.json(
+			{ error: 'Too many requests. Please try again later.' },
+			{ status: 429, headers: { 'Retry-After': '300' } },
+		)
+	}
+
+	let body: unknown
+	try {
+		body = await request.json()
+	} catch {
+		return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+	}
+
+	const parsed = prepareFundSchema.safeParse(body)
+	if (!parsed.success) {
+		return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+	}
+
+	const { payload, escrowType, contractApiVersion = 'v1' } = parsed.data
+	const contractId = payload.contractId.trim()
+
+	const { data: escrowRow } = await supabaseServiceRole
+		.from('escrow_contracts')
+		.select('metadata')
+		.eq('contract_id', contractId)
+		.maybeSingle()
+
+	const deployTxHash = readDeployTxHashFromMetadata(escrowRow?.metadata)
+
+	const indexed = await ensureEscrowIndexedForContract(contractId, deployTxHash)
+	if (!indexed.ok) {
+		return NextResponse.json(
+			{
+				error:
+					'This escrow is not registered with Trustless Work yet. A platform admin must sync the deploy transaction hash from project settings.',
+				detail: indexed.error,
+			},
+			{ status: 404 },
+		)
+	}
+
+	const fundResult = await fundEscrowViaTrustlessWorkServer(
+		payload as FundEscrowPayload,
+		escrowType as EscrowType,
+		contractApiVersion as EscrowApiVersion,
+	)
+
+	if (fundResult.status !== 'SUCCESS' || !fundResult.unsignedTransaction) {
+		const message = fundResult.error ?? 'Fund escrow request failed'
+		const status = message.toLowerCase().includes('escrow not found') ? 404 : 400
+
+		return NextResponse.json({ error: message }, { status })
+	}
+
+	return NextResponse.json({
+		status: 'SUCCESS',
+		unsignedTransaction: fundResult.unsignedTransaction,
+	})
+}

--- a/apps/web/lib/schemas/server-actions.schemas.ts
+++ b/apps/web/lib/schemas/server-actions.schemas.ts
@@ -112,6 +112,10 @@ export const saveEscrowContractInputSchema = z.object({
 	contractId: z.string().min(1, 'contractId is required').max(120, 'contractId is too long'),
 	engagementId: z.string().min(1).optional(),
 	escrowData: escrowDataSchema,
+	deployTxHash: z
+		.string()
+		.regex(/^[A-Fa-f0-9]{64}$/, 'Invalid transaction hash')
+		.optional(),
 })
 
 const stellarContractIdSchema = z

--- a/apps/web/lib/services/escrow-indexer.service.ts
+++ b/apps/web/lib/services/escrow-indexer.service.ts
@@ -198,6 +198,30 @@ const parseIndexerUpdatePayload = (payload: unknown): GetEscrowsFromIndexerRespo
 	return parseIndexerPayload(nested)
 }
 
+export async function ensureEscrowIndexedForContract(
+	contractId: string,
+	deployTxHash?: string,
+): Promise<EscrowIndexerFetchResult> {
+	const indexed = await getEscrowByContractIdFromIndexer(contractId, { validateOnChain: false })
+	if (indexed.ok) {
+		return indexed
+	}
+
+	if (!deployTxHash) {
+		return {
+			ok: false,
+			error: INDEXER_NOT_FOUND_ERROR,
+		}
+	}
+
+	const refreshed = await updateIndexerFromTxHash(deployTxHash)
+	if (refreshed.ok) {
+		return refreshed
+	}
+
+	return await getEscrowByContractIdFromIndexer(contractId, { validateOnChain: false })
+}
+
 export async function updateIndexerFromTxHash(txHash: string): Promise<EscrowIndexerFetchResult> {
 	const apiKey = getTrustlessWorkApiKey()
 	const baseUrl = getTrustlessWorkApiBaseUrl()

--- a/apps/web/lib/services/trustless-fund-escrow.client.ts
+++ b/apps/web/lib/services/trustless-fund-escrow.client.ts
@@ -1,17 +1,5 @@
 import type { EscrowType, FundEscrowPayload } from '@trustless-work/escrow'
-import {
-	getTrustlessWorkClientBaseUrl,
-	getTrustlessWorkNetwork,
-} from '~/lib/config/trustless-work.config'
-import {
-	normalizeTrustlessUnsignedXdr,
-	type UnsignedEscrowPayload,
-} from '~/lib/utils/escrow/normalize-trustless-unsigned-xdr'
-import {
-	buildFundEscrowApiPath,
-	type EscrowApiVersion,
-	resolveFundEscrowApiVersion,
-} from '~/lib/utils/escrow/resolve-escrow-api-version'
+import type { EscrowApiVersion } from '~/lib/utils/escrow/resolve-escrow-api-version'
 
 export type TrustlessFundEscrowResult = {
 	status: 'SUCCESS' | 'ERROR'
@@ -19,84 +7,46 @@ export type TrustlessFundEscrowResult = {
 	error?: string
 }
 
-const isNotFoundResponse = (status: number, body: unknown): boolean => {
-	if (status === 404) return true
-
-	if (!body || typeof body !== 'object') return false
-
-	const record = body as { statusCode?: number; message?: string }
-	return record.statusCode === 404 || record.message === 'Resource not found'
-}
-
-const requestFundEscrowPath = async (
-	path: string,
-	payload: FundEscrowPayload,
-): Promise<
-	{ ok: true; unsignedTransaction: string } | { ok: false; status: number; error: string }
-> => {
-	const response = await fetch(`${getTrustlessWorkClientBaseUrl()}/${path}`, {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-			Accept: 'application/json',
-		},
-		body: JSON.stringify(payload),
-	})
-
-	const body = (await response.json().catch(() => null)) as
-		| UnsignedEscrowPayload
-		| { message?: string; detail?: string; error?: string; statusCode?: number }
-		| null
-
-	if (!response.ok) {
-		const message =
-			(body && 'detail' in body && typeof body.detail === 'string' && body.detail) ||
-			(body && 'message' in body && typeof body.message === 'string' && body.message) ||
-			(body && 'error' in body && typeof body.error === 'string' && body.error) ||
-			`Fund escrow request failed (${response.status})`
-
-		return { ok: false, status: response.status, error: message }
-	}
-
-	const unsignedTransaction = normalizeTrustlessUnsignedXdr(
-		body && ('unsignedXdr' in body || 'unsignedTransaction' in body) ? body : {},
-	)
-	if (!unsignedTransaction) {
-		return { ok: false, status: response.status, error: 'No unsigned transaction returned' }
-	}
-
-	return { ok: true, unsignedTransaction }
-}
-
 export const fundEscrowViaTrustlessProxy = async (
 	payload: FundEscrowPayload,
 	escrowType: EscrowType,
 	contractApiVersion: EscrowApiVersion,
 ): Promise<TrustlessFundEscrowResult> => {
-	const network = getTrustlessWorkNetwork()
-	const primaryApiVersion = resolveFundEscrowApiVersion(network, contractApiVersion)
+	const response = await fetch('/api/escrow/prepare-fund', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Accept: 'application/json',
+		},
+		body: JSON.stringify({
+			payload,
+			escrowType,
+			contractApiVersion,
+		}),
+	})
 
-	const pathsToTry = [buildFundEscrowApiPath(escrowType, primaryApiVersion)]
+	const body = (await response.json().catch(() => null)) as {
+		status?: string
+		unsignedTransaction?: string
+		error?: string
+		detail?: string
+	} | null
 
-	if (primaryApiVersion === 'v2') {
-		pathsToTry.push(buildFundEscrowApiPath(escrowType, 'v1'))
+	if (!response.ok) {
+		const message =
+			(body && typeof body.detail === 'string' && body.detail) ||
+			(body && typeof body.error === 'string' && body.error) ||
+			`Fund escrow request failed (${response.status})`
+
+		return { status: 'ERROR', error: message }
 	}
 
-	let lastError = 'Fund escrow request failed'
+	const unsignedTransaction =
+		body && typeof body.unsignedTransaction === 'string' ? body.unsignedTransaction : undefined
 
-	for (const path of pathsToTry) {
-		const result = await requestFundEscrowPath(path, payload)
-
-		if (result.ok) {
-			return { status: 'SUCCESS', unsignedTransaction: result.unsignedTransaction }
-		}
-
-		lastError = result.error
-
-		if (!isNotFoundResponse(result.status, result.error)) {
-			return { status: 'ERROR', error: result.error }
-		}
+	if (!unsignedTransaction) {
+		return { status: 'ERROR', error: 'No unsigned transaction returned' }
 	}
 
-	return { status: 'ERROR', error: lastError }
+	return { status: 'SUCCESS', unsignedTransaction }
 }

--- a/apps/web/lib/services/trustless-fund-escrow.server.ts
+++ b/apps/web/lib/services/trustless-fund-escrow.server.ts
@@ -1,0 +1,105 @@
+import type { EscrowType, FundEscrowPayload } from '@trustless-work/escrow'
+import {
+	getTrustlessWorkApiKey,
+	getTrustlessWorkNetwork,
+	getTrustlessWorkUpstreamApiBaseUrl,
+} from '~/lib/config/trustless-work.config'
+import type { TrustlessFundEscrowResult } from '~/lib/services/trustless-fund-escrow.client'
+import {
+	normalizeTrustlessUnsignedXdr,
+	type UnsignedEscrowPayload,
+} from '~/lib/utils/escrow/normalize-trustless-unsigned-xdr'
+import {
+	buildFundEscrowApiPath,
+	type EscrowApiVersion,
+	resolveFundEscrowApiVersion,
+} from '~/lib/utils/escrow/resolve-escrow-api-version'
+
+const isNotFoundResponse = (status: number, message: string): boolean => {
+	if (status === 404) return true
+
+	const normalized = message.toLowerCase()
+	return normalized.includes('resource not found') || normalized.includes('escrow not found')
+}
+
+const requestFundEscrowPath = async (
+	path: string,
+	payload: FundEscrowPayload,
+	apiKey: string,
+): Promise<
+	{ ok: true; unsignedTransaction: string } | { ok: false; status: number; error: string }
+> => {
+	const upstreamBase = getTrustlessWorkUpstreamApiBaseUrl(path.replace(/^\//, ''))
+	const response = await fetch(`${upstreamBase}${path}`, {
+		method: 'POST',
+		headers: {
+			'x-api-key': apiKey,
+			'Content-Type': 'application/json',
+			Accept: 'application/json',
+		},
+		body: JSON.stringify(payload),
+		cache: 'no-store',
+	})
+
+	const body = (await response.json().catch(() => null)) as
+		| UnsignedEscrowPayload
+		| { message?: string; detail?: string; error?: string; statusCode?: number }
+		| null
+
+	if (!response.ok) {
+		const message =
+			(body && 'detail' in body && typeof body.detail === 'string' && body.detail) ||
+			(body && 'message' in body && typeof body.message === 'string' && body.message) ||
+			(body && 'error' in body && typeof body.error === 'string' && body.error) ||
+			`Fund escrow request failed (${response.status})`
+
+		return { ok: false, status: response.status, error: message }
+	}
+
+	const unsignedTransaction = normalizeTrustlessUnsignedXdr(
+		body && ('unsignedXdr' in body || 'unsignedTransaction' in body) ? body : {},
+	)
+	if (!unsignedTransaction) {
+		return { ok: false, status: response.status, error: 'No unsigned transaction returned' }
+	}
+
+	return { ok: true, unsignedTransaction }
+}
+
+export const fundEscrowViaTrustlessWorkServer = async (
+	payload: FundEscrowPayload,
+	escrowType: EscrowType,
+	contractApiVersion: EscrowApiVersion,
+): Promise<TrustlessFundEscrowResult> => {
+	const apiKey = getTrustlessWorkApiKey()
+	if (!apiKey) {
+		return { status: 'ERROR', error: 'Trustless Work API key is not configured on the server' }
+	}
+
+	const network = getTrustlessWorkNetwork()
+	const primaryApiVersion = resolveFundEscrowApiVersion(network, contractApiVersion)
+
+	const pathsToTry = [buildFundEscrowApiPath(escrowType, primaryApiVersion)]
+
+	if (primaryApiVersion === 'v2') {
+		pathsToTry.push(buildFundEscrowApiPath(escrowType, 'v1'))
+	}
+
+	let lastError = 'Fund escrow request failed'
+
+	for (const path of pathsToTry) {
+		const result = await requestFundEscrowPath(path, payload, apiKey)
+
+		if (result.ok) {
+			return { status: 'SUCCESS', unsignedTransaction: result.unsignedTransaction }
+		}
+
+		lastError = result.error
+
+		if (!isNotFoundResponse(result.status, result.error)) {
+			return { status: 'ERROR', error: result.error }
+		}
+	}
+
+	return { status: 'ERROR', error: lastError }
+}

--- a/apps/web/lib/utils/escrow/escrow-transaction-helpers.ts
+++ b/apps/web/lib/utils/escrow/escrow-transaction-helpers.ts
@@ -182,6 +182,7 @@ export const extractContractData = (
 export const saveAndRedirect = async ({
 	contractId,
 	escrowData,
+	deployTxHash,
 	formData,
 	effectiveEngagementId,
 	projectId,
@@ -190,6 +191,7 @@ export const saveAndRedirect = async ({
 }: {
 	contractId: string | undefined
 	escrowData: ExtractedContractData['escrowData']
+	deployTxHash?: string
 	formData: EscrowFormData
 	effectiveEngagementId: string
 	projectId: string
@@ -258,6 +260,7 @@ export const saveAndRedirect = async ({
 		contractId,
 		engagementId: effectiveEngagementId,
 		escrowData: serializableEscrowData,
+		deployTxHash,
 	})
 
 	if (!saveResult.success) {
@@ -349,9 +352,15 @@ export const handleSingleRelease = async ({
 	})
 
 	const { contractId, escrowData } = extractContractData(responseAny)
+	const deployTxHash =
+		typeof responseAny.txHash === 'string' && responseAny.txHash.trim().length > 0
+			? responseAny.txHash.trim()
+			: undefined
+
 	await saveAndRedirect({
 		contractId,
 		escrowData,
+		deployTxHash,
 		formData,
 		effectiveEngagementId,
 		projectId,
@@ -436,9 +445,15 @@ export const handleMultiRelease = async ({
 	})
 
 	const { contractId, escrowData } = extractContractData(responseAny)
+	const deployTxHash =
+		typeof responseAny.txHash === 'string' && responseAny.txHash.trim().length > 0
+			? responseAny.txHash.trim()
+			: undefined
+
 	await saveAndRedirect({
 		contractId,
 		escrowData,
+		deployTxHash,
 		formData,
 		effectiveEngagementId,
 		projectId,

--- a/apps/web/lib/utils/escrow/resolve-escrow-api-version.ts
+++ b/apps/web/lib/utils/escrow/resolve-escrow-api-version.ts
@@ -3,6 +3,16 @@ import type { TrustlessWorkNetwork } from '~/lib/config/trustless-work.config'
 
 export type EscrowApiVersion = 'v1' | 'v2'
 
+export const readDeployTxHashFromMetadata = (metadata: unknown): string | undefined => {
+	if (!metadata || typeof metadata !== 'object') return undefined
+
+	const hash = (metadata as { deploy_tx_hash?: unknown }).deploy_tx_hash
+	if (typeof hash !== 'string') return undefined
+
+	const trimmed = hash.trim().replace(/^0x/i, '')
+	return trimmed.length > 0 ? trimmed : undefined
+}
+
 export const readEscrowApiVersionFromMetadata = (
 	metadata: unknown,
 ): EscrowApiVersion | undefined => {


### PR DESCRIPTION
## Summary

- Fixes mainnet donation failures where `fund-escrow` returns **400 Escrow not found** because Trustless Work has not indexed the deployed contract yet.
- Adds `POST /api/escrow/prepare-fund` to refresh the TW indexer from stored `deploy_tx_hash` metadata, then build the fund transaction server-side.
- Persists `deploy_tx_hash` when escrows are deployed or synced (including manual sync with tx hash).
- Donations now call `/api/escrow/prepare-fund` instead of hitting the TW proxy directly.

## Context

After #1013 routed mainnet funding to v1 `fund-escrow`, the Ailani campaign hit **Escrow not found** — the v2 factory contract exists on-chain but was missing from TW's Firebase indexer. Deploy tx hash for that escrow is already stored in production metadata.

## Test plan

- [ ] Merge and deploy to production.
- [ ] Retry donation on [Ailani campaign](https://www.kindfi.org/projects/un-corazon-por-ailani-ayudemos-a-salvar-su-vida).
- [ ] Confirm network tab shows `POST /api/escrow/prepare-fund` returning an unsigned transaction.
- [ ] Deploy a new escrow and verify `deploy_tx_hash` is saved in `escrow_contracts.metadata`.
- [ ] For an unindexed escrow, confirm manual sync with deploy tx hash in project manage still works.


Made with [Cursor](https://cursor.com)