### PR TITLE
fix: block donations for completed campaigns

### DIFF
--- a/apps/web/app/api/contributions/create/route.ts
+++ b/apps/web/app/api/contributions/create/route.ts
@@ -8,11 +8,11 @@ import { canAccessDevelopmentOnlyProject } from '~/lib/queries/projects/developm
 import { createContributionSchema } from '~/lib/schemas/contribution.schemas'
 import {
 	checkDuplicateContribution,
-	checkFundraisingGoalNotReached,
 	createContributionWithProjectUpdate,
 	resolveProjectId,
 	sendContributionNotifications,
 	triggerGamificationUpdates,
+	validateContributionAllowed,
 } from '~/lib/services/contribution-service'
 import { validateRequest } from '~/lib/utils/validation'
 
@@ -66,16 +66,16 @@ async function createContributionHandler(req: NextRequest) {
 			return NextResponse.json({ error: 'Project not found' }, { status: 404 })
 		}
 
-		const [goalCheck, duplicateCheck] = await Promise.all([
-			checkFundraisingGoalNotReached(finalProjectId, contractId),
+		const [contributionCheck, duplicateCheck] = await Promise.all([
+			validateContributionAllowed(finalProjectId, contractId),
 			checkDuplicateContribution({
 				transactionHash,
 				projectId: finalProjectId,
 				contributorId: session.user.id,
 			}),
 		])
-		if (!goalCheck.allowed) {
-			return NextResponse.json({ error: goalCheck.error }, { status: 403 })
+		if (!contributionCheck.allowed) {
+			return NextResponse.json({ error: contributionCheck.error }, { status: 403 })
 		}
 
 		if (duplicateCheck.duplicate) {

--- a/apps/web/app/api/contributions/sync/route.ts
+++ b/apps/web/app/api/contributions/sync/route.ts
@@ -7,8 +7,8 @@ import { nextAuthOption } from '~/lib/auth/auth-options'
 import { requireOnboardingCompleteForAction } from '~/lib/onboarding/guard'
 import { syncContributionSchema } from '~/lib/schemas/contribution.schemas'
 import {
-	checkFundraisingGoalNotReached,
 	createContributionWithProjectUpdate,
+	validateContributionAllowed,
 } from '~/lib/services/contribution-service'
 import { validateRequest } from '~/lib/utils/validation'
 
@@ -70,8 +70,8 @@ export async function POST(req: NextRequest) {
 			return NextResponse.json({ error: 'Project ID is required' }, { status: 400 })
 		}
 
-		const [goalCheck, { data: existingContribution }] = await Promise.all([
-			checkFundraisingGoalNotReached(projectId, contractId),
+		const [contributionCheck, { data: existingContribution }] = await Promise.all([
+			validateContributionAllowed(projectId, contractId),
 			supabase
 				.from('contributions')
 				.select('id')
@@ -80,8 +80,8 @@ export async function POST(req: NextRequest) {
 				.eq('amount', Number(amount))
 				.single(),
 		])
-		if (!goalCheck.allowed) {
-			return NextResponse.json({ error: goalCheck.error }, { status: 403 })
+		if (!contributionCheck.allowed) {
+			return NextResponse.json({ error: contributionCheck.error }, { status: 403 })
 		}
 
 		if (existingContribution) {

--- a/apps/web/components/sections/projects/detail/project-sidebar/components/donation-form.tsx
+++ b/apps/web/components/sections/projects/detail/project-sidebar/components/donation-form.tsx
@@ -14,12 +14,15 @@ import {
 } from '~/components/base/form'
 import { Input } from '~/components/base/input'
 import { TrustlessExternalWalletBanner } from '~/components/sections/projects/manage/escrow/components/trustless-external-wallet-banner'
+import { CAMPAIGN_COMPLETE_DONATION_MESSAGE } from '~/lib/projects/project-status'
 import type { ProjectDetail } from '~/lib/types/project/project-detail.types'
 import type { FormValues } from '../types'
 
 interface DonationFormProps {
 	project: ProjectDetail
 	hasEscrow: boolean
+	isCampaignComplete: boolean
+	isAcceptingDonations: boolean
 	isGoalReached: boolean
 	isDonationReady: boolean
 	isEscrowDataLoading: boolean
@@ -32,6 +35,8 @@ interface DonationFormProps {
 export function DonationForm({
 	project,
 	hasEscrow,
+	isCampaignComplete,
+	isAcceptingDonations,
 	isGoalReached,
 	isDonationReady,
 	isEscrowDataLoading,
@@ -40,10 +45,12 @@ export function DonationForm({
 	form,
 	onSubmit,
 }: DonationFormProps) {
-	const canDonate = isDonationReady && !isGoalReached && isAuthenticated
+	const canDonate =
+		isDonationReady && isAcceptingDonations && !isGoalReached && isAuthenticated
+
 	return (
 		<>
-			{hasEscrow && isAuthenticated && (
+			{hasEscrow && isAuthenticated && isAcceptingDonations && !isGoalReached && (
 				<div className="mb-4">
 					<TrustlessExternalWalletBanner compact />
 				</div>
@@ -66,17 +73,21 @@ export function DonationForm({
 											type="text"
 											inputMode="decimal"
 											placeholder={
-												!hasEscrow
-													? 'Donations coming soon'
-													: !isAuthenticated
-														? 'Sign in to donate'
-														: isEscrowDataLoading
-															? 'Loading escrow…'
-															: isGoalReached
-																? 'Funding goal reached'
-																: !isDonationReady
-																	? 'Preparing donations…'
-																	: `Min. $${project.minInvestment}…`
+												isCampaignComplete
+													? 'Campaign complete'
+													: !hasEscrow
+														? 'Donations coming soon'
+														: !isAuthenticated
+															? 'Sign in to donate'
+															: isEscrowDataLoading
+																? 'Loading escrow…'
+																: isGoalReached
+																	? 'Funding goal reached'
+																	: !isDonationReady
+																		? 'Preparing donations…'
+																		: !isAcceptingDonations
+																			? 'Donations unavailable'
+																			: `Min. $${project.minInvestment}…`
 											}
 											className="pl-6 disabled:opacity-60 disabled:cursor-not-allowed"
 											aria-label="Donation amount in USD"
@@ -128,7 +139,7 @@ export function DonationForm({
 							className="mt-4 w-full text-white gradient-btn"
 							size="lg"
 							asChild
-							disabled={!hasEscrow || isGoalReached}
+							disabled={!hasEscrow || isGoalReached || !isAcceptingDonations}
 						>
 							<Link href={signInHref}>Sign in to donate</Link>
 						</Button>
@@ -141,6 +152,8 @@ export function DonationForm({
 
 interface DonationNoticesProps {
 	hasEscrow: boolean
+	isCampaignComplete: boolean
+	isAcceptingDonations: boolean
 	isGoalReached: boolean
 	isAuthenticated: boolean
 	signInHref: string
@@ -148,13 +161,22 @@ interface DonationNoticesProps {
 
 export function DonationNotices({
 	hasEscrow,
+	isCampaignComplete,
+	isAcceptingDonations,
 	isGoalReached,
 	isAuthenticated,
 	signInHref,
 }: DonationNoticesProps) {
 	return (
 		<>
-			{hasEscrow && isGoalReached && (
+			{isCampaignComplete && (
+				<div className="p-3 my-4 text-sm text-blue-900 bg-blue-50 rounded-md border border-blue-200">
+					<p className="font-medium mb-1">Campaign complete</p>
+					<p className="text-blue-800">{CAMPAIGN_COMPLETE_DONATION_MESSAGE}</p>
+				</div>
+			)}
+
+			{hasEscrow && isGoalReached && !isCampaignComplete && (
 				<div className="p-3 my-4 text-sm text-green-900 bg-green-50 rounded-md border border-green-300">
 					<p className="font-medium mb-1">Funding goal reached</p>
 					<p className="text-green-800">
@@ -163,7 +185,7 @@ export function DonationNotices({
 				</div>
 			)}
 
-			{hasEscrow && !isGoalReached && !isAuthenticated && (
+			{hasEscrow && isAcceptingDonations && !isGoalReached && !isAuthenticated && (
 				<div className="p-3 my-4 text-sm text-blue-900 bg-blue-50 rounded-md border border-blue-200">
 					<p className="font-medium mb-1">Sign in to donate</p>
 					<p className="text-blue-800">

--- a/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar-escrow-state.ts
+++ b/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar-escrow-state.ts
@@ -4,6 +4,11 @@ import { useEscrow } from '~/hooks/contexts/use-escrow.context'
 import { useEscrowBalance } from '~/hooks/escrow/use-escrow-balance'
 import { useEscrowData } from '~/hooks/escrow/use-escrow-data'
 import type { ProjectDetail } from '~/lib/types/project/project-detail.types'
+import {
+	isProjectAcceptingDonations,
+	isProjectCampaignComplete,
+	type ProjectStatus,
+} from '~/lib/projects/project-status'
 import { resolveEscrowType } from '~/lib/utils/escrow/resolve-escrow-type'
 import {
 	calculateReleasedAmountFromEscrow,
@@ -23,6 +28,9 @@ export function useProjectSidebarEscrowState(project: ProjectDetail) {
 	})
 
 	const hasEscrow = Boolean(project.escrowContractAddress)
+	const projectStatus = (project.status ?? 'draft') as ProjectStatus
+	const isCampaignComplete = isProjectCampaignComplete(projectStatus)
+	const isAcceptingDonations = isProjectAcceptingDonations(projectStatus)
 
 	const effectiveEscrowType = resolveEscrowType({
 		indexerEscrow: escrowData,
@@ -99,6 +107,8 @@ export function useProjectSidebarEscrowState(project: ProjectDetail) {
 	return {
 		escrowData,
 		hasEscrow,
+		isCampaignComplete,
+		isAcceptingDonations,
 		effectiveEscrowType,
 		isDonationReady,
 		isEscrowDataLoading,

--- a/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar-form-submit.tsx
+++ b/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar-form-submit.tsx
@@ -11,6 +11,13 @@ import { useTrustlessSigner } from '~/hooks/escrow/use-trustless-signer'
 import { useAuth } from '~/hooks/use-auth'
 import { zodResolver } from '~/lib/form/zod-resolver'
 import { trackOnboardingPath } from '~/lib/pollar/analytics'
+import {
+	CAMPAIGN_COMPLETE_DONATION_MESSAGE,
+	isProjectAcceptingDonations,
+	isProjectCampaignComplete,
+	PROJECT_NOT_ACCEPTING_DONATIONS_MESSAGE,
+	type ProjectStatus,
+} from '~/lib/projects/project-status'
 import type { ProjectDetail } from '~/lib/types/project/project-detail.types'
 import { submitTrustlessEscrowXdr } from '~/lib/utils/escrow/trustless-submit'
 import { buildFormSchema, type FormValues } from '../types'
@@ -67,6 +74,18 @@ export function useProjectSidebarFormSubmit({
 			toast.error('Funding goal reached', {
 				description:
 					'This project has met its fundraising goal and is no longer accepting donations.',
+				icon: <CircleAlert className="text-destructive" />,
+			})
+			return
+		}
+
+		const projectStatus = (project.status ?? 'draft') as ProjectStatus
+		if (!isProjectAcceptingDonations(projectStatus)) {
+			const isComplete = isProjectCampaignComplete(projectStatus)
+			toast.error(isComplete ? 'Campaign complete' : 'Donations unavailable', {
+				description: isComplete
+					? CAMPAIGN_COMPLETE_DONATION_MESSAGE
+					: PROJECT_NOT_ACCEPTING_DONATIONS_MESSAGE,
 				icon: <CircleAlert className="text-destructive" />,
 			})
 			return

--- a/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar.tsx
+++ b/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar.tsx
@@ -23,6 +23,8 @@ export function useProjectSidebar(project: ProjectDetail, projectSlug: string) {
 	const {
 		escrowData,
 		hasEscrow,
+		isCampaignComplete,
+		isAcceptingDonations,
 		isDonationReady,
 		isEscrowDataLoading,
 		onChainRaised,
@@ -126,6 +128,8 @@ export function useProjectSidebar(project: ProjectDetail, projectSlug: string) {
 	return {
 		form,
 		hasEscrow,
+		isCampaignComplete,
+		isAcceptingDonations,
 		isGoalReached,
 		isDonationReady,
 		isEscrowDataLoading,

--- a/apps/web/components/sections/projects/detail/project-sidebar/project-sidebar.tsx
+++ b/apps/web/components/sections/projects/detail/project-sidebar/project-sidebar.tsx
@@ -3,6 +3,7 @@
 import { motion, useReducedMotion } from 'framer-motion'
 import { Badge } from '~/components/base/badge'
 import { ReleasedProgressBar } from '~/components/sections/projects/shared'
+import { CAMPAIGN_COMPLETE_DONATION_MESSAGE } from '~/lib/projects/project-status'
 import type { ProjectDetail } from '~/lib/types/project/project-detail.types'
 import { DonationForm, DonationNotices } from './components/donation-form'
 import { EscrowContractInfo } from './components/escrow-contract-info'
@@ -23,6 +24,8 @@ export function ProjectSidebar({ project, projectSlug }: ProjectSidebarProps) {
 	const {
 		form,
 		hasEscrow,
+		isCampaignComplete,
+		isAcceptingDonations,
 		isGoalReached,
 		isDonationReady,
 		isEscrowDataLoading,
@@ -55,7 +58,15 @@ export function ProjectSidebar({ project, projectSlug }: ProjectSidebarProps) {
 			<div className="p-6">
 				<div className="flex items-center gap-2 mb-2">
 					<h2 className="text-xl font-bold">Support This Project</h2>
-					{hasEscrow && isGoalReached ? (
+					{isCampaignComplete ? (
+						<Badge
+							variant="secondary"
+							className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 border-0"
+							aria-label="This campaign is complete"
+						>
+							Campaign complete
+						</Badge>
+					) : hasEscrow && isGoalReached ? (
 						<Badge
 							variant="secondary"
 							className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 border-0"
@@ -63,7 +74,7 @@ export function ProjectSidebar({ project, projectSlug }: ProjectSidebarProps) {
 						>
 							Goal reached
 						</Badge>
-					) : hasEscrow ? (
+					) : hasEscrow && isAcceptingDonations ? (
 						<Badge
 							variant="secondary"
 							className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 border-0"
@@ -82,11 +93,13 @@ export function ProjectSidebar({ project, projectSlug }: ProjectSidebarProps) {
 					)}
 				</div>
 				<p className="mb-4 text-muted-foreground">
-					{!hasEscrow
-						? 'This project is still setting up secure escrow. Donations will be available soon.'
-						: isGoalReached
-							? 'This project has reached its fundraising goal. Thank you for your support!'
-							: 'Your contribution matters. Join the change.'}
+					{isCampaignComplete
+						? CAMPAIGN_COMPLETE_DONATION_MESSAGE
+						: !hasEscrow
+							? 'This project is still setting up secure escrow. Donations will be available soon.'
+							: isGoalReached
+								? 'This project has reached its fundraising goal. Thank you for your support!'
+								: 'Your contribution matters. Join the change.'}
 				</p>
 
 				<ProjectProgressBar
@@ -105,6 +118,8 @@ export function ProjectSidebar({ project, projectSlug }: ProjectSidebarProps) {
 				<DonationForm
 					project={project}
 					hasEscrow={hasEscrow}
+					isCampaignComplete={isCampaignComplete}
+					isAcceptingDonations={isAcceptingDonations}
 					isGoalReached={isGoalReached}
 					isDonationReady={isDonationReady}
 					isEscrowDataLoading={isEscrowDataLoading}
@@ -116,14 +131,16 @@ export function ProjectSidebar({ project, projectSlug }: ProjectSidebarProps) {
 
 				<DonationNotices
 					hasEscrow={hasEscrow}
+					isCampaignComplete={isCampaignComplete}
+					isAcceptingDonations={isAcceptingDonations}
 					isGoalReached={isGoalReached}
 					isAuthenticated={isAuthenticated}
 					signInHref={signInHref}
 				/>
 
-				{project.escrowContractAddress && (
+				{isAcceptingDonations && !isGoalReached && project.escrowContractAddress ? (
 					<EscrowContractInfo escrowContractAddress={project.escrowContractAddress} />
-				)}
+				) : null}
 
 				<SidebarActions
 					isFollowing={isFollowing}

--- a/apps/web/lib/mock-data/project/projects.mock.ts
+++ b/apps/web/lib/mock-data/project/projects.mock.ts
@@ -20,6 +20,7 @@ export const projects: Project[] = [
 			{ id: 'tag-future', name: 'FUTURE', color: '#2C3E50' },
 		],
 		createdAt: '2024-01-03T09:15:00Z',
+		status: 'active',
 	},
 	{
 		id: '2',
@@ -39,6 +40,7 @@ export const projects: Project[] = [
 			{ id: 'tag-sustainable', name: 'SUSTAINABLE', color: '#1ABC9C' },
 		],
 		createdAt: '2024-01-17T14:40:00Z',
+		status: 'active',
 	},
 	{
 		id: '3',
@@ -58,6 +60,7 @@ export const projects: Project[] = [
 			{ id: 'tag-impact', name: 'IMPACT', color: '#9B59B6' },
 		],
 		createdAt: '2024-01-29T11:05:00Z',
+		status: 'active',
 	},
 	{
 		id: '4',
@@ -77,6 +80,7 @@ export const projects: Project[] = [
 			{ id: 'tag-art', name: 'ART', color: '#D35400' },
 		],
 		createdAt: '2024-02-06T08:50:00Z',
+		status: 'active',
 	},
 	{
 		id: '5',
@@ -96,6 +100,7 @@ export const projects: Project[] = [
 			{ id: 'tag-community', name: 'COMMUNITY', color: '#FFCA28' },
 		],
 		createdAt: '2024-02-14T10:00:00Z',
+		status: 'active',
 	},
 	{
 		id: '6',
@@ -115,6 +120,7 @@ export const projects: Project[] = [
 			{ id: 'tag-community', name: 'COMMUNITY', color: '#FFCA28' },
 		],
 		createdAt: '2024-08-21T16:00:00Z',
+		status: 'active',
 	},
 	{
 		id: '7',
@@ -134,6 +140,7 @@ export const projects: Project[] = [
 			{ id: 'tag-urban', name: 'URBAN', color: '#7F8C8D' },
 		],
 		createdAt: '2024-02-27T16:30:00Z',
+		status: 'active',
 	},
 	{
 		id: '8',
@@ -153,6 +160,7 @@ export const projects: Project[] = [
 			{ id: 'tag-humanitarian', name: 'HUMANITARIAN', color: '#FF6F61' },
 		],
 		createdAt: '2024-03-05T13:20:00Z',
+		status: 'active',
 	},
 	{
 		id: '9',
@@ -172,6 +180,7 @@ export const projects: Project[] = [
 			{ id: 'tag-ngo', name: 'NGO', color: '#2980B9' },
 		],
 		createdAt: '2024-03-18T15:10:00Z',
+		status: 'active',
 	},
 	{
 		id: '10',
@@ -191,6 +200,7 @@ export const projects: Project[] = [
 			{ id: 'tag-sustainability', name: 'SUSTAINABILITY', color: '#2ECC71' },
 		],
 		createdAt: '2024-03-30T17:45:00Z',
+		status: 'active',
 	},
 	{
 		id: '11',
@@ -210,6 +220,7 @@ export const projects: Project[] = [
 			{ id: 'tag-care', name: 'CARE', color: '#F5B041' },
 		],
 		createdAt: '2024-04-08T09:25:00Z',
+		status: 'active',
 	},
 	{
 		id: '12',
@@ -229,6 +240,7 @@ export const projects: Project[] = [
 			{ id: 'tag-information', name: 'INFORMATION', color: '#9B59B6' },
 		],
 		createdAt: '2024-04-19T14:50:00Z',
+		status: 'active',
 	},
 	{
 		id: '13',
@@ -248,6 +260,7 @@ export const projects: Project[] = [
 			{ id: 'tag-community', name: 'COMMUNITY', color: '#FFCA28' },
 		],
 		createdAt: '2024-04-28T12:10:00Z',
+		status: 'active',
 	},
 	{
 		id: '14',
@@ -267,6 +280,7 @@ export const projects: Project[] = [
 			{ id: 'tag-support', name: 'SUPPORT', color: '#D35400' },
 		],
 		createdAt: '2024-05-06T11:35:00Z',
+		status: 'active',
 	},
 	{
 		id: '15',
@@ -286,6 +300,7 @@ export const projects: Project[] = [
 			{ id: 'tag-plastic', name: 'PLASTIC', color: '#34495E' },
 		],
 		createdAt: '2024-05-15T10:15:00Z',
+		status: 'active',
 	},
 	{
 		id: '16',
@@ -305,6 +320,7 @@ export const projects: Project[] = [
 			{ id: 'tag-inclusion', name: 'INCLUSION', color: '#FF9800' },
 		],
 		createdAt: '2024-06-02T07:40:00Z',
+		status: 'active',
 	},
 	{
 		id: '17',
@@ -324,6 +340,7 @@ export const projects: Project[] = [
 			{ id: 'tag-children', name: 'CHILDREN', color: '#F39C12' },
 		],
 		createdAt: '2024-06-18T13:55:00Z',
+		status: 'active',
 	},
 	{
 		id: '18',
@@ -343,6 +360,7 @@ export const projects: Project[] = [
 			{ id: 'tag-community', name: 'COMMUNITY', color: '#FFCA28' },
 		],
 		createdAt: '2024-07-01T08:20:00Z',
+		status: 'active',
 	},
 	{
 		id: '19',
@@ -362,6 +380,7 @@ export const projects: Project[] = [
 			{ id: 'tag-youth', name: 'YOUTH', color: '#03A9F4' },
 		],
 		createdAt: '2024-07-19T14:30:00Z',
+		status: 'active',
 	},
 	{
 		id: '20',
@@ -381,5 +400,6 @@ export const projects: Project[] = [
 			{ id: 'tag-community', name: 'COMMUNITY', color: '#FFCA28' },
 		],
 		createdAt: '2024-08-03T09:45:00Z',
+		status: 'active',
 	},
 ]

--- a/apps/web/lib/projects/project-status.ts
+++ b/apps/web/lib/projects/project-status.ts
@@ -2,6 +2,20 @@ import type { Enums } from '@services/supabase'
 
 export type ProjectStatus = Enums<'project_status'>
 
+export const CAMPAIGN_COMPLETE_DONATION_MESSAGE =
+	'This campaign is complete and is no longer accepting donations.'
+
+export const PROJECT_NOT_ACCEPTING_DONATIONS_MESSAGE =
+	'This campaign is not currently accepting donations.'
+
+export function isProjectAcceptingDonations(status: ProjectStatus): boolean {
+	return status === 'active'
+}
+
+export function isProjectCampaignComplete(status: ProjectStatus): boolean {
+	return status === 'funded'
+}
+
 export const PROJECT_STATUS_LABELS: Record<ProjectStatus, string> = {
 	draft: 'Draft',
 	review: 'Ready for review',

--- a/apps/web/lib/services/contribution-service.ts
+++ b/apps/web/lib/services/contribution-service.ts
@@ -16,6 +16,7 @@ export {
 } from './contribution-side-effects.service'
 export type {
 	CheckDuplicateContributionResult,
+	ContributionAllowedResult,
 	FundraisingGoalCheckResult,
 	ResolveProjectIdInput,
 	ResolveProjectIdResult,
@@ -24,4 +25,5 @@ export {
 	checkDuplicateContribution,
 	checkFundraisingGoalNotReached,
 	resolveProjectId,
+	validateContributionAllowed,
 } from './contribution-validation.service'

--- a/apps/web/lib/services/contribution-validation.service.ts
+++ b/apps/web/lib/services/contribution-validation.service.ts
@@ -1,5 +1,12 @@
 import { supabase } from '@packages/lib/supabase'
 import { logger } from '@/lib/logger'
+import {
+	CAMPAIGN_COMPLETE_DONATION_MESSAGE,
+	isProjectAcceptingDonations,
+	isProjectCampaignComplete,
+	PROJECT_NOT_ACCEPTING_DONATIONS_MESSAGE,
+	type ProjectStatus,
+} from '~/lib/projects/project-status'
 import { getEscrowBalance } from '~/lib/services/escrow-balance.service'
 import { resolveDisplayRaisedAmount } from '~/lib/utils/projects/project-funding'
 
@@ -16,23 +23,48 @@ export type CheckDuplicateContributionResult =
 	| { duplicate: true; contributionId: string }
 	| { duplicate: false }
 
-export type FundraisingGoalCheckResult = { allowed: true } | { allowed: false; error: string }
+export type ContributionAllowedResult = { allowed: true } | { allowed: false; error: string }
 
-export async function checkFundraisingGoalNotReached(
+export type FundraisingGoalCheckResult = ContributionAllowedResult
+
+export type FundEscrowProxyValidationResult =
+	| { ok: true }
+	| { ok: false; error: string; status: 400 | 403 | 500 }
+
+const GOAL_REACHED_ERROR =
+	'This project has reached its fundraising goal and is no longer accepting donations.'
+
+const getStatusRejectionMessage = (status: ProjectStatus): string => {
+	if (isProjectCampaignComplete(status)) {
+		return CAMPAIGN_COMPLETE_DONATION_MESSAGE
+	}
+
+	return PROJECT_NOT_ACCEPTING_DONATIONS_MESSAGE
+}
+
+export async function validateContributionAllowed(
 	projectId: string,
 	contractId?: string,
-): Promise<FundraisingGoalCheckResult> {
+): Promise<ContributionAllowedResult> {
 	const { data: project, error: projectError } = await supabase
 		.from('projects')
-		.select('target_amount, current_amount')
+		.select('status, target_amount, current_amount')
 		.eq('id', projectId)
 		.single()
 
 	if (projectError || !project) {
-		logger.error('Failed to load project for fundraising goal check:', projectError)
+		logger.error('Failed to load project for contribution validation:', projectError)
 		return {
 			allowed: false,
 			error: 'Failed to verify project fundraising status',
+		}
+	}
+
+	const status = (project.status ?? 'draft') as ProjectStatus
+	if (!isProjectAcceptingDonations(status)) {
+		return {
+			allowed: false,
+			error: getStatusRejectionMessage(status),
 		}
 	}
 
@@ -66,11 +98,60 @@ export async function checkFundraisingGoalNotReached(
 	if (effectiveRaised >= targetAmount) {
 		return {
 			allowed: false,
-			error: 'This project has reached its fundraising goal and is no longer accepting donations.',
+			error: GOAL_REACHED_ERROR,
 		}
 	}
 
 	return { allowed: true }
+}
+
+export function isFundEscrowProxyPath(path: string, method: string): boolean {
+	return method === 'POST' && path.startsWith('escrow/') && path.endsWith('/fund-escrow')
+}
+
+export function readContractIdFromFundEscrowBody(body: string | undefined): string | null {
+	if (!body) return null
+
+	try {
+		const parsed = JSON.parse(body) as { contractId?: unknown }
+		return typeof parsed.contractId === 'string' && parsed.contractId.trim().length > 0
+			? parsed.contractId.trim()
+			: null
+	} catch {
+		return null
+	}
+}
+
+export async function validateFundEscrowProxyRequest(
+	body: string | undefined,
+): Promise<FundEscrowProxyValidationResult> {
+	const contractId = readContractIdFromFundEscrowBody(body)
+	if (!contractId) {
+		return { ok: false, error: 'contractId is required', status: 400 }
+	}
+
+	const projectResolution = await resolveProjectId({ contractId })
+	if (!projectResolution.success) {
+		return { ok: false, error: projectResolution.error, status: projectResolution.status }
+	}
+
+	if (!projectResolution.projectId) {
+		return { ok: false, error: 'Project not found for escrow contract', status: 400 }
+	}
+
+	const validation = await validateContributionAllowed(projectResolution.projectId, contractId)
+	if (!validation.allowed) {
+		return { ok: false, error: validation.error, status: 403 }
+	}
+
+	return { ok: true }
+}
+
+export async function checkFundraisingGoalNotReached(
+	projectId: string,
+	contractId?: string,
+): Promise<FundraisingGoalCheckResult> {
+	return validateContributionAllowed(projectId, contractId)
 }
 
 export async function resolveProjectId(

--- a/apps/web/lib/services/trustless-work-proxy.service.ts
+++ b/apps/web/lib/services/trustless-work-proxy.service.ts
@@ -12,6 +12,10 @@ import {
 	isPublicTrustlessWorkRead,
 } from '~/lib/config/trustless-work-proxy.paths'
 import {
+	isFundEscrowProxyPath,
+	validateFundEscrowProxyRequest,
+} from '~/lib/services/contribution-validation.service'
+import {
 	submitTrustlessSignedTransaction,
 	TrustlessStellarSubmitError,
 } from '~/lib/services/submit-trustless-signed-transaction.service'
@@ -206,6 +210,16 @@ export async function proxyTrustlessWorkRequest(
 
 	if (path === 'helper/send-transaction' && method === 'POST') {
 		return handleSendTransaction(headers, body)
+	}
+
+	if (isFundEscrowProxyPath(path, method)) {
+		const fundEscrowValidation = await validateFundEscrowProxyRequest(body)
+		if (!fundEscrowValidation.ok) {
+			return NextResponse.json(
+				{ error: fundEscrowValidation.error },
+				{ status: fundEscrowValidation.status },
+			)
+		}
 	}
 
 	try {

--- a/apps/web/lib/types/project/index.ts
+++ b/apps/web/lib/types/project/index.ts
@@ -1,5 +1,6 @@
 import type { Tables } from '@services/supabase'
 import type { ReactNode } from 'react'
+import type { ProjectStatus } from '~/lib/projects/project-status'
 
 export interface Tag {
 	id: string
@@ -14,6 +15,7 @@ export interface Project {
 	description: string | null
 	image: string | null
 	createdAt: string | null
+	status: ProjectStatus
 	category: Tables<'categories'> | null
 	goal: number
 	raised: number

--- a/apps/web/test/contribution-validation.test.ts
+++ b/apps/web/test/contribution-validation.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import {
+	CAMPAIGN_COMPLETE_DONATION_MESSAGE,
+	PROJECT_NOT_ACCEPTING_DONATIONS_MESSAGE,
+} from '~/lib/projects/project-status'
+
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111'
+const CONTRACT_ID = 'CEScrow12345678901234567890123456789012'
+
+type ProjectRow = {
+	status: string
+	target_amount: number
+	current_amount: number
+}
+
+let projectRow: ProjectRow | null = {
+	status: 'active',
+	target_amount: 1000,
+	current_amount: 250,
+}
+
+const mockGetEscrowBalance = mock(async () => 250 as number | null)
+
+mock.module('@/lib/logger', () => ({
+	logger: { warn: () => {}, error: () => {}, info: () => {} },
+}))
+
+mock.module('~/lib/services/escrow-balance.service', () => ({
+	getEscrowBalance: mockGetEscrowBalance,
+}))
+
+mock.module('@packages/lib/supabase', () => ({
+	supabase: {
+		from: (table: string) => ({
+			select: () => ({
+				eq: () => ({
+					single: async () => {
+						if (table === 'projects') {
+							if (!projectRow) {
+								return { data: null, error: { message: 'not found' } }
+							}
+
+							return { data: projectRow, error: null }
+						}
+
+						return { data: null, error: null }
+					},
+					maybeSingle: async () => {
+						if (table === 'escrow_contracts') {
+							return { data: { project_id: PROJECT_ID, contract_id: CONTRACT_ID }, error: null }
+						}
+
+						return { data: null, error: null }
+					},
+				}),
+			}),
+		}),
+	},
+}))
+
+describe('validateContributionAllowed', () => {
+	beforeEach(() => {
+		projectRow = {
+			status: 'active',
+			target_amount: 1000,
+			current_amount: 250,
+		}
+		mockGetEscrowBalance.mockImplementation(async () => 250)
+	})
+
+	test('allows active campaigns under fundraising goal', async () => {
+		const { validateContributionAllowed } = await import(
+			'~/lib/services/contribution-validation.service'
+		)
+
+		const result = await validateContributionAllowed(PROJECT_ID, CONTRACT_ID)
+
+		expect(result).toEqual({ allowed: true })
+	})
+
+	test('rejects completed campaigns with campaign complete message', async () => {
+		projectRow = {
+			status: 'funded',
+			target_amount: 1000,
+			current_amount: 250,
+		}
+
+		const { validateContributionAllowed } = await import(
+			'~/lib/services/contribution-validation.service'
+		)
+
+		const result = await validateContributionAllowed(PROJECT_ID, CONTRACT_ID)
+
+		expect(result).toEqual({
+			allowed: false,
+			error: CAMPAIGN_COMPLETE_DONATION_MESSAGE,
+		})
+	})
+
+	test('rejects paused campaigns with generic not accepting message', async () => {
+		projectRow = {
+			status: 'paused',
+			target_amount: 1000,
+			current_amount: 250,
+		}
+
+		const { validateContributionAllowed } = await import(
+			'~/lib/services/contribution-validation.service'
+		)
+
+		const result = await validateContributionAllowed(PROJECT_ID, CONTRACT_ID)
+
+		expect(result).toEqual({
+			allowed: false,
+			error: PROJECT_NOT_ACCEPTING_DONATIONS_MESSAGE,
+		})
+	})
+
+	test('rejects active campaigns that reached fundraising goal', async () => {
+		projectRow = {
+			status: 'active',
+			target_amount: 1000,
+			current_amount: 900,
+		}
+		mockGetEscrowBalance.mockImplementation(async () => 1000)
+
+		const { validateContributionAllowed } = await import(
+			'~/lib/services/contribution-validation.service'
+		)
+
+		const result = await validateContributionAllowed(PROJECT_ID, CONTRACT_ID)
+
+		expect(result.allowed).toBe(false)
+		if (!result.allowed) {
+			expect(result.error).toContain('fundraising goal')
+		}
+	})
+})
+
+describe('checkFundraisingGoalNotReached', () => {
+	test('delegates to validateContributionAllowed', async () => {
+		projectRow = {
+			status: 'funded',
+			target_amount: 1000,
+			current_amount: 250,
+		}
+
+		const { checkFundraisingGoalNotReached } = await import(
+			'~/lib/services/contribution-validation.service'
+		)
+
+		const result = await checkFundraisingGoalNotReached(PROJECT_ID, CONTRACT_ID)
+
+		expect(result).toEqual({
+			allowed: false,
+			error: CAMPAIGN_COMPLETE_DONATION_MESSAGE,
+		})
+	})
+})
+
+describe('fund escrow proxy helpers', () => {
+	beforeEach(() => {
+		projectRow = {
+			status: 'active',
+			target_amount: 1000,
+			current_amount: 250,
+		}
+	})
+
+	test('isFundEscrowProxyPath matches escrow fund routes only', async () => {
+		const { isFundEscrowProxyPath } = await import('~/lib/services/contribution-validation.service')
+
+		expect(isFundEscrowProxyPath('escrow/single-release/fund-escrow', 'POST')).toBe(true)
+		expect(isFundEscrowProxyPath('escrow/multi-release/fund-escrow', 'POST')).toBe(true)
+		expect(isFundEscrowProxyPath('escrow/single-release/fund-escrow', 'GET')).toBe(false)
+		expect(isFundEscrowProxyPath('helper/send-transaction', 'POST')).toBe(false)
+	})
+
+	test('readContractIdFromFundEscrowBody extracts contractId', async () => {
+		const { readContractIdFromFundEscrowBody } = await import(
+			'~/lib/services/contribution-validation.service'
+		)
+
+		expect(
+			readContractIdFromFundEscrowBody(
+				JSON.stringify({ contractId: CONTRACT_ID, amount: 25, signer: 'GABC123' }),
+			),
+		).toBe(CONTRACT_ID)
+		expect(readContractIdFromFundEscrowBody('{}')).toBeNull()
+	})
+
+	test('validateFundEscrowProxyRequest rejects completed campaigns', async () => {
+		projectRow = {
+			status: 'funded',
+			target_amount: 1000,
+			current_amount: 250,
+		}
+
+		const { validateFundEscrowProxyRequest } = await import(
+			'~/lib/services/contribution-validation.service'
+		)
+
+		const result = await validateFundEscrowProxyRequest(
+			JSON.stringify({ contractId: CONTRACT_ID, amount: 25 }),
+		)
+
+		expect(result).toEqual({
+			ok: false,
+			error: CAMPAIGN_COMPLETE_DONATION_MESSAGE,
+			status: 403,
+		})
+	})
+})

--- a/apps/web/test/project-donation-status.test.ts
+++ b/apps/web/test/project-donation-status.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test'
+import {
+	isProjectAcceptingDonations,
+	isProjectCampaignComplete,
+	type ProjectStatus,
+} from '~/lib/projects/project-status'
+
+const ALL_STATUSES: ProjectStatus[] = [
+	'draft',
+	'review',
+	'active',
+	'paused',
+	'funded',
+	'rejected',
+]
+
+describe('isProjectAcceptingDonations', () => {
+	test('returns true only for active campaigns', () => {
+		expect(isProjectAcceptingDonations('active')).toBe(true)
+	})
+
+	test('returns false for non-active campaign statuses', () => {
+		for (const status of ALL_STATUSES) {
+			if (status === 'active') continue
+			expect(isProjectAcceptingDonations(status)).toBe(false)
+		}
+	})
+})
+
+describe('isProjectCampaignComplete', () => {
+	test('returns true only for funded status', () => {
+		expect(isProjectCampaignComplete('funded')).toBe(true)
+	})
+
+	test('returns false for non-funded campaign statuses', () => {
+		for (const status of ALL_STATUSES) {
+			if (status === 'funded') continue
+			expect(isProjectCampaignComplete(status)).toBe(false)
+		}
+	})
+})


### PR DESCRIPTION
## Summary
- Add shared project-status guards so only `active` campaigns can accept donations, treating admin `funded` status as campaign complete.
- Reject new contributions in `/api/contributions/create` and `/api/contributions/sync`, and block Trustless Work `fund-escrow` proxy requests before unsigned transactions are returned.
- Update the public project sidebar to show a completed state, disable donation actions, and hide the escrow contract panel while preserving funding history and milestone data.

## Test plan
- [x] Mark an active campaign with escrow as complete (`funded`) and confirm the sidebar shows **Campaign complete** with no donation form, sign-in CTA, or escrow address panel.
- [x] Confirm an active campaign with ready escrow still accepts donations normally.
- [x] Call `POST /api/contributions/create` for a completed campaign and verify `403`.
- [x] Call `POST /api/contributions/sync` for a new contribution on a completed campaign and verify `403`; verify existing duplicate sync still returns success.
- [x] Open an active campaign, mark it complete from admin without refreshing, attempt to donate, and verify `fundEscrow` is rejected before signing.
- [x] Run `bun test test/project-donation-status.test.ts test/contribution-validation.test.ts`.


Closes #1002


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Donation availability now reflects campaign status, including completed and paused campaigns.
  * Completed campaigns display a completion message and badge.
  * Donation forms provide clearer status-specific messaging and disable unavailable actions.
  * Contribution requests are consistently validated before processing.

* **Bug Fixes**
  * Prevented donations to completed or non-accepting campaigns across supported contribution flows.
  * Added validation for escrow contribution requests to reject invalid submissions.

