### PR TITLE
feat(admin): redesign /admin as a production-grade operations dashboard

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -76,6 +76,11 @@ TRUSTLESS_WORK_API_KEY=your-trustless-work-api-key-here
 # See apps/web/lib/smart-account/README.md
 NEXT_PUBLIC_ENABLE_SMART_ACCOUNT_CREATION=false
 
+# Optional: Admin operations dashboard redesign — always on in development.
+# Set to true to enable the new /admin interface outside development;
+# false instantly restores the legacy admin UI.
+NEXT_PUBLIC_ADMIN_OPS_DASHBOARD=false
+
 # Optional: Pollar onboarding — social/email login with auto-provisioned G-address wallet
 # See apps/web/lib/pollar/README.md
 NEXT_PUBLIC_ENABLE_POLLAR_ONBOARDING=false

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -257,6 +257,29 @@ The app supports WebAuthn passkeys for passwordless authentication:
 - Milestone-based releases require verification
 - Dispute resolution system for conflicts
 
+### Admin Operations Dashboard
+
+`/admin` is an action-oriented operations dashboard for platform admins:
+
+- **Action center**: pending-work queues (project reviews, missing escrows,
+  milestone reviews, KYC cases, disputed escrows, new users) with direct
+  resolution actions, plus platform metrics that link to pre-filtered views.
+- **Server-side lists**: projects, escrows, and users are searched, filtered,
+  sorted, and paginated in the database via `/api/admin/*` routes guarded by
+  `requireAdminApi()`. All list state lives in the URL so views can be
+  bookmarked and shared.
+- **Feature flag**: the redesigned interface is gated by
+  `NEXT_PUBLIC_ADMIN_OPS_DASHBOARD` (always on in development). Setting it to
+  `false` in production instantly restores the legacy admin UI — the legacy
+  components are untouched.
+- **Safety**: high-impact actions (milestone review decisions, campaign
+  status changes, escrow deploy/fund/release, gamification triggers,
+  governance round creation, backfills) require an explicit confirmation
+  dialog that shows the state change and, for blockchain mutations, the
+  active Stellar network and connected signer. Consequential admin actions
+  are recorded in `public.audit_logs` (operations prefixed `admin_*`) via the
+  server-only `recordAdminAudit()` helper.
+
 ### KYC Verification
 
 Identity verification powered by [Didit](https://didit.me/), an AI-native identity verification platform:

--- a/apps/web/app/(routes)/admin/escrows/page.tsx
+++ b/apps/web/app/(routes)/admin/escrows/page.tsx
@@ -1,10 +1,42 @@
+import { isAdminOpsDashboardEnabled } from '@packages/lib/admin'
 import { prefetchSupabaseQuery } from '@packages/lib/supabase-server'
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query'
 import { AdminEscrowsList } from '~/components/sections/admin/admin-escrows-list'
+import { AdminEscrowsPage } from '~/components/sections/admin/escrows/admin-escrows-page'
+import { getAdminEscrows } from '~/lib/queries/admin/get-admin-escrows'
 import { getAllEscrows } from '~/lib/queries/admin/get-all-escrows'
+import { prefetchAdminSurface } from '~/lib/supabase/prefetch-admin-query'
+import {
+	adminEscrowsQuerySchema,
+	normalizeAdminListParams,
+	parseAdminListParams,
+} from '~/lib/validators/admin-list-params'
 
-export default async function AdminEscrowsPage() {
+export default async function AdminEscrowsRoute({
+	searchParams,
+}: {
+	searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
 	const queryClient = new QueryClient()
+
+	if (isAdminOpsDashboardEnabled()) {
+		const resolvedParams = await searchParams
+		const urlParams = new URLSearchParams()
+		for (const [key, value] of Object.entries(resolvedParams)) {
+			if (typeof value === 'string') urlParams.set(key, value)
+		}
+		const params = parseAdminListParams(adminEscrowsQuerySchema, urlParams)
+
+		await prefetchAdminSurface(queryClient, 'escrows', normalizeAdminListParams(params), (client) =>
+			getAdminEscrows(client, params),
+		)
+
+		return (
+			<HydrationBoundary state={dehydrate(queryClient)}>
+				<AdminEscrowsPage />
+			</HydrationBoundary>
+		)
+	}
 
 	await prefetchSupabaseQuery(queryClient, 'admin-escrows', (client) => getAllEscrows(client), [])
 

--- a/apps/web/app/(routes)/admin/layout.tsx
+++ b/apps/web/app/(routes)/admin/layout.tsx
@@ -1,21 +1,55 @@
+import { isAdminOpsDashboardEnabled } from '@packages/lib/admin'
 import Link from 'next/link'
 import type { ReactNode } from 'react'
 import { AdminNavigation } from '~/components/sections/admin/admin-navigation'
+import { AdminBreadcrumbs } from '~/components/sections/admin/nav/admin-breadcrumbs'
+import { AdminSidebar } from '~/components/sections/admin/nav/admin-sidebar'
 import { Web3Providers } from '~/components/shared/layout/web3-providers'
 import { requireAdmin } from '~/lib/utils/admin'
+
+function SkipLink() {
+	return (
+		<Link
+			href="#admin-main"
+			className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+		>
+			Skip to main content
+		</Link>
+	)
+}
 
 export default async function AdminLayout({ children }: { children: ReactNode }) {
 	await requireAdmin()
 
+	if (isAdminOpsDashboardEnabled()) {
+		return (
+			<Web3Providers>
+				<div className="min-h-screen bg-muted/30">
+					<SkipLink />
+					<div className="container mx-auto px-4 py-6 sm:py-8">
+						<div className="flex flex-col gap-4 lg:flex-row lg:gap-8">
+							<AdminSidebar />
+							<div className="min-w-0 flex-1 space-y-3">
+								<AdminBreadcrumbs />
+								<main
+									id="admin-main"
+									className="min-w-0 scroll-mt-8 rounded-xl border border-border/60 bg-card p-4 shadow-sm sm:p-6 lg:p-8"
+									tabIndex={-1}
+								>
+									{children}
+								</main>
+							</div>
+						</div>
+					</div>
+				</div>
+			</Web3Providers>
+		)
+	}
+
 	return (
 		<Web3Providers>
 			<div className="min-h-screen bg-muted/30">
-				<Link
-					href="#admin-main"
-					className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-				>
-					Skip to main content
-				</Link>
+				<SkipLink />
 				<div className="container mx-auto px-4 py-6 sm:py-8">
 					<div className="flex flex-col gap-6 lg:flex-row lg:gap-8">
 						<aside

--- a/apps/web/app/(routes)/admin/page.tsx
+++ b/apps/web/app/(routes)/admin/page.tsx
@@ -1,9 +1,13 @@
+import { isAdminOpsDashboardEnabled } from '@packages/lib/admin'
 import { prefetchSupabaseQuery } from '@packages/lib/supabase-server'
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query'
 import dynamic from 'next/dynamic'
 import { Suspense } from 'react'
+import { AdminActionCenter } from '~/components/sections/admin/action-center/action-center'
 import { AdminOverviewSkeleton } from '~/components/sections/admin/skeletons'
+import { getActionQueuePayload } from '~/lib/queries/admin/get-action-queue-payload'
 import { getAdminStats } from '~/lib/queries/admin/get-admin-stats'
+import { prefetchAdminSurface } from '~/lib/supabase/prefetch-admin-query'
 
 const AdminOverview = dynamic(
 	() =>
@@ -17,6 +21,18 @@ const AdminOverview = dynamic(
 
 export default async function AdminDashboardPage() {
 	const queryClient = new QueryClient()
+
+	if (isAdminOpsDashboardEnabled()) {
+		await prefetchAdminSurface(queryClient, 'action-queue', undefined, getActionQueuePayload)
+
+		return (
+			<HydrationBoundary state={dehydrate(queryClient)}>
+				<Suspense fallback={<AdminOverviewSkeleton />}>
+					<AdminActionCenter />
+				</Suspense>
+			</HydrationBoundary>
+		)
+	}
 
 	await prefetchSupabaseQuery(queryClient, 'admin-stats', (client) => getAdminStats(client), [])
 

--- a/apps/web/app/(routes)/admin/projects/page.tsx
+++ b/apps/web/app/(routes)/admin/projects/page.tsx
@@ -36,9 +36,9 @@ export default async function AdminProjectsRoute({
 			async (client) => {
 				const [result, filterOptions] = await Promise.all([
 					getAdminProjects(client, params),
-					params.page === 1 ? getAdminProjectFilterOptions(client) : Promise.resolve(null),
+					getAdminProjectFilterOptions(client),
 				])
-				return filterOptions ? { ...result, filterOptions } : result
+				return { ...result, filterOptions }
 			},
 		)
 

--- a/apps/web/app/(routes)/admin/projects/page.tsx
+++ b/apps/web/app/(routes)/admin/projects/page.tsx
@@ -1,10 +1,53 @@
+import { isAdminOpsDashboardEnabled } from '@packages/lib/admin'
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query'
 import { AdminProjectsList } from '~/components/sections/admin/admin-projects-list'
+import { AdminProjectsPage } from '~/components/sections/admin/projects/admin-projects-page'
+import {
+	getAdminProjectFilterOptions,
+	getAdminProjects,
+} from '~/lib/queries/admin/get-admin-projects'
 import { getAllProjects } from '~/lib/queries/projects/get-all-projects'
-import { prefetchAdminQuery } from '~/lib/supabase/prefetch-admin-query'
+import { prefetchAdminQuery, prefetchAdminSurface } from '~/lib/supabase/prefetch-admin-query'
+import {
+	adminProjectsQuerySchema,
+	normalizeAdminListParams,
+	parseAdminListParams,
+} from '~/lib/validators/admin-list-params'
 
-export default async function AdminProjectsPage() {
+export default async function AdminProjectsRoute({
+	searchParams,
+}: {
+	searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
 	const queryClient = new QueryClient()
+
+	if (isAdminOpsDashboardEnabled()) {
+		const resolvedParams = await searchParams
+		const urlParams = new URLSearchParams()
+		for (const [key, value] of Object.entries(resolvedParams)) {
+			if (typeof value === 'string') urlParams.set(key, value)
+		}
+		const params = parseAdminListParams(adminProjectsQuerySchema, urlParams)
+
+		await prefetchAdminSurface(
+			queryClient,
+			'projects',
+			normalizeAdminListParams(params),
+			async (client) => {
+				const [result, filterOptions] = await Promise.all([
+					getAdminProjects(client, params),
+					params.page === 1 ? getAdminProjectFilterOptions(client) : Promise.resolve(null),
+				])
+				return filterOptions ? { ...result, filterOptions } : result
+			},
+		)
+
+		return (
+			<HydrationBoundary state={dehydrate(queryClient)}>
+				<AdminProjectsPage />
+			</HydrationBoundary>
+		)
+	}
 
 	await prefetchAdminQuery(queryClient, 'admin-projects', (client) =>
 		getAllProjects(client, [], 'most-recent', 1000),

--- a/apps/web/app/(routes)/admin/users/page.tsx
+++ b/apps/web/app/(routes)/admin/users/page.tsx
@@ -1,10 +1,42 @@
+import { isAdminOpsDashboardEnabled } from '@packages/lib/admin'
 import { prefetchSupabaseQuery } from '@packages/lib/supabase-server'
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query'
 import { AdminUsersList } from '~/components/sections/admin/admin-users-list'
+import { AdminUsersPage } from '~/components/sections/admin/users/admin-users-page'
+import { getAdminUsers } from '~/lib/queries/admin/get-admin-users'
 import { getAllUsers } from '~/lib/queries/admin/get-all-users'
+import { prefetchAdminSurface } from '~/lib/supabase/prefetch-admin-query'
+import {
+	adminUsersQuerySchema,
+	normalizeAdminListParams,
+	parseAdminListParams,
+} from '~/lib/validators/admin-list-params'
 
-export default async function AdminUsersPage() {
+export default async function AdminUsersRoute({
+	searchParams,
+}: {
+	searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
 	const queryClient = new QueryClient()
+
+	if (isAdminOpsDashboardEnabled()) {
+		const resolvedParams = await searchParams
+		const urlParams = new URLSearchParams()
+		for (const [key, value] of Object.entries(resolvedParams)) {
+			if (typeof value === 'string') urlParams.set(key, value)
+		}
+		const params = parseAdminListParams(adminUsersQuerySchema, urlParams)
+
+		await prefetchAdminSurface(queryClient, 'users', normalizeAdminListParams(params), (client) =>
+			getAdminUsers(client, params),
+		)
+
+		return (
+			<HydrationBoundary state={dehydrate(queryClient)}>
+				<AdminUsersPage />
+			</HydrationBoundary>
+		)
+	}
 
 	await prefetchSupabaseQuery(queryClient, 'admin-users', (client) => getAllUsers(client), [])
 

--- a/apps/web/app/actions/admin/sync-escrow-as-admin.ts
+++ b/apps/web/app/actions/admin/sync-escrow-as-admin.ts
@@ -1,0 +1,47 @@
+'use server'
+
+import { syncEscrowToDatabaseAction } from '~/app/actions/escrow/sync-escrow-to-database'
+import { requireAdminSession, toServerActionFailure } from '~/lib/auth/server-action-auth'
+import { recordAdminAudit } from '~/lib/services/admin-audit'
+
+export interface AdminSyncEscrowResult {
+	success: boolean
+	error?: string
+	alreadySynced?: boolean
+}
+
+/**
+ * Admin-context wrapper around the existing escrow sync action: verifies
+ * platform-admin authorization independently, delegates to
+ * syncEscrowToDatabaseAction (which keeps its own auth, validation, and
+ * rate limiting), and records an audit entry for the reconciliation.
+ */
+export async function syncEscrowAsAdminAction(input: {
+	projectId: string
+	contractId: string
+}): Promise<AdminSyncEscrowResult> {
+	let adminId: string
+	try {
+		const session = await requireAdminSession('admin_sync_escrow')
+		adminId = session.user.id
+	} catch (error) {
+		return toServerActionFailure(error) as AdminSyncEscrowResult
+	}
+
+	const result = await syncEscrowToDatabaseAction(input)
+
+	void recordAdminAudit({
+		operation: 'admin_escrow_synced',
+		resourceType: 'escrow',
+		resourceId: input.contractId,
+		actorId: adminId,
+		status: result.success ? 'success' : 'failure',
+		failureReason: result.success ? null : (result.error ?? 'Sync failed'),
+		details: {
+			project_id: input.projectId,
+			already_synced: result.alreadySynced ?? false,
+		},
+	})
+
+	return result
+}

--- a/apps/web/app/actions/admin/sync-escrow-as-admin.ts
+++ b/apps/web/app/actions/admin/sync-escrow-as-admin.ts
@@ -30,7 +30,7 @@ export async function syncEscrowAsAdminAction(input: {
 
 	const result = await syncEscrowToDatabaseAction(input)
 
-	void recordAdminAudit({
+	await recordAdminAudit({
 		operation: 'admin_escrow_synced',
 		resourceType: 'escrow',
 		resourceId: input.contractId,

--- a/apps/web/app/api/admin/action-queue/route.ts
+++ b/apps/web/app/api/admin/action-queue/route.ts
@@ -1,0 +1,34 @@
+import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import { NextResponse } from 'next/server'
+import { requireAdminApi } from '~/lib/auth/require-admin-api'
+import { getActionQueuePayload } from '~/lib/queries/admin/get-action-queue-payload'
+import { getDashboardStats } from '~/lib/queries/admin/get-dashboard-stats'
+import {
+	adminActionQueueQuerySchema,
+	parseAdminListParams,
+} from '~/lib/validators/admin-list-params'
+
+/**
+ * Action-center read model: pending-work queues plus dashboard counts.
+ * `?countsOnly=true` returns just the stats (used for navigation badges).
+ * Queues and stats degrade independently so one failed metric does not
+ * break the dashboard.
+ */
+export async function GET(request: Request) {
+	const auth = await requireAdminApi()
+	if (!auth.ok) return auth.response
+
+	const { searchParams } = new URL(request.url)
+	const params = parseAdminListParams(adminActionQueueQuerySchema, searchParams)
+
+	if (params.countsOnly === 'true') {
+		const result = await getDashboardStats(supabaseServiceRole).then(
+			(stats) => ({ stats, statsError: false }),
+			() => ({ stats: null, statsError: true }),
+		)
+		return NextResponse.json(result)
+	}
+
+	const payload = await getActionQueuePayload(supabaseServiceRole)
+	return NextResponse.json(payload)
+}

--- a/apps/web/app/api/admin/action-queue/route.ts
+++ b/apps/web/app/api/admin/action-queue/route.ts
@@ -1,6 +1,8 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { requireAdminApi } from '~/lib/auth/require-admin-api'
+import { withRateLimit } from '~/lib/middleware/rate-limit'
 import { getActionQueuePayload } from '~/lib/queries/admin/get-action-queue-payload'
 import { getDashboardStats } from '~/lib/queries/admin/get-dashboard-stats'
 import {
@@ -14,7 +16,7 @@ import {
  * Queues and stats degrade independently so one failed metric does not
  * break the dashboard.
  */
-export async function GET(request: Request) {
+async function handleActionQueue(request: NextRequest): Promise<NextResponse> {
 	const auth = await requireAdminApi()
 	if (!auth.ok) return auth.response
 
@@ -32,3 +34,11 @@ export async function GET(request: Request) {
 	const payload = await getActionQueuePayload(supabaseServiceRole)
 	return NextResponse.json(payload)
 }
+
+export const GET = withRateLimit(
+	{
+		preset: 'lenient',
+		identifier: (req) => req.headers.get('x-forwarded-for') ?? 'anonymous',
+	},
+	handleActionQueue,
+)

--- a/apps/web/app/api/admin/escrows/route.ts
+++ b/apps/web/app/api/admin/escrows/route.ts
@@ -1,14 +1,16 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
 import { requireAdminApi } from '~/lib/auth/require-admin-api'
+import { withRateLimit } from '~/lib/middleware/rate-limit'
 import { getAdminEscrows } from '~/lib/queries/admin/get-admin-escrows'
 import { adminEscrowsQuerySchema, parseAdminListParams } from '~/lib/validators/admin-list-params'
 
 /**
  * Paginated admin escrow list with project association health flags.
  */
-export async function GET(request: Request) {
+async function handleEscrows(request: NextRequest): Promise<NextResponse> {
 	const auth = await requireAdminApi()
 	if (!auth.ok) return auth.response
 
@@ -23,3 +25,11 @@ export async function GET(request: Request) {
 		return NextResponse.json({ error: 'Failed to load escrows' }, { status: 500 })
 	}
 }
+
+export const GET = withRateLimit(
+	{
+		preset: 'lenient',
+		identifier: (req) => req.headers.get('x-forwarded-for') ?? 'anonymous',
+	},
+	handleEscrows,
+)

--- a/apps/web/app/api/admin/escrows/route.ts
+++ b/apps/web/app/api/admin/escrows/route.ts
@@ -1,0 +1,25 @@
+import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import { NextResponse } from 'next/server'
+import { logger } from '@/lib/logger'
+import { requireAdminApi } from '~/lib/auth/require-admin-api'
+import { getAdminEscrows } from '~/lib/queries/admin/get-admin-escrows'
+import { adminEscrowsQuerySchema, parseAdminListParams } from '~/lib/validators/admin-list-params'
+
+/**
+ * Paginated admin escrow list with project association health flags.
+ */
+export async function GET(request: Request) {
+	const auth = await requireAdminApi()
+	if (!auth.ok) return auth.response
+
+	const { searchParams } = new URL(request.url)
+	const params = parseAdminListParams(adminEscrowsQuerySchema, searchParams)
+
+	try {
+		const result = await getAdminEscrows(supabaseServiceRole, params)
+		return NextResponse.json(result)
+	} catch (error) {
+		logger.error(error)
+		return NextResponse.json({ error: 'Failed to load escrows' }, { status: 500 })
+	}
+}

--- a/apps/web/app/api/admin/gamification/backfill-quests/route.ts
+++ b/apps/web/app/api/admin/gamification/backfill-quests/route.ts
@@ -65,7 +65,7 @@ export async function POST(req: NextRequest) {
 			errors: results.flatMap((row) => row.errors),
 		}
 
-		void recordAdminAudit({
+		await recordAdminAudit({
 			operation: 'admin_quest_backfill_run',
 			resourceType: 'quest',
 			resourceId: userId ?? 'all',

--- a/apps/web/app/api/admin/gamification/backfill-quests/route.ts
+++ b/apps/web/app/api/admin/gamification/backfill-quests/route.ts
@@ -1,9 +1,9 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
-import { getServerSession } from 'next-auth'
 import { z } from 'zod'
 import { logger } from '@/lib/logger'
-import { nextAuthOption } from '~/lib/auth/auth-options'
+import { requireAdminApi } from '~/lib/auth/require-admin-api'
+import { recordAdminAudit } from '~/lib/services/admin-audit'
 import {
 	backfillDonationQuestProgressForUser,
 	listContributorIdsWithDonations,
@@ -16,12 +16,6 @@ const backfillQuestsSchema = z.object({
 	limit: z.coerce.number().int().min(1).max(500).optional().default(100),
 })
 
-async function requireAdminApiUser(userId: string): Promise<boolean> {
-	const { supabase } = await import('@packages/lib/supabase')
-	const { data: profile } = await supabase.from('profiles').select('role').eq('id', userId).single()
-	return profile?.role === 'admin'
-}
-
 /**
  * POST /api/admin/gamification/backfill-quests
  *
@@ -30,14 +24,8 @@ async function requireAdminApiUser(userId: string): Promise<boolean> {
  */
 export async function POST(req: NextRequest) {
 	try {
-		const session = await getServerSession(nextAuthOption)
-		if (!session?.user?.id) {
-			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-		}
-
-		if (!(await requireAdminApiUser(session.user.id))) {
-			return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-		}
+		const auth = await requireAdminApi()
+		if (!auth.ok) return auth.response
 
 		const body = await req.json()
 		const validation = validateRequest(backfillQuestsSchema, body)
@@ -58,7 +46,7 @@ export async function POST(req: NextRequest) {
 		const userIds = userId ? [userId] : await listContributorIdsWithDonations(supabase, limit)
 
 		logger.info('[AdminQuestBackfill] Starting', {
-			adminId: session.user.id,
+			adminId: auth.userId,
 			userCount: userIds.length,
 			mode: userId ? 'single' : 'all',
 		})
@@ -76,6 +64,22 @@ export async function POST(req: NextRequest) {
 			chainFailed: results.reduce((sum, row) => sum + row.chainFailed, 0),
 			errors: results.flatMap((row) => row.errors),
 		}
+
+		void recordAdminAudit({
+			operation: 'admin_quest_backfill_run',
+			resourceType: 'quest',
+			resourceId: userId ?? 'all',
+			actorId: auth.userId,
+			status: summary.chainFailed > 0 ? 'failure' : 'success',
+			failureReason: summary.chainFailed > 0 ? `${summary.chainFailed} chain syncs failed` : null,
+			details: {
+				mode: userId ? 'single' : 'all',
+				users_processed: summary.usersProcessed,
+				quests_updated: summary.questsUpdated,
+				chain_synced: summary.chainSynced,
+				chain_failed: summary.chainFailed,
+			},
+		})
 
 		return NextResponse.json({ success: true, summary, results })
 	} catch (error) {

--- a/apps/web/app/api/admin/gamification/trigger/route.ts
+++ b/apps/web/app/api/admin/gamification/trigger/route.ts
@@ -1,14 +1,14 @@
 import { Keypair } from '@stellar/stellar-sdk'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
-import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
-import { nextAuthOption } from '~/lib/auth/auth-options'
+import { requireAdminApi } from '~/lib/auth/require-admin-api'
 import {
 	type ClientStellarNetworkId,
 	STELLAR_MAINNET_PASSPHRASE,
 } from '~/lib/config/stellar-network.config'
 import { adminGamificationTriggerSchema } from '~/lib/schemas/admin-gamification-trigger.schemas'
+import { recordAdminAudit } from '~/lib/services/admin-audit'
 import { syncQuestProgressOnChain } from '~/lib/services/quest-chain-sync.service'
 import { GamificationContractService } from '~/lib/stellar/gamification-contracts'
 import { GovernanceContractService } from '~/lib/stellar/governance-contract'
@@ -27,12 +27,6 @@ function requireEnv(name: string, fallback?: string): string | null {
 	return process.env[name] || (fallback ? process.env[fallback] : undefined) || null
 }
 
-async function requireAdminApiUser(userId: string): Promise<boolean> {
-	const { supabase } = await import('@packages/lib/supabase')
-	const { data: profile } = await supabase.from('profiles').select('role').eq('id', userId).single()
-	return profile?.role === 'admin'
-}
-
 function buildResponse(
 	result: {
 		success: boolean
@@ -42,9 +36,21 @@ function buildResponse(
 	},
 	module: string,
 	action: string,
+	adminId: string,
 ) {
 	const network = resolveNetworkId()
 	const explorerUrl = result.txHash ? getStellarExplorerTxUrl(result.txHash, network) : undefined
+
+	void recordAdminAudit({
+		operation: 'admin_gamification_triggered',
+		resourceType: 'gamification_module',
+		resourceId: module,
+		actorId: adminId,
+		status: result.success ? 'success' : 'failure',
+		txHash: result.txHash ?? null,
+		failureReason: result.success ? null : (result.error ?? 'Contract call failed'),
+		details: { action, network },
+	})
 
 	if (!result.success) {
 		return NextResponse.json(
@@ -80,14 +86,8 @@ function buildResponse(
  */
 export async function POST(req: NextRequest) {
 	try {
-		const session = await getServerSession(nextAuthOption)
-		if (!session?.user?.id) {
-			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-		}
-
-		if (!(await requireAdminApiUser(session.user.id))) {
-			return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-		}
+		const auth = await requireAdminApi()
+		if (!auth.ok) return auth.response
 
 		if (!process.env.SOROBAN_PRIVATE_KEY) {
 			return NextResponse.json(
@@ -104,7 +104,7 @@ export async function POST(req: NextRequest) {
 
 		const input = validation.data
 		logger.info('[AdminGamificationTrigger] Invoking', {
-			adminId: session.user.id,
+			adminId: auth.userId,
 			module: input.module,
 			action: input.action,
 		})
@@ -125,7 +125,7 @@ export async function POST(req: NextRequest) {
 					period: input.period,
 					donationTimestamp: input.donationTimestamp ?? Math.floor(Date.now() / 1000),
 				})
-				return buildResponse(result, input.module, input.action)
+				return buildResponse(result, input.module, input.action, auth.userId)
 			}
 
 			case 'referral': {
@@ -161,20 +161,20 @@ export async function POST(req: NextRequest) {
 						referrerAddress,
 						referredAddress: input.referredAddress,
 					})
-					return buildResponse(result, input.module, input.action)
+					return buildResponse(result, input.module, input.action, auth.userId)
 				}
 
 				if (input.action === 'mark_onboarded') {
 					const result = await contractService.markOnboarded(address, {
 						referredAddress: input.referredAddress,
 					})
-					return buildResponse(result, input.module, input.action)
+					return buildResponse(result, input.module, input.action, auth.userId)
 				}
 
 				const result = await contractService.recordReferralDonation(address, {
 					referredAddress: input.referredAddress,
 				})
-				return buildResponse(result, input.module, input.action)
+				return buildResponse(result, input.module, input.action, auth.userId)
 			}
 
 			case 'quest': {
@@ -210,7 +210,7 @@ export async function POST(req: NextRequest) {
 							progressValue: input.progressValue,
 						})
 
-				return buildResponse(result, input.module, input.action)
+				return buildResponse(result, input.module, input.action, auth.userId)
 			}
 
 			case 'nft': {
@@ -242,7 +242,7 @@ export async function POST(req: NextRequest) {
 						toAddress: input.toAddress,
 						metadata,
 					})
-					return buildResponse(result, input.module, input.action)
+					return buildResponse(result, input.module, input.action, auth.userId)
 				}
 
 				if (input.tokenId == null) {
@@ -255,7 +255,7 @@ export async function POST(req: NextRequest) {
 					tokenId: input.tokenId,
 					metadata,
 				})
-				return buildResponse(result, input.module, input.action)
+				return buildResponse(result, input.module, input.action, auth.userId)
 			}
 
 			case 'reputation': {
@@ -274,7 +274,7 @@ export async function POST(req: NextRequest) {
 					eventType: input.eventType,
 					points: input.points,
 				})
-				return buildResponse(result, input.module, input.action)
+				return buildResponse(result, input.module, input.action, auth.userId)
 			}
 
 			case 'governance': {
@@ -292,7 +292,7 @@ export async function POST(req: NextRequest) {
 					voteType: input.voteType,
 					tier: input.tier,
 				})
-				return buildResponse(result, input.module, input.action)
+				return buildResponse(result, input.module, input.action, auth.userId)
 			}
 
 			default: {

--- a/apps/web/app/api/admin/gamification/trigger/route.ts
+++ b/apps/web/app/api/admin/gamification/trigger/route.ts
@@ -27,7 +27,7 @@ function requireEnv(name: string, fallback?: string): string | null {
 	return process.env[name] || (fallback ? process.env[fallback] : undefined) || null
 }
 
-function buildResponse(
+async function buildResponse(
 	result: {
 		success: boolean
 		txHash?: string
@@ -41,7 +41,7 @@ function buildResponse(
 	const network = resolveNetworkId()
 	const explorerUrl = result.txHash ? getStellarExplorerTxUrl(result.txHash, network) : undefined
 
-	void recordAdminAudit({
+	await recordAdminAudit({
 		operation: 'admin_gamification_triggered',
 		resourceType: 'gamification_module',
 		resourceId: module,

--- a/apps/web/app/api/admin/milestone-reviews/[id]/route.ts
+++ b/apps/web/app/api/admin/milestone-reviews/[id]/route.ts
@@ -5,6 +5,7 @@ import { logger } from '@/lib/logger'
 import { nextAuthOption } from '~/lib/auth/auth-options'
 import { mapMilestoneReviewRequestRow } from '~/lib/queries/milestone-reviews/map-milestone-review-request'
 import { isPlatformAdmin } from '~/lib/queries/projects/development-only-access'
+import { recordAdminAudit } from '~/lib/services/admin-audit'
 import { notifyOwnersOfMilestoneReviewDecision } from '~/lib/services/milestone-review-notification.service'
 import { updateMilestoneReviewRequestSchema } from '~/lib/validators/milestone-review-request'
 
@@ -91,6 +92,24 @@ export async function PATCH(request: Request, context: { params: Promise<{ id: s
 			logger.error(updateError)
 			return NextResponse.json({ error: 'Failed to update review request' }, { status: 500 })
 		}
+
+		void recordAdminAudit({
+			operation:
+				status === 'approved'
+					? 'admin_milestone_review_approved'
+					: 'admin_milestone_review_rejected',
+			resourceType: 'milestone',
+			resourceId: id,
+			actorId: adminId,
+			status: 'success',
+			previousState: 'pending',
+			newState: status,
+			details: {
+				project_id: existing.project_id,
+				escrow_contract_id: existing.escrow_contract_id,
+				milestone_index: existing.milestone_index,
+			},
+		})
 
 		const projectRelation = existing.project as
 			| { title: string; slug: string; kindler_id: string }

--- a/apps/web/app/api/admin/milestone-reviews/[id]/route.ts
+++ b/apps/web/app/api/admin/milestone-reviews/[id]/route.ts
@@ -93,7 +93,7 @@ export async function PATCH(request: Request, context: { params: Promise<{ id: s
 			return NextResponse.json({ error: 'Failed to update review request' }, { status: 500 })
 		}
 
-		void recordAdminAudit({
+		await recordAdminAudit({
 			operation:
 				status === 'approved'
 					? 'admin_milestone_review_approved'

--- a/apps/web/app/api/admin/projects/route.ts
+++ b/apps/web/app/api/admin/projects/route.ts
@@ -1,18 +1,47 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
 import { NextResponse } from 'next/server'
-import { getServerSession } from 'next-auth'
-import { nextAuthOption } from '~/lib/auth/auth-options'
-import { isPlatformAdmin } from '~/lib/queries/projects/development-only-access'
+import { logger } from '@/lib/logger'
+import { requireAdminApi } from '~/lib/auth/require-admin-api'
+import {
+	getAdminProjectFilterOptions,
+	getAdminProjects,
+} from '~/lib/queries/admin/get-admin-projects'
 import { getAllProjects } from '~/lib/queries/projects/get-all-projects'
+import { adminProjectsQuerySchema, parseAdminListParams } from '~/lib/validators/admin-list-params'
 
-export async function GET() {
-	const session = await getServerSession(nextAuthOption)
+/**
+ * Admin project list.
+ *
+ * With query params: paginated `{ items, total, page, pageSize }` response
+ * with server-side search, filters, and sorting (the ops dashboard list).
+ * Page 1 additionally includes `filterOptions` (categories/foundations).
+ *
+ * Without query params: the legacy flat-array response consumed by the
+ * pre-redesign AdminProjectsList, kept intact so the feature-flag-off path
+ * behaves exactly as before.
+ */
+export async function GET(request: Request) {
+	const auth = await requireAdminApi()
+	if (!auth.ok) return auth.response
 
-	if (!session?.user?.id || !(await isPlatformAdmin(session.user.id))) {
-		return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+	const { searchParams } = new URL(request.url)
+
+	if ([...searchParams.keys()].length === 0) {
+		const projects = await getAllProjects(supabaseServiceRole, [], 'most-recent', 1000)
+		return NextResponse.json(projects)
 	}
 
-	const projects = await getAllProjects(supabaseServiceRole, [], 'most-recent', 1000)
+	const params = parseAdminListParams(adminProjectsQuerySchema, searchParams)
 
-	return NextResponse.json(projects)
+	try {
+		const [result, filterOptions] = await Promise.all([
+			getAdminProjects(supabaseServiceRole, params),
+			params.page === 1 ? getAdminProjectFilterOptions(supabaseServiceRole) : Promise.resolve(null),
+		])
+
+		return NextResponse.json(filterOptions ? { ...result, filterOptions } : result)
+	} catch (error) {
+		logger.error(error)
+		return NextResponse.json({ error: 'Failed to load projects' }, { status: 500 })
+	}
 }

--- a/apps/web/app/api/admin/projects/route.ts
+++ b/apps/web/app/api/admin/projects/route.ts
@@ -1,7 +1,9 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
 import { requireAdminApi } from '~/lib/auth/require-admin-api'
+import { withRateLimit } from '~/lib/middleware/rate-limit'
 import {
 	getAdminProjectFilterOptions,
 	getAdminProjects,
@@ -14,13 +16,14 @@ import { adminProjectsQuerySchema, parseAdminListParams } from '~/lib/validators
  *
  * With query params: paginated `{ items, total, page, pageSize }` response
  * with server-side search, filters, and sorting (the ops dashboard list).
- * Page 1 additionally includes `filterOptions` (categories/foundations).
+ * Every response includes `filterOptions` (categories/foundations) so
+ * bookmarked deep links render populated filter menus.
  *
  * Without query params: the legacy flat-array response consumed by the
  * pre-redesign AdminProjectsList, kept intact so the feature-flag-off path
  * behaves exactly as before.
  */
-export async function GET(request: Request) {
+async function handleProjects(request: NextRequest): Promise<NextResponse> {
 	const auth = await requireAdminApi()
 	if (!auth.ok) return auth.response
 
@@ -34,14 +37,24 @@ export async function GET(request: Request) {
 	const params = parseAdminListParams(adminProjectsQuerySchema, searchParams)
 
 	try {
+		// Filter options ship with every response (they are tiny lookup tables)
+		// so bookmarked deep links like ?page=2 render populated filter menus.
 		const [result, filterOptions] = await Promise.all([
 			getAdminProjects(supabaseServiceRole, params),
-			params.page === 1 ? getAdminProjectFilterOptions(supabaseServiceRole) : Promise.resolve(null),
+			getAdminProjectFilterOptions(supabaseServiceRole),
 		])
 
-		return NextResponse.json(filterOptions ? { ...result, filterOptions } : result)
+		return NextResponse.json({ ...result, filterOptions })
 	} catch (error) {
 		logger.error(error)
 		return NextResponse.json({ error: 'Failed to load projects' }, { status: 500 })
 	}
 }
+
+export const GET = withRateLimit(
+	{
+		preset: 'lenient',
+		identifier: (req) => req.headers.get('x-forwarded-for') ?? 'anonymous',
+	},
+	handleProjects,
+)

--- a/apps/web/app/api/admin/users/route.ts
+++ b/apps/web/app/api/admin/users/route.ts
@@ -1,0 +1,27 @@
+import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import { NextResponse } from 'next/server'
+import { logger } from '@/lib/logger'
+import { requireAdminApi } from '~/lib/auth/require-admin-api'
+import { getAdminUsers } from '~/lib/queries/admin/get-admin-users'
+import { adminUsersQuerySchema, parseAdminListParams } from '~/lib/validators/admin-list-params'
+
+/**
+ * Paginated admin user list with role, KYC, provider, wallet, and signup
+ * filters. Responses expose only operational fields — never KYC notes,
+ * provider payloads, or documents.
+ */
+export async function GET(request: Request) {
+	const auth = await requireAdminApi()
+	if (!auth.ok) return auth.response
+
+	const { searchParams } = new URL(request.url)
+	const params = parseAdminListParams(adminUsersQuerySchema, searchParams)
+
+	try {
+		const result = await getAdminUsers(supabaseServiceRole, params)
+		return NextResponse.json(result)
+	} catch (error) {
+		logger.error(error)
+		return NextResponse.json({ error: 'Failed to load users' }, { status: 500 })
+	}
+}

--- a/apps/web/app/api/admin/users/route.ts
+++ b/apps/web/app/api/admin/users/route.ts
@@ -1,7 +1,9 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
 import { requireAdminApi } from '~/lib/auth/require-admin-api'
+import { withRateLimit } from '~/lib/middleware/rate-limit'
 import { getAdminUsers } from '~/lib/queries/admin/get-admin-users'
 import { adminUsersQuerySchema, parseAdminListParams } from '~/lib/validators/admin-list-params'
 
@@ -10,7 +12,7 @@ import { adminUsersQuerySchema, parseAdminListParams } from '~/lib/validators/ad
  * filters. Responses expose only operational fields — never KYC notes,
  * provider payloads, or documents.
  */
-export async function GET(request: Request) {
+async function handleUsers(request: NextRequest): Promise<NextResponse> {
 	const auth = await requireAdminApi()
 	if (!auth.ok) return auth.response
 
@@ -25,3 +27,11 @@ export async function GET(request: Request) {
 		return NextResponse.json({ error: 'Failed to load users' }, { status: 500 })
 	}
 }
+
+export const GET = withRateLimit(
+	{
+		preset: 'lenient',
+		identifier: (req) => req.headers.get('x-forwarded-for') ?? 'anonymous',
+	},
+	handleUsers,
+)

--- a/apps/web/app/api/governance/rounds/route.ts
+++ b/apps/web/app/api/governance/rounds/route.ts
@@ -7,6 +7,7 @@ import {
 	createGovernanceRoundSchema,
 	governanceRoundsQuerySchema,
 } from '~/lib/schemas/governance.schemas'
+import { recordAdminAudit } from '~/lib/services/admin-audit'
 import { GovernanceContractService } from '~/lib/stellar/governance-contract'
 import { validateRequest } from '~/lib/utils/validation'
 
@@ -220,6 +221,20 @@ export async function POST(req: NextRequest) {
 		} catch (err) {
 			logger.error('[Governance] on-chain recording error:', err)
 		}
+
+		void recordAdminAudit({
+			operation: 'admin_governance_round_created',
+			resourceType: 'governance_round',
+			resourceId: round.id,
+			actorId: session.user.id,
+			status: 'success',
+			newState: status,
+			details: {
+				on_chain: contractRoundId !== null,
+				contract_round_id: contractRoundId,
+				option_count: insertedOptions.length,
+			},
+		})
 
 		return NextResponse.json(
 			{

--- a/apps/web/app/api/governance/rounds/route.ts
+++ b/apps/web/app/api/governance/rounds/route.ts
@@ -222,7 +222,7 @@ export async function POST(req: NextRequest) {
 			logger.error('[Governance] on-chain recording error:', err)
 		}
 
-		void recordAdminAudit({
+		await recordAdminAudit({
 			operation: 'admin_governance_round_created',
 			resourceType: 'governance_round',
 			resourceId: round.id,

--- a/apps/web/app/api/projects/[slug]/manage/status/route.ts
+++ b/apps/web/app/api/projects/[slug]/manage/status/route.ts
@@ -90,7 +90,7 @@ export async function PATCH(request: Request, context: { params: Promise<{ slug:
 
 		// Campaign status changes made by platform admins are auditable.
 		if (auth.access.isPlatformAdmin) {
-			void recordAdminAudit({
+			await recordAdminAudit({
 				operation: 'admin_project_status_changed',
 				resourceType: 'project',
 				resourceId: projectId,

--- a/apps/web/app/api/projects/[slug]/manage/status/route.ts
+++ b/apps/web/app/api/projects/[slug]/manage/status/route.ts
@@ -10,6 +10,7 @@ import {
 	PROJECT_STATUS_LABELS,
 	type ProjectStatus,
 } from '~/lib/projects/project-status'
+import { recordAdminAudit } from '~/lib/services/admin-audit'
 
 // Local Zod 4 enum — do not reuse @services/supabase projectStatusSchema (Zod 3).
 const updateStatusBodySchema = z.object({
@@ -85,6 +86,19 @@ export async function PATCH(request: Request, context: { params: Promise<{ slug:
 		if (updateError || !updated) {
 			logger.error(updateError)
 			return NextResponse.json({ error: 'Failed to update project status' }, { status: 500 })
+		}
+
+		// Campaign status changes made by platform admins are auditable.
+		if (auth.access.isPlatformAdmin) {
+			void recordAdminAudit({
+				operation: 'admin_project_status_changed',
+				resourceType: 'project',
+				resourceId: projectId,
+				actorId: userId,
+				status: 'success',
+				previousState: currentStatus,
+				newState: nextStatus,
+			})
 		}
 
 		return NextResponse.json({

--- a/apps/web/components/sections/admin/action-center/action-center.tsx
+++ b/apps/web/components/sections/admin/action-center/action-center.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { usePathname, useSearchParams } from 'next/navigation'
+import { Button } from '~/components/base/button'
+import { Skeleton } from '~/components/base/skeleton'
+import { AdminSectionHeader } from '~/components/sections/admin/admin-section-header'
+import { useAdminQuery } from '~/hooks/admin/use-admin-query'
+import type { AdminQueueSection } from '~/lib/queries/admin/get-action-queues'
+import type { AdminDashboardStats } from '~/lib/validators/admin-dashboard-stats'
+import { MetricGrid } from './metric-grid'
+import { QueueSection } from './queue-section'
+
+export interface ActionQueuePayload {
+	queues: AdminQueueSection[]
+	stats: AdminDashboardStats | null
+	statsError: boolean
+}
+
+const SKELETON_KEYS = ['a', 'b', 'c', 'd']
+
+/**
+ * The admin action center: work requiring attention first, platform metrics
+ * (linking to pre-filtered management views) below.
+ */
+export function AdminActionCenter() {
+	const pathname = usePathname()
+	const searchParams = useSearchParams()
+	const from = searchParams.size > 0 ? `${pathname}?${searchParams.toString()}` : pathname
+
+	const { data, isLoading, isError, refetch } = useAdminQuery<ActionQueuePayload>('action-queue')
+
+	const queues = data?.queues ?? []
+	const activeQueues = queues.filter((queue) => queue.error || queue.total > 0)
+	const allClear = !isLoading && !isError && activeQueues.length === 0
+
+	return (
+		<div className="space-y-8">
+			<AdminSectionHeader
+				title="Operations"
+				description="Work requiring admin attention, with platform metrics below."
+			/>
+
+			<section aria-label="Action queue" className="space-y-4">
+				{isLoading ? (
+					<output aria-label="Loading action queue" className="block space-y-4">
+						{SKELETON_KEYS.map((key) => (
+							<Skeleton key={key} className="h-40 w-full rounded-xl" />
+						))}
+					</output>
+				) : isError ? (
+					<div
+						role="alert"
+						className="flex flex-col items-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-8 text-center"
+					>
+						<p className="font-medium">The action queue could not be loaded.</p>
+						<Button type="button" variant="outline" onClick={() => refetch()}>
+							Retry
+						</Button>
+					</div>
+				) : allClear ? (
+					<div className="rounded-lg border border-dashed p-8 text-center">
+						<p className="font-medium">All clear</p>
+						<p className="mt-1 text-sm text-muted-foreground">
+							No projects, escrows, reviews, or KYC cases are waiting on an admin right now.
+						</p>
+					</div>
+				) : (
+					<div className="grid gap-4 xl:grid-cols-2">
+						{activeQueues.map((section) => (
+							<QueueSection
+								key={section.key}
+								section={section}
+								from={from}
+								onRetry={() => refetch()}
+							/>
+						))}
+					</div>
+				)}
+			</section>
+
+			<section aria-label="Platform metrics" className="space-y-4">
+				<h2 className="text-lg font-semibold">Platform metrics</h2>
+				{data?.stats ? (
+					<MetricGrid stats={data.stats} />
+				) : data?.statsError ? (
+					<div role="alert" className="flex items-center justify-between rounded-lg border p-4">
+						<p className="text-sm text-muted-foreground">Metrics could not be loaded.</p>
+						<Button type="button" variant="outline" size="sm" onClick={() => refetch()}>
+							Retry
+						</Button>
+					</div>
+				) : isLoading ? (
+					<Skeleton className="h-64 w-full rounded-xl" />
+				) : null}
+			</section>
+		</div>
+	)
+}

--- a/apps/web/components/sections/admin/action-center/metric-grid.tsx
+++ b/apps/web/components/sections/admin/action-center/metric-grid.tsx
@@ -1,0 +1,208 @@
+'use client'
+
+import Link from 'next/link'
+import { Card, CardContent } from '~/components/base/card'
+import { formatCurrency } from '~/components/sections/admin/admin-overview/formatters'
+import type { AdminDashboardStats } from '~/lib/validators/admin-dashboard-stats'
+
+interface MetricCard {
+	label: string
+	value: string
+	href: string
+	detail?: string
+}
+
+function buildMetricGroups(stats: AdminDashboardStats): Array<{
+	title: string
+	metrics: MetricCard[]
+}> {
+	const projectStatus = (status: string) => stats.projects.by_status[status] ?? 0
+	const escrowState = (state: string) => stats.escrows.by_state[state] ?? 0
+	const number = (value: number) => value.toLocaleString('en-US')
+
+	return [
+		{
+			title: 'Users & KYC',
+			metrics: [
+				{ label: 'Total users', value: number(stats.users.total), href: '/admin/users' },
+				{
+					label: 'New today',
+					value: number(stats.users.new_today),
+					href: '/admin/users?sort=newest',
+				},
+				{
+					label: 'New this week',
+					value: number(stats.users.new_week),
+					href: '/admin/users?sort=newest',
+				},
+				{
+					label: 'New this month',
+					value: number(stats.users.new_month),
+					href: '/admin/users?sort=newest',
+				},
+				{
+					label: 'KYC not started',
+					value: number(stats.kyc.not_started),
+					href: '/admin/users?kyc=not_started',
+				},
+				{
+					label: 'KYC pending',
+					value: number(stats.kyc.pending),
+					href: '/admin/users?kyc=pending',
+				},
+				{
+					label: 'KYC approved',
+					value: number(stats.kyc.approved),
+					href: '/admin/users?kyc=approved',
+				},
+				{
+					label: 'KYC rejected',
+					value: number(stats.kyc.rejected),
+					href: '/admin/users?kyc=rejected',
+				},
+			],
+		},
+		{
+			title: 'Projects',
+			metrics: [
+				{ label: 'All projects', value: number(stats.projects.total), href: '/admin/projects' },
+				{
+					label: 'Draft',
+					value: number(projectStatus('draft')),
+					href: '/admin/projects?status=draft',
+				},
+				{
+					label: 'Awaiting review',
+					value: number(projectStatus('review')),
+					href: '/admin/projects?status=review',
+				},
+				{
+					label: 'Active',
+					value: number(projectStatus('active')),
+					href: '/admin/projects?status=active',
+				},
+				{
+					label: 'Paused',
+					value: number(projectStatus('paused')),
+					href: '/admin/projects?status=paused',
+				},
+				{
+					label: 'Funded',
+					value: number(projectStatus('funded')),
+					href: '/admin/projects?status=funded',
+				},
+				{
+					label: 'Rejected',
+					value: number(projectStatus('rejected')),
+					href: '/admin/projects?status=rejected',
+				},
+				{
+					label: 'Without escrow',
+					value: number(stats.projects.without_escrow),
+					href: '/admin/projects?escrow=none&status=active',
+				},
+			],
+		},
+		{
+			title: 'Escrows',
+			metrics: [
+				{ label: 'Total escrows', value: number(stats.escrows.total), href: '/admin/escrows' },
+				{ label: 'New', value: number(escrowState('NEW')), href: '/admin/escrows?state=NEW' },
+				{
+					label: 'Funded',
+					value: number(escrowState('FUNDED')),
+					href: '/admin/escrows?state=FUNDED',
+				},
+				{
+					label: 'Active',
+					value: number(escrowState('ACTIVE')),
+					href: '/admin/escrows?state=ACTIVE',
+				},
+				{
+					label: 'Completed',
+					value: number(escrowState('COMPLETED')),
+					href: '/admin/escrows?state=COMPLETED',
+				},
+				{
+					label: 'Disputed',
+					value: number(escrowState('DISPUTED')),
+					href: '/admin/escrows?state=DISPUTED',
+				},
+				{
+					label: 'Cancelled',
+					value: number(escrowState('CANCELLED')),
+					href: '/admin/escrows?state=CANCELLED',
+				},
+			],
+		},
+		{
+			title: 'Operations',
+			metrics: [
+				{
+					label: 'Pending milestone reviews',
+					value: number(stats.milestone_reviews.pending),
+					href: '/admin/milestone-reviews',
+				},
+				{
+					label: 'Contributions',
+					value: number(stats.contributions.count),
+					detail: formatCurrency(stats.contributions.total_amount),
+					href: '/admin/analytics',
+				},
+				{
+					label: 'Foundations',
+					value: number(stats.foundations.total),
+					href: '/admin/foundations',
+				},
+				{
+					label: 'Governance rounds',
+					value: number(stats.governance.rounds_total),
+					detail: `${number(stats.governance.rounds_active)} active`,
+					href: '/admin/governance',
+				},
+			],
+		},
+	]
+}
+
+interface MetricGridProps {
+	stats: AdminDashboardStats
+}
+
+/**
+ * Platform metrics organized below the action center. Every card links to a
+ * pre-filtered management view instead of being a read-only number.
+ */
+export function MetricGrid({ stats }: MetricGridProps) {
+	const groups = buildMetricGroups(stats)
+
+	return (
+		<div className="space-y-6">
+			{groups.map((group) => (
+				<section key={group.title} aria-label={group.title}>
+					<h3 className="mb-2 text-sm font-semibold text-muted-foreground">{group.title}</h3>
+					<div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+						{group.metrics.map((metric) => (
+							<Card key={metric.label} className="transition-colors hover:border-primary/50">
+								<CardContent className="p-0">
+									<Link
+										href={metric.href}
+										className="block rounded-xl p-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+									>
+										<p className="text-2xl font-semibold tabular-nums">{metric.value}</p>
+										<p className="mt-1 truncate text-sm text-muted-foreground">{metric.label}</p>
+										{metric.detail ? (
+											<p className="mt-0.5 truncate text-xs text-muted-foreground">
+												{metric.detail}
+											</p>
+										) : null}
+									</Link>
+								</CardContent>
+							</Card>
+						))}
+					</div>
+				</section>
+			))}
+		</div>
+	)
+}

--- a/apps/web/components/sections/admin/action-center/metric-grid.tsx
+++ b/apps/web/components/sections/admin/action-center/metric-grid.tsx
@@ -12,6 +12,12 @@ interface MetricCard {
 	detail?: string
 }
 
+/** UTC date string N days ago, matching the users list `from` filter. */
+function isoDaysAgo(days: number): string {
+	const date = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+	return date.toISOString().slice(0, 10)
+}
+
 function buildMetricGroups(stats: AdminDashboardStats): Array<{
 	title: string
 	metrics: MetricCard[]
@@ -28,17 +34,17 @@ function buildMetricGroups(stats: AdminDashboardStats): Array<{
 				{
 					label: 'New today',
 					value: number(stats.users.new_today),
-					href: '/admin/users?sort=newest',
+					href: `/admin/users?sort=newest&from=${isoDaysAgo(0)}`,
 				},
 				{
 					label: 'New this week',
 					value: number(stats.users.new_week),
-					href: '/admin/users?sort=newest',
+					href: `/admin/users?sort=newest&from=${isoDaysAgo(7)}`,
 				},
 				{
 					label: 'New this month',
 					value: number(stats.users.new_month),
-					href: '/admin/users?sort=newest',
+					href: `/admin/users?sort=newest&from=${isoDaysAgo(30)}`,
 				},
 				{
 					label: 'KYC not started',

--- a/apps/web/components/sections/admin/action-center/queue-item-row.tsx
+++ b/apps/web/components/sections/admin/action-center/queue-item-row.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { formatDistanceToNow } from 'date-fns'
+import Link from 'next/link'
+import { Button } from '~/components/base/button'
+import {
+	AdminStatusBadge,
+	type AdminStatusKind,
+} from '~/components/sections/admin/shared/admin-status-badge'
+import type { AdminQueueItem } from '~/lib/queries/admin/get-action-queues'
+
+/** Appends a `from` back-link param to hrefs that leave the admin area. */
+export function withFromParam(href: string, from: string): string {
+	if (!href.startsWith('/projects/')) return href
+	const separator = href.includes('?') ? '&' : '?'
+	return `${href}${separator}from=${encodeURIComponent(from)}`
+}
+
+interface QueueItemRowProps {
+	item: AdminQueueItem
+	/** Current admin URL (path + search) used as the back-link target. */
+	from: string
+}
+
+export function QueueItemRow({ item, from }: QueueItemRowProps) {
+	return (
+		<li className="flex flex-col gap-2 border-t py-3 first:border-t-0 sm:flex-row sm:items-center sm:justify-between">
+			<div className="min-w-0 space-y-1">
+				<div className="flex flex-wrap items-center gap-2">
+					<AdminStatusBadge kind="priority" status={item.priority} />
+					<AdminStatusBadge kind={item.statusKind as AdminStatusKind} status={item.status} />
+				</div>
+				<p className="truncate font-medium">{item.title}</p>
+				<p className="flex flex-wrap items-center gap-x-2 text-sm text-muted-foreground">
+					{item.subtitle ? <span className="truncate">{item.subtitle}</span> : null}
+					{item.waitingSince ? (
+						<>
+							<span aria-hidden="true">·</span>
+							<span>
+								Waiting{' '}
+								<time dateTime={item.waitingSince}>
+									{formatDistanceToNow(new Date(item.waitingSince))}
+								</time>
+							</span>
+						</>
+					) : null}
+				</p>
+			</div>
+			<div className="flex shrink-0 items-center gap-2">
+				{item.viewHref ? (
+					<Button asChild variant="ghost" size="sm">
+						<Link href={withFromParam(item.viewHref, from)}>View</Link>
+					</Button>
+				) : null}
+				<Button asChild variant="outline" size="sm">
+					<Link href={withFromParam(item.primaryAction.href, from)}>
+						{item.primaryAction.label}
+					</Link>
+				</Button>
+			</div>
+		</li>
+	)
+}

--- a/apps/web/components/sections/admin/action-center/queue-section.tsx
+++ b/apps/web/components/sections/admin/action-center/queue-section.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { ArrowRight, RotateCcw } from 'lucide-react'
+import Link from 'next/link'
+import { Badge } from '~/components/base/badge'
+import { Button } from '~/components/base/button'
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/base/card'
+import type { AdminQueueSection } from '~/lib/queries/admin/get-action-queues'
+import { QueueItemRow } from './queue-item-row'
+
+interface QueueSectionProps {
+	section: AdminQueueSection
+	from: string
+	onRetry: () => void
+}
+
+export function QueueSection({ section, from, onRetry }: QueueSectionProps) {
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-start justify-between gap-2 space-y-0 pb-2">
+				<div>
+					<CardTitle className="flex items-center gap-2 text-base">
+						{section.title}
+						{!section.error ? (
+							<Badge variant="secondary" aria-label={`${section.total} items`}>
+								{section.total}
+							</Badge>
+						) : null}
+					</CardTitle>
+					<p className="mt-1 text-sm text-muted-foreground">{section.description}</p>
+				</div>
+				<Button asChild variant="ghost" size="sm" className="shrink-0">
+					<Link href={section.viewAllHref}>
+						View all
+						<ArrowRight className="ml-1 h-4 w-4" aria-hidden="true" />
+					</Link>
+				</Button>
+			</CardHeader>
+			<CardContent>
+				{section.error ? (
+					<div role="alert" className="flex items-center justify-between gap-3 py-2">
+						<p className="text-sm text-muted-foreground">This queue could not be loaded.</p>
+						<Button type="button" variant="outline" size="sm" onClick={onRetry}>
+							<RotateCcw className="mr-1 h-4 w-4" aria-hidden="true" />
+							Retry
+						</Button>
+					</div>
+				) : section.items.length === 0 ? (
+					<p className="py-2 text-sm text-muted-foreground">Nothing waiting here right now.</p>
+				) : (
+					<ul className="divide-y-0">
+						{section.items.map((item) => (
+							<QueueItemRow key={item.id} item={item} from={from} />
+						))}
+					</ul>
+				)}
+			</CardContent>
+		</Card>
+	)
+}

--- a/apps/web/components/sections/admin/admin-gamification-triggers.tsx
+++ b/apps/web/components/sections/admin/admin-gamification-triggers.tsx
@@ -572,7 +572,7 @@ export function AdminGamificationTriggers() {
 							]
 						: undefined
 				}
-				blockchain={{ networkId }}
+				blockchain={{ networkId, signerLabel: 'Platform service account (server-side)' }}
 				confirmLabel="Trigger contract"
 				pendingLabel="Submitting…"
 				isPending={form.isPending}

--- a/apps/web/components/sections/admin/admin-gamification-triggers.tsx
+++ b/apps/web/components/sections/admin/admin-gamification-triggers.tsx
@@ -21,6 +21,8 @@ import {
 	SelectValue,
 } from '~/components/base/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/base/tabs'
+import { ConfirmActionDialog } from '~/components/sections/admin/shared/confirm-action-dialog'
+import { useStellarNetworkConfig } from '~/hooks/contexts/stellar-network.context'
 import { useWallet } from '~/hooks/contexts/use-stellar-wallet.context'
 import { useEffectiveWalletAddress } from '~/hooks/wallet/use-effective-wallet-address'
 import { MODULES, REPUTATION_EVENTS } from './admin-gamification-triggers/constants'
@@ -185,6 +187,7 @@ export function AdminGamificationTriggers() {
 		disconnectKit,
 	} = useEffectiveWalletAddress()
 	const form = useAdminGamificationTriggerForm(address)
+	const { networkId } = useStellarNetworkConfig()
 
 	return (
 		<div className="space-y-4">
@@ -553,6 +556,28 @@ export function AdminGamificationTriggers() {
 					<TriggerResultBanner result={form.lastResult} />
 				</CardContent>
 			</Card>
+
+			<ConfirmActionDialog
+				open={form.pendingPayload !== null}
+				onOpenChange={(open) => {
+					if (!open) form.cancelPending()
+				}}
+				title="Trigger gamification contract"
+				description="This invokes a production smart-contract method signed by the platform service account."
+				summary={
+					form.pendingPayload
+						? [
+								{ label: 'Module', value: form.pendingPayload.module },
+								{ label: 'Action', value: form.pendingPayload.action },
+							]
+						: undefined
+				}
+				blockchain={{ networkId }}
+				confirmLabel="Trigger contract"
+				pendingLabel="Submitting…"
+				isPending={form.isPending}
+				onConfirm={form.confirmPending}
+			/>
 		</div>
 	)
 }

--- a/apps/web/components/sections/admin/admin-gamification-triggers/hooks/use-admin-gamification-trigger-form.ts
+++ b/apps/web/components/sections/admin/admin-gamification-triggers/hooks/use-admin-gamification-trigger-form.ts
@@ -20,6 +20,8 @@ async function triggerContract(payload: AdminGamificationTriggerInput): Promise<
 export function useAdminGamificationTriggerForm(address: string | null) {
 	const [activeModule, setActiveModule] = useState<string>('streak')
 	const [lastResult, setLastResult] = useState<TriggerResponse | null>(null)
+	// Payload staged for explicit confirmation before anything is submitted.
+	const [pendingPayload, setPendingPayload] = useState<AdminGamificationTriggerInput | null>(null)
 
 	const [period, setPeriod] = useState<'weekly' | 'monthly'>('weekly')
 	const [referralAction, setReferralAction] = useState<
@@ -41,6 +43,7 @@ export function useAdminGamificationTriggerForm(address: string | null) {
 	const mutation = useMutation({
 		mutationFn: triggerContract,
 		onSuccess: (data) => {
+			setPendingPayload(null)
 			setLastResult(data)
 			if (data.success) {
 				toast.success('On-chain trigger submitted', {
@@ -55,6 +58,7 @@ export function useAdminGamificationTriggerForm(address: string | null) {
 			}
 		},
 		onError: (error) => {
+			setPendingPayload(null)
 			const message = error instanceof Error ? error.message : 'Request failed'
 			setLastResult({ success: false, error: message })
 			toast.error('Request failed', { description: message })
@@ -67,6 +71,8 @@ export function useAdminGamificationTriggerForm(address: string | null) {
 		return connectedAddress
 	}
 
+	// Stages the payload for confirmation instead of submitting directly —
+	// contract calls only fire after an explicit confirm.
 	const handleSubmit = (
 		payload: AdminGamificationTriggerInput,
 		connectedAddress: string | null,
@@ -81,8 +87,7 @@ export function useAdminGamificationTriggerForm(address: string | null) {
 				toast.error('Enter a target Stellar G-address or connect a wallet')
 				return
 			}
-			setLastResult(null)
-			mutation.mutate({ ...payload, userAddress: targetAddress })
+			setPendingPayload({ ...payload, userAddress: targetAddress })
 			return
 		}
 
@@ -91,8 +96,18 @@ export function useAdminGamificationTriggerForm(address: string | null) {
 			return
 		}
 
+		setPendingPayload(payload)
+	}
+
+	const confirmPending = () => {
+		if (!pendingPayload || mutation.isPending) return
 		setLastResult(null)
-		mutation.mutate(payload)
+		mutation.mutate(pendingPayload)
+	}
+
+	const cancelPending = () => {
+		if (mutation.isPending) return
+		setPendingPayload(null)
 	}
 
 	const canSubmitWithAddress = (connectedAddress: string | null) =>
@@ -107,6 +122,9 @@ export function useAdminGamificationTriggerForm(address: string | null) {
 		canSubmit,
 		isPending: mutation.isPending,
 		handleSubmit,
+		pendingPayload,
+		confirmPending,
+		cancelPending,
 
 		period,
 		setPeriod,

--- a/apps/web/components/sections/admin/admin-gamification-triggers/quest-progress-backfill-panel.tsx
+++ b/apps/web/components/sections/admin/admin-gamification-triggers/quest-progress-backfill-panel.tsx
@@ -7,6 +7,7 @@ import { Button } from '~/components/base/button'
 import { Input } from '~/components/base/input'
 import { Label } from '~/components/base/label'
 import { ConfirmActionDialog } from '~/components/sections/admin/shared/confirm-action-dialog'
+import { useStellarNetworkConfig } from '~/hooks/contexts/stellar-network.context'
 
 type BackfillResponse = {
 	success: boolean
@@ -43,6 +44,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 }
 
 export function QuestProgressBackfillPanel() {
+	const { networkId } = useStellarNetworkConfig()
 	const [userId, setUserId] = useState('')
 	const [limit, setLimit] = useState('100')
 	const [pendingRun, setPendingRun] = useState<{
@@ -138,6 +140,7 @@ export function QuestProgressBackfillPanel() {
 							]
 						: undefined
 				}
+				blockchain={{ networkId, signerLabel: 'Platform service account (server-side)' }}
 				confirmLabel="Run backfill"
 				pendingLabel="Running…"
 				isPending={mutation.isPending}

--- a/apps/web/components/sections/admin/admin-gamification-triggers/quest-progress-backfill-panel.tsx
+++ b/apps/web/components/sections/admin/admin-gamification-triggers/quest-progress-backfill-panel.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner'
 import { Button } from '~/components/base/button'
 import { Input } from '~/components/base/input'
 import { Label } from '~/components/base/label'
+import { ConfirmActionDialog } from '~/components/sections/admin/shared/confirm-action-dialog'
 
 type BackfillResponse = {
 	success: boolean
@@ -44,9 +45,15 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 export function QuestProgressBackfillPanel() {
 	const [userId, setUserId] = useState('')
 	const [limit, setLimit] = useState('100')
+	const [pendingRun, setPendingRun] = useState<{
+		userId?: string
+		all?: boolean
+		limit?: number
+	} | null>(null)
 
 	const mutation = useMutation({
 		mutationFn: runBackfill,
+		onSettled: () => setPendingRun(null),
 		onSuccess: (data) => {
 			const summary = data.summary
 			if (!summary) return
@@ -98,7 +105,7 @@ export function QuestProgressBackfillPanel() {
 					variant="secondary"
 					disabled={mutation.isPending || !userId.trim()}
 					onClick={() =>
-						mutation.mutate({ userId: userId.trim(), all: false, limit: Number(limit) || 100 })
+						setPendingRun({ userId: userId.trim(), all: false, limit: Number(limit) || 100 })
 					}
 				>
 					{mutation.isPending ? 'Running…' : 'Backfill one user'}
@@ -107,11 +114,37 @@ export function QuestProgressBackfillPanel() {
 					type="button"
 					variant="outline"
 					disabled={mutation.isPending}
-					onClick={() => mutation.mutate({ all: true, limit: Number(limit) || 100 })}
+					onClick={() => setPendingRun({ all: true, limit: Number(limit) || 100 })}
 				>
 					{mutation.isPending ? 'Running…' : 'Backfill all donors'}
 				</Button>
 			</div>
+
+			<ConfirmActionDialog
+				open={pendingRun !== null}
+				onOpenChange={(open) => {
+					if (!open && !mutation.isPending) setPendingRun(null)
+				}}
+				title="Run quest progress backfill"
+				description="Recomputes quest progress from contribution history and syncs it on-chain. This can take a while for many users."
+				summary={
+					pendingRun
+						? [
+								{
+									label: 'Scope',
+									value: pendingRun.all ? `All donors (max ${pendingRun.limit})` : 'Single user',
+								},
+								...(pendingRun.userId ? [{ label: 'User ID', value: pendingRun.userId }] : []),
+							]
+						: undefined
+				}
+				confirmLabel="Run backfill"
+				pendingLabel="Running…"
+				isPending={mutation.isPending}
+				onConfirm={() => {
+					if (pendingRun) mutation.mutate(pendingRun)
+				}}
+			/>
 		</div>
 	)
 }

--- a/apps/web/components/sections/admin/admin-governance-manager/create-round-dialog.tsx
+++ b/apps/web/components/sections/admin/admin-governance-manager/create-round-dialog.tsx
@@ -11,6 +11,8 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from '~/components/base/dialog'
+import { ConfirmActionDialog } from '~/components/sections/admin/shared/confirm-action-dialog'
+import { useStellarNetworkConfig } from '~/hooks/contexts/stellar-network.context'
 import { EMPTY_ROW } from './constants'
 import { CreateRoundForm } from './create-round-form'
 import { CreateRoundSuccess } from './create-round-success'
@@ -36,6 +38,8 @@ interface CreateRoundDialogProps {
 
 export const CreateRoundDialog = ({ onCreated }: CreateRoundDialogProps) => {
 	const [open, setOpen] = useState(false)
+	const [confirmOpen, setConfirmOpen] = useState(false)
+	const { networkId } = useStellarNetworkConfig()
 	const [result, setResult] = useState<CreateRoundResult | null>(null)
 	const [form, setForm] = useState(INITIAL_FORM)
 	const [optionRows, setOptionRows] = useState<OptionRow[]>([{ ...EMPTY_ROW }])
@@ -55,6 +59,7 @@ export const CreateRoundDialog = ({ onCreated }: CreateRoundDialogProps) => {
 	}
 
 	const { mutate: createRound, isPending } = useCreateRound((data) => {
+		setConfirmOpen(false)
 		setResult(data)
 	})
 
@@ -118,7 +123,7 @@ export const CreateRoundDialog = ({ onCreated }: CreateRoundDialogProps) => {
 							<Button variant="outline" onClick={handleClose} disabled={isPending}>
 								Cancel
 							</Button>
-							<Button onClick={() => createRound({ form, optionRows })} disabled={!canSubmit}>
+							<Button onClick={() => setConfirmOpen(true)} disabled={!canSubmit}>
 								{isPending ? (
 									<>
 										<Loader2 className="h-4 w-4 mr-2 animate-spin" />
@@ -132,6 +137,26 @@ export const CreateRoundDialog = ({ onCreated }: CreateRoundDialogProps) => {
 					)}
 				</DialogFooter>
 			</DialogContent>
+
+			<ConfirmActionDialog
+				open={confirmOpen}
+				onOpenChange={setConfirmOpen}
+				title="Create governance round"
+				description="This creates the round in the database and records it on-chain via the platform service account."
+				summary={[
+					{ label: 'Title', value: form.title },
+					{ label: 'Voting window', value: `${form.startsAt} → ${form.endsAt}` },
+					{ label: 'Options', value: String(validOptionCount) },
+					...(form.totalFundAmount
+						? [{ label: 'Fund', value: `${form.totalFundAmount} ${form.fundCurrency}` }]
+						: []),
+				]}
+				blockchain={{ networkId }}
+				confirmLabel="Create round"
+				pendingLabel="Creating…"
+				isPending={isPending}
+				onConfirm={() => createRound({ form, optionRows })}
+			/>
 		</Dialog>
 	)
 }

--- a/apps/web/components/sections/admin/escrows/admin-escrows-page.tsx
+++ b/apps/web/components/sections/admin/escrows/admin-escrows-page.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { usePathname, useSearchParams } from 'next/navigation'
+import { useId } from 'react'
+import { Label } from '~/components/base/label'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '~/components/base/select'
+import { AdminSectionHeader } from '~/components/sections/admin/admin-section-header'
+import { AdminListShell } from '~/components/sections/admin/shared/admin-list-shell'
+import { useAdminListParams } from '~/hooks/admin/use-admin-list-params'
+import { useAdminQuery } from '~/hooks/admin/use-admin-query'
+import type { AdminEscrowListItem } from '~/lib/queries/admin/get-admin-escrows'
+import type { AdminListResponse } from '~/lib/validators/admin-list-params'
+import {
+	adminEscrowsQuerySchema,
+	ESCROW_SORT_OPTIONS,
+	ESCROW_STATE_FILTERS,
+} from '~/lib/validators/admin-list-params'
+import { EscrowRow } from './escrow-row'
+
+const ALL = 'all'
+
+const SORT_LABELS: Record<(typeof ESCROW_SORT_OPTIONS)[number], string> = {
+	newest: 'Newest first',
+	oldest: 'Oldest first',
+	updated: 'Recently updated',
+	amount: 'Highest amount',
+}
+
+export function AdminEscrowsPage() {
+	const pathname = usePathname()
+	const searchParams = useSearchParams()
+	const from = searchParams.size > 0 ? `${pathname}?${searchParams.toString()}` : pathname
+	const stateSelectId = useId()
+	const sortSelectId = useId()
+
+	const { params, normalizedParams, setParam, setPage, resetFilters } =
+		useAdminListParams(adminEscrowsQuerySchema)
+
+	const { data, isLoading, isError, refetch } = useAdminQuery<
+		AdminListResponse<AdminEscrowListItem>
+	>('escrows', { params: normalizedParams })
+
+	const hasActiveFilters = Object.keys(normalizedParams).some(
+		(key) => !['page', 'pageSize', 'sort'].includes(key),
+	)
+
+	return (
+		<div className="space-y-6">
+			<AdminSectionHeader
+				title="Escrows"
+				description="Every escrow shown with its campaign. Broken associations are flagged; on-chain detail loads when a row is expanded."
+			/>
+
+			<AdminListShell
+				searchValue={params.q ?? ''}
+				onSearchChange={(value) => setParam('q', value || undefined)}
+				searchPlaceholder="Search by project, contract address, or engagement ID…"
+				filters={
+					<>
+						<div className="flex items-center gap-1.5">
+							<Label htmlFor={stateSelectId} className="sr-only">
+								Filter by escrow state
+							</Label>
+							<Select
+								value={params.state ?? ALL}
+								onValueChange={(next) => setParam('state', next === ALL ? undefined : next)}
+							>
+								<SelectTrigger
+									id={stateSelectId}
+									className="h-9 w-auto min-w-32 gap-1"
+									aria-label="Filter by escrow state"
+								>
+									<SelectValue placeholder="All states" />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value={ALL}>All states</SelectItem>
+									{ESCROW_STATE_FILTERS.map((state) => (
+										<SelectItem key={state} value={state}>
+											{state}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div className="flex items-center gap-1.5">
+							<Label htmlFor={sortSelectId} className="sr-only">
+								Sort escrows
+							</Label>
+							<Select
+								value={params.sort}
+								onValueChange={(next) => setParam('sort', next === 'newest' ? undefined : next)}
+							>
+								<SelectTrigger
+									id={sortSelectId}
+									className="h-9 w-auto min-w-32 gap-1"
+									aria-label="Sort escrows"
+								>
+									<SelectValue placeholder="Newest first" />
+								</SelectTrigger>
+								<SelectContent>
+									{ESCROW_SORT_OPTIONS.map((sort) => (
+										<SelectItem key={sort} value={sort}>
+											{SORT_LABELS[sort]}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					</>
+				}
+				isLoading={isLoading}
+				isError={isError}
+				onRetry={() => refetch()}
+				total={data?.total ?? 0}
+				page={params.page}
+				pageSize={params.pageSize}
+				onPageChange={setPage}
+				emptyTitle="No escrows yet"
+				emptyDescription="Escrow contracts appear here once campaigns deploy them."
+				hasActiveFilters={hasActiveFilters}
+				onResetFilters={resetFilters}
+				skeletonRowHeight={128}
+			>
+				<ul className="space-y-3">
+					{(data?.items ?? []).map((escrow) => (
+						<li key={escrow.id}>
+							<EscrowRow escrow={escrow} from={from} onSynced={() => refetch()} />
+						</li>
+					))}
+				</ul>
+			</AdminListShell>
+		</div>
+	)
+}

--- a/apps/web/components/sections/admin/escrows/escrow-detail-expand.tsx
+++ b/apps/web/components/sections/admin/escrows/escrow-detail-expand.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { useEffect, useState, useTransition } from 'react'
+import { toast } from 'sonner'
+import { syncEscrowToDatabaseAction } from '~/app/actions/escrow/sync-escrow-to-database'
+import { Button } from '~/components/base/button'
+import { Skeleton } from '~/components/base/skeleton'
+import { useEscrowData } from '~/hooks/escrow/use-escrow-data'
+import type { AdminEscrowListItem } from '~/lib/queries/admin/get-admin-escrows'
+
+interface EscrowDetailExpandProps {
+	escrow: AdminEscrowListItem
+	onSynced: () => void
+}
+
+/**
+ * Lazily-loaded on-chain detail for one escrow. Indexer data is fetched
+ * only when the row is expanded — never for the whole list at once.
+ */
+export function EscrowDetailExpand({ escrow, onSynced }: EscrowDetailExpandProps) {
+	const { escrowData, isLoading, error, refetch } = useEscrowData({
+		escrowContractAddress: escrow.contractId,
+		escrowType: escrow.type ?? undefined,
+	})
+	const [hasFetched, setHasFetched] = useState(false)
+	const [isSyncing, startSync] = useTransition()
+
+	useEffect(() => {
+		if (!hasFetched) {
+			setHasFetched(true)
+			void refetch()
+		}
+	}, [hasFetched, refetch])
+
+	const indexerBalance = escrowData?.balance != null ? String(escrowData.balance) : null
+	const milestones = escrowData?.milestones ?? []
+	const approvedCount = milestones.filter(
+		(milestone) =>
+			('approved' in milestone && milestone.approved === true) ||
+			('flags' in milestone &&
+				(milestone as { flags?: { approved?: boolean } }).flags?.approved === true),
+	).length
+	const indexerMissing = !isLoading && !escrowData && error !== null
+	const needsSync = escrow.health.issues.includes('missing_association')
+
+	const handleSync = () => {
+		if (!escrow.project) {
+			toast.error('This escrow has no resolvable project to sync against.')
+			return
+		}
+		const projectId = escrow.project.id
+		startSync(async () => {
+			const result = await syncEscrowToDatabaseAction({
+				projectId,
+				contractId: escrow.contractId,
+			})
+			if (result.success) {
+				toast.success(
+					result.alreadySynced ? 'Escrow was already in sync.' : 'Escrow synced to the database.',
+				)
+				onSynced()
+			} else {
+				toast.error(result.error ?? 'Escrow sync failed.')
+			}
+		})
+	}
+
+	return (
+		<div className="space-y-3 border-t bg-muted/30 p-4 text-sm">
+			{isLoading ? (
+				<output aria-label="Loading on-chain escrow detail" className="block space-y-2">
+					<Skeleton className="h-4 w-2/3" />
+					<Skeleton className="h-4 w-1/2" />
+				</output>
+			) : escrowData ? (
+				<dl className="grid gap-x-8 gap-y-2 sm:grid-cols-2 lg:grid-cols-4">
+					<div>
+						<dt className="text-xs text-muted-foreground">Indexer balance</dt>
+						<dd className="font-medium tabular-nums">{indexerBalance ?? '—'}</dd>
+					</div>
+					<div>
+						<dt className="text-xs text-muted-foreground">Releases approved</dt>
+						<dd className="font-medium">
+							{approvedCount} of {milestones.length}
+						</dd>
+					</div>
+					<div>
+						<dt className="text-xs text-muted-foreground">Disputed flag</dt>
+						<dd className="font-medium">
+							{(escrowData.flags as { disputed?: boolean } | undefined)?.disputed ? 'Yes' : 'No'}
+						</dd>
+					</div>
+					<div>
+						<dt className="text-xs text-muted-foreground">Released flag</dt>
+						<dd className="font-medium">
+							{(escrowData.flags as { released?: boolean } | undefined)?.released ? 'Yes' : 'No'}
+						</dd>
+					</div>
+				</dl>
+			) : (
+				<div role="alert" className="flex flex-wrap items-center gap-3">
+					<p className="text-muted-foreground">
+						{indexerMissing
+							? 'The Trustless Work indexer has no data for this contract — the database record may be ahead of the indexer, or the contract id is wrong.'
+							: 'On-chain detail is unavailable.'}
+					</p>
+					<Button type="button" variant="outline" size="sm" onClick={() => refetch()}>
+						Retry
+					</Button>
+				</div>
+			)}
+
+			{needsSync || indexerMissing ? (
+				<div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-amber-300 bg-amber-50 p-3">
+					<p className="text-amber-800">
+						{needsSync
+							? 'This escrow is not linked to its project in the database.'
+							: 'Database and indexer state may be out of sync.'}
+					</p>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={handleSync}
+						disabled={isSyncing || !escrow.project}
+					>
+						{isSyncing ? 'Syncing…' : 'Sync escrow'}
+					</Button>
+				</div>
+			) : null}
+		</div>
+	)
+}

--- a/apps/web/components/sections/admin/escrows/escrow-detail-expand.tsx
+++ b/apps/web/components/sections/admin/escrows/escrow-detail-expand.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useTransition } from 'react'
 import { toast } from 'sonner'
-import { syncEscrowToDatabaseAction } from '~/app/actions/escrow/sync-escrow-to-database'
+import { syncEscrowAsAdminAction } from '~/app/actions/admin/sync-escrow-as-admin'
 import { Button } from '~/components/base/button'
 import { Skeleton } from '~/components/base/skeleton'
 import { useEscrowData } from '~/hooks/escrow/use-escrow-data'
@@ -50,7 +50,7 @@ export function EscrowDetailExpand({ escrow, onSynced }: EscrowDetailExpandProps
 		}
 		const projectId = escrow.project.id
 		startSync(async () => {
-			const result = await syncEscrowToDatabaseAction({
+			const result = await syncEscrowAsAdminAction({
 				projectId,
 				contractId: escrow.contractId,
 			})

--- a/apps/web/components/sections/admin/escrows/escrow-row.tsx
+++ b/apps/web/components/sections/admin/escrows/escrow-row.tsx
@@ -154,7 +154,7 @@ export function EscrowRow({ escrow, from, onSynced }: EscrowRowProps) {
 					>
 						{expanded ? 'Hide detail' : 'On-chain detail'}
 						<ChevronDown
-							className={`ml-1 h-4 w-4 transition-transform ${expanded ? 'rotate-180' : ''}`}
+							className={`ml-1 h-4 w-4 transition-transform motion-reduce:transition-none ${expanded ? 'rotate-180' : ''}`}
 							aria-hidden="true"
 						/>
 					</Button>

--- a/apps/web/components/sections/admin/escrows/escrow-row.tsx
+++ b/apps/web/components/sections/admin/escrows/escrow-row.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import { formatDistanceToNow } from 'date-fns'
+import { AlertTriangle, ChevronDown, ExternalLink } from 'lucide-react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useState } from 'react'
+import { Badge } from '~/components/base/badge'
+import { Button } from '~/components/base/button'
+import { Card } from '~/components/base/card'
+import { formatCurrency } from '~/components/sections/admin/admin-overview/formatters'
+import { AdminStatusBadge } from '~/components/sections/admin/shared/admin-status-badge'
+import { TruncatedId } from '~/components/sections/admin/shared/truncated-id'
+import { useStellarNetworkConfig } from '~/hooks/contexts/stellar-network.context'
+import { projectManageSectionHref } from '~/lib/admin/project-actions'
+import type { AdminEscrowListItem } from '~/lib/queries/admin/get-admin-escrows'
+import { formatHumanPlatformFee } from '~/lib/utils/escrow/platform-fee'
+import { getStellarExplorerUrl } from '~/lib/utils/escrow/stellar-explorer'
+import { EscrowDetailExpand } from './escrow-detail-expand'
+
+const HEALTH_LABELS: Record<string, string> = {
+	missing_association: 'Missing DB association',
+	orphaned_project: 'Orphaned escrow',
+}
+
+interface EscrowRowProps {
+	escrow: AdminEscrowListItem
+	/** Current admin URL (path + search) used as the back-link target. */
+	from: string
+	onSynced: () => void
+}
+
+export function EscrowRow({ escrow, from, onSynced }: EscrowRowProps) {
+	const [expanded, setExpanded] = useState(false)
+	const { networkId } = useStellarNetworkConfig()
+	const explorerUrl = getStellarExplorerUrl(escrow.contractId, networkId)
+
+	const manageHref = escrow.project?.slug
+		? `${projectManageSectionHref('escrow-manage', escrow.project.slug)}?from=${encodeURIComponent(from)}`
+		: null
+
+	return (
+		<Card className={escrow.health.healthy ? undefined : 'border-amber-400'}>
+			<div className="flex flex-col gap-3 p-4">
+				<div className="flex flex-wrap items-start justify-between gap-3">
+					<div className="flex min-w-0 items-center gap-3">
+						<div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-lg">
+							{escrow.project?.imageUrl ? (
+								<Image
+									src={escrow.project.imageUrl}
+									alt={`${escrow.project.title} cover image`}
+									fill
+									className="object-cover"
+									sizes="48px"
+									loading="lazy"
+								/>
+							) : (
+								<div
+									aria-hidden="true"
+									className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-300 text-lg font-semibold text-slate-600"
+								>
+									{(escrow.project?.title ?? 'E').slice(0, 1).toUpperCase()}
+								</div>
+							)}
+						</div>
+						<div className="min-w-0">
+							<div className="flex flex-wrap items-center gap-2">
+								{escrow.project ? (
+									<>
+										<h3 className="truncate font-semibold">{escrow.project.title}</h3>
+										<AdminStatusBadge kind="project" status={escrow.project.status} />
+									</>
+								) : (
+									<h3 className="font-semibold text-muted-foreground">No linked project</h3>
+								)}
+								<AdminStatusBadge kind="escrow" status={escrow.state ?? 'NEW'} />
+								{escrow.type ? <Badge variant="secondary">{escrow.type}</Badge> : null}
+							</div>
+							<p className="mt-0.5 flex flex-wrap items-center gap-x-2 text-sm text-muted-foreground">
+								{escrow.project?.slug ? <span>/projects/{escrow.project.slug}</span> : null}
+								<span aria-hidden="true">·</span>
+								<span>Engagement {escrow.engagementId}</span>
+							</p>
+						</div>
+					</div>
+
+					<div className="flex shrink-0 flex-wrap items-center gap-2">
+						{escrow.project?.slug ? (
+							<Button asChild variant="ghost" size="sm">
+								<Link href={`/projects/${escrow.project.slug}`}>View project</Link>
+							</Button>
+						) : null}
+						<Button asChild variant="ghost" size="sm">
+							<a href={explorerUrl} target="_blank" rel="noopener noreferrer">
+								Explorer
+								<ExternalLink className="ml-1 h-3.5 w-3.5" aria-hidden="true" />
+								<span className="sr-only">(opens Stellar Explorer in a new tab)</span>
+							</a>
+						</Button>
+						{manageHref ? (
+							<Button asChild variant="outline" size="sm">
+								<Link href={manageHref}>Manage escrow</Link>
+							</Button>
+						) : null}
+					</div>
+				</div>
+
+				{!escrow.health.healthy ? (
+					<div
+						role="alert"
+						className="flex flex-wrap items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+					>
+						<AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
+						{escrow.health.issues.map((issue) => (
+							<span key={issue} className="font-medium">
+								{HEALTH_LABELS[issue] ?? issue}
+							</span>
+						))}
+					</div>
+				) : null}
+
+				<div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-muted-foreground">
+					<TruncatedId value={escrow.contractId} copyLabel="Copy contract address" />
+					<span>Amount {formatCurrency(escrow.amount)}</span>
+					<span>Fee {formatHumanPlatformFee(escrow.platformFee)}</span>
+					{escrow.releaseCount > 0 ? (
+						<span>
+							{escrow.releaseCount} {escrow.releaseCount === 1 ? 'release' : 'releases'}
+						</span>
+					) : null}
+					{escrow.createdAt ? (
+						<span>
+							Created{' '}
+							<time dateTime={escrow.createdAt}>
+								{formatDistanceToNow(new Date(escrow.createdAt))} ago
+							</time>
+						</span>
+					) : null}
+					{escrow.updatedAt ? (
+						<span>
+							Updated{' '}
+							<time dateTime={escrow.updatedAt}>
+								{formatDistanceToNow(new Date(escrow.updatedAt))} ago
+							</time>
+						</span>
+					) : null}
+					<Button
+						type="button"
+						variant="ghost"
+						size="sm"
+						className="ml-auto"
+						onClick={() => setExpanded((current) => !current)}
+						aria-expanded={expanded}
+					>
+						{expanded ? 'Hide detail' : 'On-chain detail'}
+						<ChevronDown
+							className={`ml-1 h-4 w-4 transition-transform ${expanded ? 'rotate-180' : ''}`}
+							aria-hidden="true"
+						/>
+					</Button>
+				</div>
+			</div>
+
+			{expanded ? <EscrowDetailExpand escrow={escrow} onSynced={onSynced} /> : null}
+		</Card>
+	)
+}

--- a/apps/web/components/sections/admin/escrows/escrow-row.tsx
+++ b/apps/web/components/sections/admin/escrows/escrow-row.tsx
@@ -14,6 +14,7 @@ import { TruncatedId } from '~/components/sections/admin/shared/truncated-id'
 import { useStellarNetworkConfig } from '~/hooks/contexts/stellar-network.context'
 import { projectManageSectionHref } from '~/lib/admin/project-actions'
 import type { AdminEscrowListItem } from '~/lib/queries/admin/get-admin-escrows'
+import { cn } from '~/lib/utils'
 import { formatHumanPlatformFee } from '~/lib/utils/escrow/platform-fee'
 import { getStellarExplorerUrl } from '~/lib/utils/escrow/stellar-explorer'
 import { EscrowDetailExpand } from './escrow-detail-expand'
@@ -154,7 +155,10 @@ export function EscrowRow({ escrow, from, onSynced }: EscrowRowProps) {
 					>
 						{expanded ? 'Hide detail' : 'On-chain detail'}
 						<ChevronDown
-							className={`ml-1 h-4 w-4 transition-transform motion-reduce:transition-none ${expanded ? 'rotate-180' : ''}`}
+							className={cn(
+								'ml-1 h-4 w-4 transition-transform motion-reduce:transition-none',
+								expanded && 'rotate-180',
+							)}
 							aria-hidden="true"
 						/>
 					</Button>

--- a/apps/web/components/sections/admin/milestone-reviews/milestone-reviews-queue.tsx
+++ b/apps/web/components/sections/admin/milestone-reviews/milestone-reviews-queue.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import { useQueryClient } from '@tanstack/react-query'
 import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useState } from 'react'
 import { IoOpenOutline } from 'react-icons/io5'
 import { toast } from 'sonner'
@@ -25,6 +27,7 @@ import {
 import type { AdminMilestoneReviewRequest } from '~/lib/types/milestone-review-request'
 import { cn } from '~/lib/utils'
 import { AdminSectionHeader } from '../admin-section-header'
+import { ConfirmActionDialog } from '../shared/confirm-action-dialog'
 
 const FILTER_TABS: { value: AdminReviewFilter; label: string }[] = [
 	{ value: 'pending', label: 'Pending' },
@@ -143,10 +146,42 @@ const ReviewQueueItem = ({
 	)
 }
 
+const FILTER_VALUES: AdminReviewFilter[] = ['pending', 'approved', 'rejected', 'all']
+
 export const MilestoneReviewsQueue = () => {
-	const [filter, setFilter] = useState<AdminReviewFilter>('pending')
+	const router = useRouter()
+	const searchParams = useSearchParams()
+	const queryClient = useQueryClient()
+
+	// The status filter lives in the URL so filtered queues can be
+	// bookmarked and linked from the action center.
+	const statusParam = searchParams.get('status')
+	const filter: AdminReviewFilter = FILTER_VALUES.includes(statusParam as AdminReviewFilter)
+		? (statusParam as AdminReviewFilter)
+		: 'pending'
+	const setFilter = (next: AdminReviewFilter) => {
+		const params = new URLSearchParams(searchParams.toString())
+		if (next === 'pending') {
+			params.delete('status')
+		} else {
+			params.set('status', next)
+		}
+		const query = params.toString()
+		router.replace(query ? `?${query}` : '/admin/milestone-reviews', { scroll: false })
+	}
+
 	const { data: requests = [], isLoading, error } = useAdminMilestoneReviews(filter)
 	const updateRequest = useUpdateMilestoneReviewRequest()
+
+	const invalidateAdminCounts = () => {
+		void queryClient.invalidateQueries({ queryKey: ['admin', 'nav-counts'] })
+		void queryClient.invalidateQueries({ queryKey: ['admin', 'action-queue'] })
+	}
+
+	const [approveDialog, setApproveDialog] = useState<{
+		open: boolean
+		request: AdminMilestoneReviewRequest | null
+	}>({ open: false, request: null })
 
 	const [rejectDialog, setRejectDialog] = useState<{
 		open: boolean
@@ -154,11 +189,17 @@ export const MilestoneReviewsQueue = () => {
 		notes: string
 	}>({ open: false, request: null, notes: '' })
 
-	const handleApprove = (request: AdminMilestoneReviewRequest) => {
+	const handleApproveConfirm = () => {
+		if (!approveDialog.request) return
+
 		updateRequest.mutate(
-			{ id: request.id, status: 'approved' },
+			{ id: approveDialog.request.id, status: 'approved' },
 			{
-				onSuccess: () => toast.success('Milestone review approved'),
+				onSuccess: () => {
+					toast.success('Milestone review approved')
+					setApproveDialog({ open: false, request: null })
+					invalidateAdminCounts()
+				},
 				onError: (err: Error) => toast.error(err.message),
 			},
 		)
@@ -177,6 +218,7 @@ export const MilestoneReviewsQueue = () => {
 				onSuccess: () => {
 					toast.success('Milestone review rejected')
 					setRejectDialog({ open: false, request: null, notes: '' })
+					invalidateAdminCounts()
 				},
 				onError: (err: Error) => toast.error(err.message),
 			},
@@ -233,12 +275,41 @@ export const MilestoneReviewsQueue = () => {
 					<ReviewQueueItem
 						key={request.id}
 						request={request}
-						onApprove={handleApprove}
+						onApprove={(item) => setApproveDialog({ open: true, request: item })}
 						onReject={(item) => setRejectDialog({ open: true, request: item, notes: '' })}
 						isUpdating={updateRequest.isPending}
 					/>
 				))}
 			</div>
+
+			<ConfirmActionDialog
+				open={approveDialog.open}
+				onOpenChange={(open) =>
+					setApproveDialog((current) => ({ open, request: open ? current.request : null }))
+				}
+				title="Approve milestone review"
+				description="The owner will be notified. The on-chain release still happens separately in Escrow ops."
+				summary={
+					approveDialog.request
+						? [
+								{ label: 'Project', value: approveDialog.request.projectTitle },
+								{
+									label: 'Release',
+									value: `Release ${approveDialog.request.milestoneIndex + 1}${
+										approveDialog.request.milestoneTitle
+											? `: ${approveDialog.request.milestoneTitle}`
+											: ''
+									}`,
+								},
+								{ label: 'Status change', value: 'pending → approved' },
+							]
+						: undefined
+				}
+				confirmLabel="Approve review"
+				pendingLabel="Approving…"
+				isPending={updateRequest.isPending}
+				onConfirm={handleApproveConfirm}
+			/>
 
 			<Dialog
 				open={rejectDialog.open}

--- a/apps/web/components/sections/admin/nav/admin-breadcrumbs.tsx
+++ b/apps/web/components/sections/admin/nav/admin-breadcrumbs.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import * as React from 'react'
+import {
+	Breadcrumb,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbList,
+	BreadcrumbPage,
+	BreadcrumbSeparator,
+} from '~/components/base/breadcrumb'
+
+const SEGMENT_LABELS: Record<string, string> = {
+	admin: 'Admin',
+	projects: 'Projects',
+	escrows: 'Escrows',
+	'milestone-reviews': 'Milestone Reviews',
+	users: 'Users & KYC',
+	foundations: 'Foundations',
+	governance: 'Governance',
+	gamification: 'Gamification',
+	compliance: 'Compliance',
+	analytics: 'Analytics',
+	settings: 'Settings',
+	create: 'Create',
+}
+
+/**
+ * Breadcrumb trail derived from the current admin path, so admins always
+ * know where they are and can step back up the hierarchy.
+ */
+export function AdminBreadcrumbs() {
+	const pathname = usePathname()
+	const segments = (pathname ?? '').split('/').filter(Boolean)
+
+	if (segments.length <= 1 || segments[0] !== 'admin') return null
+
+	const crumbs = segments.map((segment, index) => ({
+		label: SEGMENT_LABELS[segment] ?? segment,
+		href: `/${segments.slice(0, index + 1).join('/')}`,
+		isLast: index === segments.length - 1,
+	}))
+
+	return (
+		<Breadcrumb>
+			<BreadcrumbList>
+				{crumbs.map((crumb) => (
+					<React.Fragment key={crumb.href}>
+						<BreadcrumbItem>
+							{crumb.isLast ? (
+								<BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+							) : (
+								<BreadcrumbLink href={crumb.href}>{crumb.label}</BreadcrumbLink>
+							)}
+						</BreadcrumbItem>
+						{!crumb.isLast ? <BreadcrumbSeparator /> : null}
+					</React.Fragment>
+				))}
+			</BreadcrumbList>
+		</Breadcrumb>
+	)
+}

--- a/apps/web/components/sections/admin/nav/admin-nav-items.ts
+++ b/apps/web/components/sections/admin/nav/admin-nav-items.ts
@@ -1,0 +1,88 @@
+import type { ComponentType } from 'react'
+import {
+	IoBarChartOutline,
+	IoBusinessOutline,
+	IoEarthOutline,
+	IoFlagOutline,
+	IoFolderOutline,
+	IoGiftOutline,
+	IoHomeOutline,
+	IoPeopleOutline,
+	IoSettingsOutline,
+	IoShieldCheckmarkOutline,
+	IoStatsChartOutline,
+} from 'react-icons/io5'
+import type { AdminDashboardStats } from '~/lib/validators/admin-dashboard-stats'
+
+export interface AdminNavItem {
+	href: string
+	label: string
+	Icon: ComponentType<{ size?: number; className?: string }>
+	/** Derives the pending-work badge count for this destination. */
+	getCount?: (stats: AdminDashboardStats) => number
+}
+
+export interface AdminNavGroup {
+	label: string | null
+	items: AdminNavItem[]
+}
+
+/**
+ * Operations-oriented navigation: work surfaces first, analytics and
+ * configuration last. Badge counts surface pending work per destination.
+ */
+export const ADMIN_NAV_GROUPS: AdminNavGroup[] = [
+	{
+		label: null,
+		items: [{ href: '/admin', label: 'Overview & Queue', Icon: IoHomeOutline }],
+	},
+	{
+		label: 'Operations',
+		items: [
+			{
+				href: '/admin/projects',
+				label: 'Projects',
+				Icon: IoFolderOutline,
+				getCount: (stats) => stats.projects.by_status.review ?? 0,
+			},
+			{
+				href: '/admin/escrows',
+				label: 'Escrows',
+				Icon: IoShieldCheckmarkOutline,
+				getCount: (stats) => stats.escrows.by_state.DISPUTED ?? 0,
+			},
+			{
+				href: '/admin/milestone-reviews',
+				label: 'Milestone Reviews',
+				Icon: IoFlagOutline,
+				getCount: (stats) => stats.milestone_reviews.pending,
+			},
+			{
+				href: '/admin/users',
+				label: 'Users & KYC',
+				Icon: IoPeopleOutline,
+				getCount: (stats) => stats.kyc.pending,
+			},
+			{ href: '/admin/foundations', label: 'Foundations', Icon: IoBusinessOutline },
+		],
+	},
+	{
+		label: 'Platform',
+		items: [
+			{ href: '/admin/governance', label: 'Governance', Icon: IoBarChartOutline },
+			{ href: '/admin/gamification', label: 'Gamification', Icon: IoGiftOutline },
+			{ href: '/admin/compliance', label: 'Compliance', Icon: IoEarthOutline },
+			{ href: '/admin/analytics', label: 'Analytics', Icon: IoStatsChartOutline },
+		],
+	},
+	{
+		label: 'Config',
+		items: [{ href: '/admin/settings', label: 'Settings', Icon: IoSettingsOutline }],
+	},
+]
+
+export function isAdminNavItemActive(pathname: string | null, href: string): boolean {
+	if (!pathname) return false
+	if (href === '/admin') return pathname === '/admin'
+	return pathname === href || pathname.startsWith(`${href}/`)
+}

--- a/apps/web/components/sections/admin/nav/admin-sidebar.tsx
+++ b/apps/web/components/sections/admin/nav/admin-sidebar.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { IoMenuOutline } from 'react-icons/io5'
+import { Badge } from '~/components/base/badge'
+import { Button } from '~/components/base/button'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '~/components/base/sheet'
+import { useAdminCounts } from '~/hooks/admin/use-admin-counts'
+import { cn } from '~/lib/utils'
+import type { AdminDashboardStats } from '~/lib/validators/admin-dashboard-stats'
+import { ADMIN_NAV_GROUPS, type AdminNavItem, isAdminNavItemActive } from './admin-nav-items'
+
+function NavLink({
+	item,
+	isActive,
+	stats,
+}: {
+	item: AdminNavItem
+	isActive: boolean
+	stats: AdminDashboardStats | null
+}) {
+	const count = stats && item.getCount ? item.getCount(stats) : 0
+
+	return (
+		<Link
+			href={item.href}
+			aria-current={isActive ? 'page' : undefined}
+			className={cn(
+				'group flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+				isActive
+					? 'bg-green-800 text-white shadow-sm'
+					: 'text-muted-foreground hover:bg-muted hover:text-foreground',
+			)}
+		>
+			<span
+				className={cn(
+					'flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors',
+					isActive ? 'bg-white/20' : 'bg-muted/80 group-hover:bg-muted',
+				)}
+			>
+				<item.Icon
+					className={cn('h-4 w-4', isActive ? 'opacity-100' : 'opacity-70')}
+					size={16}
+					aria-hidden
+				/>
+			</span>
+			<span className="min-w-0 truncate">{item.label}</span>
+			{count > 0 ? (
+				<Badge
+					variant={isActive ? 'secondary' : 'outline'}
+					className="ml-auto shrink-0 tabular-nums"
+					aria-label={`${count} pending`}
+				>
+					{count > 99 ? '99+' : count}
+				</Badge>
+			) : null}
+		</Link>
+	)
+}
+
+function AdminNavList() {
+	const pathname = usePathname()
+	const { data } = useAdminCounts()
+	const stats = data?.stats ?? null
+
+	return (
+		<nav aria-label="Admin navigation" className="space-y-1">
+			{ADMIN_NAV_GROUPS.map((group) => (
+				<div key={group.label ?? 'root'} className="space-y-1">
+					{group.label ? (
+						<p className="px-3 pb-1.5 pt-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+							{group.label}
+						</p>
+					) : null}
+					<ul className="space-y-0.5">
+						{group.items.map((item) => (
+							<li key={item.href}>
+								<NavLink
+									item={item}
+									isActive={isAdminNavItemActive(pathname, item.href)}
+									stats={stats}
+								/>
+							</li>
+						))}
+					</ul>
+				</div>
+			))}
+		</nav>
+	)
+}
+
+/**
+ * Admin ops navigation.
+ *
+ * Desktop: sticky sidebar. Mobile: a compact bar with a menu button that
+ * opens the navigation in a sheet — the nav no longer stacks above the page
+ * content on small screens.
+ */
+export function AdminSidebar() {
+	const pathname = usePathname()
+	const [mobileOpen, setMobileOpen] = useState(false)
+
+	// Close the sheet after navigating.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the navigation signal
+	useEffect(() => {
+		setMobileOpen(false)
+	}, [pathname])
+
+	const activeItem = ADMIN_NAV_GROUPS.flatMap((group) => group.items).find((item) =>
+		isAdminNavItemActive(pathname, item.href),
+	)
+
+	return (
+		<>
+			{/* Mobile: compact bar + sheet */}
+			<div className="flex items-center justify-between gap-2 rounded-xl border border-border/60 bg-card p-2 shadow-sm lg:hidden">
+				<p className="truncate px-2 text-sm font-semibold">{activeItem?.label ?? 'Admin'}</p>
+				<Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+					<SheetTrigger asChild>
+						<Button type="button" variant="outline" size="sm" aria-label="Open admin navigation">
+							<IoMenuOutline className="mr-1.5 h-4 w-4" aria-hidden />
+							Menu
+						</Button>
+					</SheetTrigger>
+					<SheetContent side="left" className="w-72 overflow-y-auto p-4">
+						<SheetHeader className="pb-2 text-left">
+							<SheetTitle>Admin</SheetTitle>
+						</SheetHeader>
+						<AdminNavList />
+					</SheetContent>
+				</Sheet>
+			</div>
+
+			{/* Desktop: sticky sidebar */}
+			<aside
+				className="hidden w-full shrink-0 lg:sticky lg:top-6 lg:block lg:w-60 lg:self-start"
+				aria-label="Admin navigation"
+			>
+				<div className="rounded-xl border border-border/60 bg-card p-4 shadow-sm">
+					<AdminNavList />
+				</div>
+			</aside>
+		</>
+	)
+}

--- a/apps/web/components/sections/admin/projects/admin-projects-page.tsx
+++ b/apps/web/components/sections/admin/projects/admin-projects-page.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname, useSearchParams } from 'next/navigation'
+import { useRef } from 'react'
+import { Button } from '~/components/base/button'
+import { AdminSectionHeader } from '~/components/sections/admin/admin-section-header'
+import { AdminListShell } from '~/components/sections/admin/shared/admin-list-shell'
+import { useAdminListParams } from '~/hooks/admin/use-admin-list-params'
+import { useAdminQuery } from '~/hooks/admin/use-admin-query'
+import type {
+	AdminProjectFilterOptions,
+	AdminProjectListItem,
+} from '~/lib/queries/admin/get-admin-projects'
+import type { AdminListResponse } from '~/lib/validators/admin-list-params'
+import { adminProjectsQuerySchema } from '~/lib/validators/admin-list-params'
+import { ProjectFilters } from './project-filters'
+import { ProjectRowCard } from './project-row-card'
+
+type ProjectsResponse = AdminListResponse<AdminProjectListItem> & {
+	filterOptions?: AdminProjectFilterOptions
+}
+
+export function AdminProjectsPage() {
+	const pathname = usePathname()
+	const searchParams = useSearchParams()
+	const from = searchParams.size > 0 ? `${pathname}?${searchParams.toString()}` : pathname
+
+	const { params, normalizedParams, setParam, setPage, resetFilters } =
+		useAdminListParams(adminProjectsQuerySchema)
+
+	const { data, isLoading, isError, refetch } = useAdminQuery<ProjectsResponse>('projects', {
+		params: normalizedParams,
+	})
+
+	// filterOptions only ship with page 1; keep the last seen set.
+	const filterOptionsRef = useRef<AdminProjectFilterOptions | null>(null)
+	if (data?.filterOptions) {
+		filterOptionsRef.current = data.filterOptions
+	}
+
+	const hasActiveFilters = Object.keys(normalizedParams).some(
+		(key) => !['page', 'pageSize', 'sort'].includes(key),
+	)
+
+	return (
+		<div className="space-y-6">
+			<AdminSectionHeader
+				title="Projects"
+				description="Search, review, and manage every campaign. Filters are stored in the URL so views can be bookmarked and shared."
+			>
+				<Button asChild variant="outline">
+					<Link href="/admin/projects/create">Create dev project</Link>
+				</Button>
+			</AdminSectionHeader>
+
+			<AdminListShell
+				searchValue={params.q ?? ''}
+				onSearchChange={(value) => setParam('q', value || undefined)}
+				searchPlaceholder="Search by title, slug, creator, foundation, or ID…"
+				filters={
+					<ProjectFilters
+						values={{
+							status: params.status,
+							escrow: params.escrow,
+							category: params.category,
+							foundation: params.foundation,
+							devOnly: params.devOnly,
+							sort: params.sort,
+						}}
+						options={filterOptionsRef.current}
+						onChange={setParam}
+					/>
+				}
+				isLoading={isLoading}
+				isError={isError}
+				onRetry={() => refetch()}
+				total={data?.total ?? 0}
+				page={params.page}
+				pageSize={params.pageSize}
+				onPageChange={setPage}
+				emptyTitle="No projects yet"
+				emptyDescription="Projects appear here as soon as creators start campaigns."
+				hasActiveFilters={hasActiveFilters}
+				onResetFilters={resetFilters}
+				skeletonRowHeight={148}
+			>
+				<ul className="space-y-3">
+					{(data?.items ?? []).map((project) => (
+						<li key={project.id}>
+							<ProjectRowCard project={project} from={from} />
+						</li>
+					))}
+				</ul>
+			</AdminListShell>
+		</div>
+	)
+}

--- a/apps/web/components/sections/admin/projects/admin-projects-page.tsx
+++ b/apps/web/components/sections/admin/projects/admin-projects-page.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link'
 import { usePathname, useSearchParams } from 'next/navigation'
-import { useRef } from 'react'
 import { Button } from '~/components/base/button'
 import { AdminSectionHeader } from '~/components/sections/admin/admin-section-header'
 import { AdminListShell } from '~/components/sections/admin/shared/admin-list-shell'
@@ -33,11 +32,7 @@ export function AdminProjectsPage() {
 		params: normalizedParams,
 	})
 
-	// filterOptions only ship with page 1; keep the last seen set.
-	const filterOptionsRef = useRef<AdminProjectFilterOptions | null>(null)
-	if (data?.filterOptions) {
-		filterOptionsRef.current = data.filterOptions
-	}
+	const filterOptions = data?.filterOptions ?? null
 
 	const hasActiveFilters = Object.keys(normalizedParams).some(
 		(key) => !['page', 'pageSize', 'sort'].includes(key),
@@ -68,7 +63,7 @@ export function AdminProjectsPage() {
 							devOnly: params.devOnly,
 							sort: params.sort,
 						}}
-						options={filterOptionsRef.current}
+						options={filterOptions}
 						onChange={setParam}
 					/>
 				}

--- a/apps/web/components/sections/admin/projects/project-filters.tsx
+++ b/apps/web/components/sections/admin/projects/project-filters.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useId } from 'react'
+import { Label } from '~/components/base/label'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '~/components/base/select'
+import type { AdminProjectFilterOptions } from '~/lib/queries/admin/get-admin-projects'
+import {
+	ESCROW_STATE_FILTERS,
+	PROJECT_SORT_OPTIONS,
+	PROJECT_STATUS_FILTERS,
+} from '~/lib/validators/admin-list-params'
+
+const ALL = 'all'
+
+const STATUS_LABELS: Record<string, string> = {
+	draft: 'Draft',
+	review: 'In review',
+	active: 'Active',
+	paused: 'Paused',
+	funded: 'Funded',
+	rejected: 'Rejected',
+}
+
+const SORT_LABELS: Record<(typeof PROJECT_SORT_OPTIONS)[number], string> = {
+	newest: 'Newest first',
+	oldest: 'Oldest first',
+	funding: 'Most funded',
+	target: 'Highest target',
+	status: 'By status',
+}
+
+interface FilterSelectProps {
+	label: string
+	value: string
+	onChange: (value: string | undefined) => void
+	options: Array<{ value: string; label: string }>
+	allLabel: string
+}
+
+function FilterSelect({ label, value, onChange, options, allLabel }: FilterSelectProps) {
+	const id = useId()
+	return (
+		<div className="flex items-center gap-1.5">
+			<Label htmlFor={id} className="sr-only">
+				{label}
+			</Label>
+			<Select
+				value={value || ALL}
+				onValueChange={(next) => onChange(next === ALL ? undefined : next)}
+			>
+				<SelectTrigger id={id} className="h-9 w-auto min-w-32 gap-1" aria-label={label}>
+					<SelectValue placeholder={allLabel} />
+				</SelectTrigger>
+				<SelectContent>
+					<SelectItem value={ALL}>{allLabel}</SelectItem>
+					{options.map((option) => (
+						<SelectItem key={option.value} value={option.value}>
+							{option.label}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+		</div>
+	)
+}
+
+interface ProjectFiltersProps {
+	values: {
+		status?: string
+		escrow?: string
+		category?: string
+		foundation?: string
+		devOnly?: string
+		sort: string
+	}
+	options: AdminProjectFilterOptions | null
+	onChange: (key: string, value: string | undefined) => void
+}
+
+export function ProjectFilters({ values, options, onChange }: ProjectFiltersProps) {
+	return (
+		<>
+			<FilterSelect
+				label="Filter by status"
+				allLabel="All statuses"
+				value={values.status ?? ''}
+				onChange={(value) => onChange('status', value)}
+				options={PROJECT_STATUS_FILTERS.map((status) => ({
+					value: status,
+					label: STATUS_LABELS[status] ?? status,
+				}))}
+			/>
+			<FilterSelect
+				label="Filter by escrow"
+				allLabel="Any escrow state"
+				value={values.escrow ?? ''}
+				onChange={(value) => onChange('escrow', value)}
+				options={[
+					{ value: 'none', label: 'No escrow' },
+					{ value: 'any', label: 'Has escrow' },
+					...ESCROW_STATE_FILTERS.map((state) => ({ value: state, label: `Escrow ${state}` })),
+				]}
+			/>
+			<FilterSelect
+				label="Filter by category"
+				allLabel="All categories"
+				value={values.category ?? ''}
+				onChange={(value) => onChange('category', value)}
+				options={(options?.categories ?? [])
+					.filter((category) => category.slug)
+					.map((category) => ({ value: category.slug as string, label: category.name }))}
+			/>
+			<FilterSelect
+				label="Filter by foundation"
+				allLabel="All foundations"
+				value={values.foundation ?? ''}
+				onChange={(value) => onChange('foundation', value)}
+				options={(options?.foundations ?? []).map((foundation) => ({
+					value: foundation.slug,
+					label: foundation.name,
+				}))}
+			/>
+			<FilterSelect
+				label="Filter by visibility"
+				allLabel="All projects"
+				value={values.devOnly ?? ''}
+				onChange={(value) => onChange('devOnly', value)}
+				options={[
+					{ value: 'true', label: 'Development only' },
+					{ value: 'false', label: 'Public projects' },
+				]}
+			/>
+			<FilterSelect
+				label="Sort projects"
+				allLabel="Newest first"
+				value={values.sort === 'newest' ? '' : values.sort}
+				onChange={(value) => onChange('sort', value ?? 'newest')}
+				options={PROJECT_SORT_OPTIONS.filter((sort) => sort !== 'newest').map((sort) => ({
+					value: sort,
+					label: SORT_LABELS[sort],
+				}))}
+			/>
+		</>
+	)
+}

--- a/apps/web/components/sections/admin/projects/project-row-card.tsx
+++ b/apps/web/components/sections/admin/projects/project-row-card.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { formatDistanceToNow } from 'date-fns'
+import Image from 'next/image'
+import Link from 'next/link'
+import { Badge } from '~/components/base/badge'
+import { Button } from '~/components/base/button'
+import { Card } from '~/components/base/card'
+import { formatCurrency } from '~/components/sections/admin/admin-overview/formatters'
+import { AdminStatusBadge } from '~/components/sections/admin/shared/admin-status-badge'
+import { getProjectPrimaryAction } from '~/lib/admin/project-actions'
+import type { AdminProjectListItem } from '~/lib/queries/admin/get-admin-projects'
+
+interface ProjectRowCardProps {
+	project: AdminProjectListItem
+	/** Current admin URL (path + search) used as the back-link target. */
+	from: string
+}
+
+function withFrom(href: string, from: string): string {
+	if (!href.startsWith('/projects/')) return href
+	const separator = href.includes('?') ? '&' : '?'
+	return `${href}${separator}from=${encodeURIComponent(from)}`
+}
+
+export function ProjectRowCard({ project, from }: ProjectRowCardProps) {
+	const primaryAction = getProjectPrimaryAction({
+		status: project.status,
+		slug: project.slug,
+		hasEscrow: project.escrow !== null,
+	})
+	const fundingPercent =
+		project.targetAmount > 0
+			? Math.min(100, Math.round((project.currentAmount / project.targetAmount) * 100))
+			: 0
+	const creatorLabel = project.foundation?.name ?? project.creator?.displayName ?? null
+
+	return (
+		<Card className="overflow-hidden">
+			<div className="flex flex-col sm:flex-row">
+				<div className="relative h-36 w-full shrink-0 sm:h-auto sm:w-40 md:w-48">
+					{project.imageUrl ? (
+						<Image
+							src={project.imageUrl}
+							alt={`${project.title} cover image`}
+							fill
+							className="object-cover"
+							sizes="(max-width: 640px) 100vw, 192px"
+							loading="lazy"
+						/>
+					) : (
+						<div
+							aria-hidden="true"
+							className="flex h-full min-h-24 w-full items-center justify-center bg-gradient-to-br from-emerald-100 to-teal-200 text-2xl font-semibold text-emerald-700"
+						>
+							{project.title.slice(0, 1).toUpperCase()}
+						</div>
+					)}
+				</div>
+
+				<div className="flex min-w-0 flex-1 flex-col gap-3 p-4">
+					<div className="flex flex-wrap items-start justify-between gap-2">
+						<div className="min-w-0">
+							<div className="flex flex-wrap items-center gap-2">
+								<h3 className="truncate font-semibold">{project.title}</h3>
+								<AdminStatusBadge kind="project" status={project.status} />
+								<AdminStatusBadge kind="escrow" status={project.escrow?.state ?? 'none'} />
+								{project.developmentOnly ? (
+									<Badge variant="outline" className="border-amber-300 text-amber-700">
+										Development only
+									</Badge>
+								) : null}
+							</div>
+							<p className="mt-1 flex flex-wrap items-center gap-x-2 text-sm text-muted-foreground">
+								{creatorLabel ? <span className="truncate">{creatorLabel}</span> : null}
+								{project.category ? (
+									<>
+										<span aria-hidden="true">·</span>
+										<span>{project.category.name}</span>
+									</>
+								) : null}
+								{project.location ? (
+									<>
+										<span aria-hidden="true">·</span>
+										<span>{project.location}</span>
+									</>
+								) : null}
+								{project.createdAt ? (
+									<>
+										<span aria-hidden="true">·</span>
+										<span>
+											Created{' '}
+											<time dateTime={project.createdAt}>
+												{formatDistanceToNow(new Date(project.createdAt))} ago
+											</time>
+										</span>
+									</>
+								) : null}
+							</p>
+						</div>
+
+						<div className="flex shrink-0 items-center gap-2">
+							{project.slug ? (
+								<Button asChild variant="ghost" size="sm">
+									<Link href={`/projects/${project.slug}`}>View public page</Link>
+								</Button>
+							) : null}
+							<Button asChild variant="outline" size="sm">
+								<Link href={withFrom(primaryAction.href, from)}>{primaryAction.label}</Link>
+							</Button>
+						</div>
+					</div>
+
+					<div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
+						<div className="min-w-40 flex-1">
+							<div className="flex justify-between text-xs text-muted-foreground">
+								<span>
+									{formatCurrency(project.currentAmount)} of {formatCurrency(project.targetAmount)}
+								</span>
+								<span>{fundingPercent}%</span>
+							</div>
+							<div
+								role="progressbar"
+								aria-valuenow={fundingPercent}
+								aria-valuemin={0}
+								aria-valuemax={100}
+								aria-label={`Funding progress ${fundingPercent}%`}
+								className="mt-1 h-2 overflow-hidden rounded-full bg-muted"
+							>
+								<div
+									className="h-full rounded-full bg-emerald-500"
+									style={{ width: `${fundingPercent}%` }}
+								/>
+							</div>
+						</div>
+						<p className="shrink-0 text-muted-foreground">
+							{project.kinderCount.toLocaleString('en-US')}{' '}
+							{project.kinderCount === 1 ? 'supporter' : 'supporters'}
+						</p>
+					</div>
+				</div>
+			</div>
+		</Card>
+	)
+}

--- a/apps/web/components/sections/admin/shared/admin-list-shell.tsx
+++ b/apps/web/components/sections/admin/shared/admin-list-shell.tsx
@@ -85,6 +85,8 @@ export function AdminListShell({
 
 	const pageCount = Math.max(1, Math.ceil(total / pageSize))
 	const isEmpty = !isLoading && !isError && total === 0
+	// A bookmarked URL can request a page beyond the current result set.
+	const isPageOutOfRange = !isLoading && !isError && total > 0 && page > pageCount
 
 	return (
 		<div className="space-y-4">
@@ -136,6 +138,16 @@ export function AdminListShell({
 						/>
 					))}
 				</output>
+			) : isPageOutOfRange ? (
+				<div className="flex flex-col items-center gap-2 rounded-lg border border-dashed p-10 text-center">
+					<p className="font-medium">Page {page} is out of range</p>
+					<p className="text-sm text-muted-foreground">
+						These results only have {pageCount} {pageCount === 1 ? 'page' : 'pages'}.
+					</p>
+					<Button type="button" variant="outline" size="sm" onClick={() => onPageChange(pageCount)}>
+						Go to page {pageCount}
+					</Button>
+				</div>
 			) : isEmpty ? (
 				<div className="flex flex-col items-center gap-2 rounded-lg border border-dashed p-10 text-center">
 					<p className="font-medium">{emptyTitle}</p>

--- a/apps/web/components/sections/admin/shared/admin-list-shell.tsx
+++ b/apps/web/components/sections/admin/shared/admin-list-shell.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { ChevronLeft, ChevronRight, RotateCcw, Search } from 'lucide-react'
+import { type ReactNode, useEffect, useId, useRef, useState } from 'react'
+import { Button } from '~/components/base/button'
+import { Input } from '~/components/base/input'
+import { Skeleton } from '~/components/base/skeleton'
+
+const SEARCH_DEBOUNCE_MS = 300
+
+interface AdminListShellProps {
+	/** Current search value from the URL params. */
+	searchValue: string
+	onSearchChange: (value: string) => void
+	searchPlaceholder?: string
+	/** Filter and sort controls rendered next to the search input. */
+	filters?: ReactNode
+	isLoading: boolean
+	isError: boolean
+	onRetry: () => void
+	total: number
+	page: number
+	pageSize: number
+	onPageChange: (page: number) => void
+	emptyTitle: string
+	emptyDescription: string
+	/** Whether any filter/search is active, to explain empty states. */
+	hasActiveFilters?: boolean
+	onResetFilters?: () => void
+	skeletonRowHeight?: number
+	children: ReactNode
+}
+
+/**
+ * Shared chrome for admin list surfaces: debounced search, filter slot,
+ * result count, layout-preserving loading state, empty and error states with
+ * a retry path, and pagination. Keeps every admin list consistent.
+ */
+export function AdminListShell({
+	searchValue,
+	onSearchChange,
+	searchPlaceholder = 'Search…',
+	filters,
+	isLoading,
+	isError,
+	onRetry,
+	total,
+	page,
+	pageSize,
+	onPageChange,
+	emptyTitle,
+	emptyDescription,
+	hasActiveFilters = false,
+	onResetFilters,
+	skeletonRowHeight = 88,
+	children,
+}: AdminListShellProps) {
+	const searchInputId = useId()
+	const [searchDraft, setSearchDraft] = useState(searchValue)
+	const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const lastSubmitted = useRef(searchValue)
+
+	// Keep the draft in sync when the URL changes externally (back/forward).
+	useEffect(() => {
+		if (searchValue !== lastSubmitted.current) {
+			lastSubmitted.current = searchValue
+			setSearchDraft(searchValue)
+		}
+	}, [searchValue])
+
+	useEffect(() => {
+		return () => {
+			if (debounceTimer.current) clearTimeout(debounceTimer.current)
+		}
+	}, [])
+
+	const handleSearchInput = (value: string) => {
+		setSearchDraft(value)
+		if (debounceTimer.current) clearTimeout(debounceTimer.current)
+		debounceTimer.current = setTimeout(() => {
+			lastSubmitted.current = value
+			onSearchChange(value)
+		}, SEARCH_DEBOUNCE_MS)
+	}
+
+	const pageCount = Math.max(1, Math.ceil(total / pageSize))
+	const isEmpty = !isLoading && !isError && total === 0
+
+	return (
+		<div className="space-y-4">
+			<div className="flex flex-col gap-3 md:flex-row md:items-center">
+				<div className="relative w-full md:max-w-sm">
+					<Search
+						className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+						aria-hidden="true"
+					/>
+					<label htmlFor={searchInputId} className="sr-only">
+						{searchPlaceholder}
+					</label>
+					<Input
+						id={searchInputId}
+						type="search"
+						value={searchDraft}
+						onChange={(event) => handleSearchInput(event.target.value)}
+						placeholder={searchPlaceholder}
+						className="pl-9"
+					/>
+				</div>
+				{filters ? <div className="flex flex-wrap items-center gap-2">{filters}</div> : null}
+			</div>
+
+			{!isLoading && !isError ? (
+				<p className="text-sm text-muted-foreground" aria-live="polite">
+					{total === 1 ? '1 result' : `${total.toLocaleString('en-US')} results`}
+				</p>
+			) : null}
+
+			{isError ? (
+				<div
+					role="alert"
+					className="flex flex-col items-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-8 text-center"
+				>
+					<p className="font-medium">Something went wrong while loading this list.</p>
+					<Button type="button" variant="outline" onClick={onRetry}>
+						<RotateCcw className="mr-2 h-4 w-4" aria-hidden="true" />
+						Retry
+					</Button>
+				</div>
+			) : isLoading ? (
+				<output aria-label="Loading results" className="block space-y-3">
+					{['a', 'b', 'c', 'd', 'e'].map((key) => (
+						<Skeleton
+							key={key}
+							className="w-full rounded-lg"
+							style={{ height: skeletonRowHeight }}
+						/>
+					))}
+				</output>
+			) : isEmpty ? (
+				<div className="flex flex-col items-center gap-2 rounded-lg border border-dashed p-10 text-center">
+					<p className="font-medium">{emptyTitle}</p>
+					<p className="text-sm text-muted-foreground">
+						{hasActiveFilters
+							? 'No records match the current filters. Try adjusting or clearing them.'
+							: emptyDescription}
+					</p>
+					{hasActiveFilters && onResetFilters ? (
+						<Button type="button" variant="outline" size="sm" onClick={onResetFilters}>
+							Clear filters
+						</Button>
+					) : null}
+				</div>
+			) : (
+				<>
+					{children}
+					{pageCount > 1 ? (
+						<nav
+							aria-label="Pagination"
+							className="flex items-center justify-between gap-4 border-t pt-4"
+						>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => onPageChange(page - 1)}
+								disabled={page <= 1}
+							>
+								<ChevronLeft className="mr-1 h-4 w-4" aria-hidden="true" />
+								Previous
+							</Button>
+							<p className="text-sm text-muted-foreground">
+								Page {page} of {pageCount}
+							</p>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => onPageChange(page + 1)}
+								disabled={page >= pageCount}
+							>
+								Next
+								<ChevronRight className="ml-1 h-4 w-4" aria-hidden="true" />
+							</Button>
+						</nav>
+					) : null}
+				</>
+			)}
+		</div>
+	)
+}

--- a/apps/web/components/sections/admin/shared/admin-status-badge.tsx
+++ b/apps/web/components/sections/admin/shared/admin-status-badge.tsx
@@ -1,0 +1,81 @@
+import { Badge } from '~/components/base/badge'
+import { cn } from '~/lib/utils'
+
+export type AdminStatusKind = 'project' | 'escrow' | 'kyc' | 'review' | 'role' | 'priority'
+
+interface StatusStyle {
+	label: string
+	className: string
+}
+
+/**
+ * Single source of truth for admin status presentation. Every badge renders
+ * a text label (status never relies on color alone) with a consistent color
+ * treatment across projects, escrows, KYC, milestone reviews, and roles.
+ */
+const STATUS_STYLES: Record<AdminStatusKind, Record<string, StatusStyle>> = {
+	project: {
+		draft: { label: 'Draft', className: 'bg-gray-100 text-gray-800' },
+		review: { label: 'In review', className: 'bg-yellow-100 text-yellow-800' },
+		active: { label: 'Active', className: 'bg-green-200 text-green-800' },
+		paused: { label: 'Paused', className: 'bg-orange-100 text-orange-800' },
+		funded: { label: 'Funded', className: 'bg-purple-100 text-purple-800' },
+		rejected: { label: 'Rejected', className: 'bg-red-100 text-red-800' },
+	},
+	escrow: {
+		NEW: { label: 'New', className: 'bg-gray-100 text-gray-800' },
+		FUNDED: { label: 'Funded', className: 'bg-blue-100 text-blue-800' },
+		ACTIVE: { label: 'Active', className: 'bg-green-200 text-green-800' },
+		COMPLETED: { label: 'Completed', className: 'bg-purple-100 text-purple-800' },
+		DISPUTED: { label: 'Disputed', className: 'bg-red-100 text-red-800' },
+		CANCELLED: { label: 'Cancelled', className: 'bg-orange-100 text-orange-800' },
+		none: { label: 'No escrow', className: 'bg-gray-100 text-gray-600' },
+	},
+	kyc: {
+		not_started: { label: 'KYC not started', className: 'bg-gray-100 text-gray-600' },
+		pending: { label: 'KYC pending', className: 'bg-yellow-100 text-yellow-800' },
+		approved: { label: 'KYC approved', className: 'bg-green-200 text-green-800' },
+		verified: { label: 'KYC verified', className: 'bg-green-200 text-green-800' },
+		rejected: { label: 'KYC rejected', className: 'bg-red-100 text-red-800' },
+		unknown: { label: 'KYC unknown', className: 'bg-orange-100 text-orange-800' },
+	},
+	review: {
+		pending: { label: 'Pending', className: 'bg-yellow-100 text-yellow-800' },
+		approved: { label: 'Approved', className: 'bg-green-200 text-green-800' },
+		rejected: { label: 'Rejected', className: 'bg-red-100 text-red-800' },
+	},
+	role: {
+		admin: { label: 'Admin', className: 'bg-red-100 text-red-800' },
+		creator: { label: 'Creator', className: 'bg-purple-100 text-purple-800' },
+		donor: { label: 'Donor', className: 'bg-blue-100 text-blue-800' },
+		kinder: { label: 'Kinder', className: 'bg-green-200 text-green-800' },
+		kindler: { label: 'Kindler', className: 'bg-yellow-100 text-yellow-800' },
+		pending: { label: 'Pending', className: 'bg-gray-100 text-gray-800' },
+	},
+	priority: {
+		high: { label: 'High priority', className: 'bg-red-100 text-red-800' },
+		medium: { label: 'Medium priority', className: 'bg-yellow-100 text-yellow-800' },
+		low: { label: 'Low priority', className: 'bg-gray-100 text-gray-700' },
+	},
+}
+
+const FALLBACK_STYLE: StatusStyle = { label: 'Unknown', className: 'bg-gray-100 text-gray-800' }
+
+export function getAdminStatusLabel(kind: AdminStatusKind, status: string): string {
+	return STATUS_STYLES[kind][status]?.label ?? status
+}
+
+interface AdminStatusBadgeProps {
+	kind: AdminStatusKind
+	status: string
+	className?: string
+}
+
+export function AdminStatusBadge({ kind, status, className }: AdminStatusBadgeProps) {
+	const style = STATUS_STYLES[kind][status] ?? { ...FALLBACK_STYLE, label: status }
+	return (
+		<Badge variant="outline" className={cn('border-transparent', style.className, className)}>
+			{style.label}
+		</Badge>
+	)
+}

--- a/apps/web/components/sections/admin/shared/confirm-action-dialog.tsx
+++ b/apps/web/components/sections/admin/shared/confirm-action-dialog.tsx
@@ -30,10 +30,13 @@ interface ConfirmActionDialogProps {
 	/**
 	 * For blockchain mutations: the active Stellar network and the signer
 	 * that will be asked to sign, shown before anything is submitted.
+	 * `signerLabel` describes non-wallet signers (e.g. the platform service
+	 * account that signs server-side).
 	 */
 	blockchain?: {
 		networkId: string
 		signerAddress?: string | null
+		signerLabel?: string
 		requiredSigner?: string | null
 	}
 	confirmLabel: string
@@ -110,6 +113,11 @@ export function ConfirmActionDialog({
 							<div className="flex items-center justify-between gap-4">
 								<span className="text-muted-foreground">Connected signer</span>
 								<TruncatedId value={blockchain.signerAddress} />
+							</div>
+						) : blockchain.signerLabel ? (
+							<div className="flex items-center justify-between gap-4">
+								<span className="text-muted-foreground">Signer</span>
+								<span className="font-medium">{blockchain.signerLabel}</span>
 							</div>
 						) : null}
 						{blockchain.requiredSigner ? (

--- a/apps/web/components/sections/admin/shared/confirm-action-dialog.tsx
+++ b/apps/web/components/sections/admin/shared/confirm-action-dialog.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { Loader2 } from 'lucide-react'
+import type { ReactNode } from 'react'
+import {
+	AlertDialog,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from '~/components/base/alert-dialog'
+import { Badge } from '~/components/base/badge'
+import { Button } from '~/components/base/button'
+import { TruncatedId } from '~/components/sections/admin/shared/truncated-id'
+
+export interface ConfirmActionSummaryRow {
+	label: string
+	value: ReactNode
+}
+
+interface ConfirmActionDialogProps {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+	title: string
+	description?: string
+	/** Structured summary: entity, current state → new state, amounts, etc. */
+	summary?: ConfirmActionSummaryRow[]
+	/**
+	 * For blockchain mutations: the active Stellar network and the signer
+	 * that will be asked to sign, shown before anything is submitted.
+	 */
+	blockchain?: {
+		networkId: string
+		signerAddress?: string | null
+		requiredSigner?: string | null
+	}
+	confirmLabel: string
+	pendingLabel?: string
+	/** Prevents duplicate submissions while the action is in flight. */
+	isPending: boolean
+	destructive?: boolean
+	onConfirm: () => void
+	children?: ReactNode
+}
+
+/**
+ * Shared confirmation dialog for high-impact admin actions. Shows a clear
+ * summary of what is about to happen; blockchain actions additionally show
+ * the active network and connected signer. The confirm button is disabled
+ * while the action is pending, so a double click cannot submit twice.
+ */
+export function ConfirmActionDialog({
+	open,
+	onOpenChange,
+	title,
+	description,
+	summary,
+	blockchain,
+	confirmLabel,
+	pendingLabel = 'Working…',
+	isPending,
+	destructive = false,
+	onConfirm,
+	children,
+}: ConfirmActionDialogProps) {
+	return (
+		<AlertDialog
+			open={open}
+			onOpenChange={(next) => {
+				// The dialog cannot be dismissed while the action is running.
+				if (isPending && !next) return
+				onOpenChange(next)
+			}}
+		>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>{title}</AlertDialogTitle>
+					{description ? <AlertDialogDescription>{description}</AlertDialogDescription> : null}
+				</AlertDialogHeader>
+
+				{summary && summary.length > 0 ? (
+					<dl className="space-y-2 rounded-md border bg-muted/40 p-3 text-sm">
+						{summary.map((row) => (
+							<div key={row.label} className="flex items-start justify-between gap-4">
+								<dt className="shrink-0 text-muted-foreground">{row.label}</dt>
+								<dd className="min-w-0 text-right font-medium">{row.value}</dd>
+							</div>
+						))}
+					</dl>
+				) : null}
+
+				{blockchain ? (
+					<div className="space-y-2 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm">
+						<div className="flex items-center justify-between gap-4">
+							<span className="text-muted-foreground">Stellar network</span>
+							<Badge
+								variant="outline"
+								className={
+									blockchain.networkId === 'mainnet'
+										? 'border-red-300 bg-red-50 text-red-700'
+										: 'border-blue-300 bg-blue-100 text-blue-800'
+								}
+							>
+								{blockchain.networkId === 'mainnet' ? 'Mainnet' : 'Testnet'}
+							</Badge>
+						</div>
+						{blockchain.signerAddress ? (
+							<div className="flex items-center justify-between gap-4">
+								<span className="text-muted-foreground">Connected signer</span>
+								<TruncatedId value={blockchain.signerAddress} />
+							</div>
+						) : null}
+						{blockchain.requiredSigner ? (
+							<div className="flex items-center justify-between gap-4">
+								<span className="text-muted-foreground">Required signer</span>
+								<TruncatedId value={blockchain.requiredSigner} />
+							</div>
+						) : null}
+						<p className="text-xs text-muted-foreground">
+							Nothing is signed or submitted until you confirm.
+						</p>
+					</div>
+				) : null}
+
+				{children}
+
+				<AlertDialogFooter>
+					<AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+					<Button
+						type="button"
+						variant={destructive ? 'destructive' : 'default'}
+						onClick={onConfirm}
+						disabled={isPending}
+					>
+						{isPending ? (
+							<>
+								<Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+								{pendingLabel}
+							</>
+						) : (
+							confirmLabel
+						)}
+					</Button>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	)
+}

--- a/apps/web/components/sections/admin/shared/confirm-action-dialog.tsx
+++ b/apps/web/components/sections/admin/shared/confirm-action-dialog.tsx
@@ -136,7 +136,10 @@ export function ConfirmActionDialog({
 					>
 						{isPending ? (
 							<>
-								<Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+								<Loader2
+									className="mr-2 h-4 w-4 animate-spin motion-reduce:animate-none"
+									aria-hidden="true"
+								/>
 								{pendingLabel}
 							</>
 						) : (

--- a/apps/web/components/sections/admin/shared/copy-button.tsx
+++ b/apps/web/components/sections/admin/shared/copy-button.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { Check, Copy } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '~/components/base/button'
+import { cn } from '~/lib/utils'
+
+interface CopyButtonProps {
+	value: string
+	/** Accessible name describing what gets copied, e.g. "Copy contract address". */
+	label: string
+	className?: string
+}
+
+/**
+ * Icon-only copy-to-clipboard button with an accessible name and visible
+ * copied feedback.
+ */
+export function CopyButton({ value, label, className }: CopyButtonProps) {
+	const [copied, setCopied] = useState(false)
+	const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+	useEffect(() => {
+		return () => {
+			if (resetTimer.current) clearTimeout(resetTimer.current)
+		}
+	}, [])
+
+	const handleCopy = useCallback(async () => {
+		try {
+			await navigator.clipboard.writeText(value)
+			setCopied(true)
+			if (resetTimer.current) clearTimeout(resetTimer.current)
+			resetTimer.current = setTimeout(() => setCopied(false), 2000)
+		} catch {
+			toast.error('Could not copy to clipboard')
+		}
+	}, [value])
+
+	return (
+		<Button
+			type="button"
+			variant="ghost"
+			size="icon"
+			className={cn('h-7 w-7 shrink-0', className)}
+			onClick={handleCopy}
+			aria-label={copied ? 'Copied' : label}
+		>
+			{copied ? (
+				<Check className="h-3.5 w-3.5 text-green-600" aria-hidden="true" />
+			) : (
+				<Copy className="h-3.5 w-3.5" aria-hidden="true" />
+			)}
+			<span aria-live="polite" className="sr-only">
+				{copied ? 'Copied to clipboard' : ''}
+			</span>
+		</Button>
+	)
+}

--- a/apps/web/components/sections/admin/shared/truncated-id.tsx
+++ b/apps/web/components/sections/admin/shared/truncated-id.tsx
@@ -1,0 +1,30 @@
+import { cn } from '~/lib/utils'
+import { CopyButton } from './copy-button'
+
+interface TruncatedIdProps {
+	value: string
+	/** Accessible name for the copy control, e.g. "Copy contract address". */
+	copyLabel?: string
+	className?: string
+}
+
+function truncateMiddle(value: string, visible = 6): string {
+	if (value.length <= visible * 2 + 1) return value
+	return `${value.slice(0, visible)}…${value.slice(-visible)}`
+}
+
+/**
+ * Middle-truncated identifier (contract address, tx hash, UUID) that never
+ * breaks layouts. The full value stays available via `title` and the
+ * optional copy control.
+ */
+export function TruncatedId({ value, copyLabel, className }: TruncatedIdProps) {
+	return (
+		<span className={cn('inline-flex min-w-0 items-center gap-1', className)}>
+			<span className="truncate font-mono text-xs" title={value}>
+				{truncateMiddle(value)}
+			</span>
+			{copyLabel ? <CopyButton value={value} label={copyLabel} /> : null}
+		</span>
+	)
+}

--- a/apps/web/components/sections/admin/users/admin-users-page.tsx
+++ b/apps/web/components/sections/admin/users/admin-users-page.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import { useId } from 'react'
+import { Label } from '~/components/base/label'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '~/components/base/select'
+import { AdminSectionHeader } from '~/components/sections/admin/admin-section-header'
+import { AdminListShell } from '~/components/sections/admin/shared/admin-list-shell'
+import { useAdminListParams } from '~/hooks/admin/use-admin-list-params'
+import { useAdminQuery } from '~/hooks/admin/use-admin-query'
+import type { AdminUserListItem } from '~/lib/queries/admin/get-admin-users'
+import type { AdminListResponse } from '~/lib/validators/admin-list-params'
+import {
+	adminUsersQuerySchema,
+	ONBOARDING_PROVIDER_FILTERS,
+	USER_ROLE_FILTERS,
+	USER_SORT_OPTIONS,
+	WALLET_READINESS_FILTERS,
+} from '~/lib/validators/admin-list-params'
+import { KycStatsBar } from './kyc-stats-bar'
+import { UserRow } from './user-row'
+
+const ALL = 'all'
+
+interface FilterSelectProps {
+	label: string
+	value: string
+	onChange: (value: string | undefined) => void
+	options: Array<{ value: string; label: string }>
+	allLabel: string
+}
+
+function FilterSelect({ label, value, onChange, options, allLabel }: FilterSelectProps) {
+	const id = useId()
+	return (
+		<div className="flex items-center gap-1.5">
+			<Label htmlFor={id} className="sr-only">
+				{label}
+			</Label>
+			<Select
+				value={value || ALL}
+				onValueChange={(next) => onChange(next === ALL ? undefined : next)}
+			>
+				<SelectTrigger id={id} className="h-9 w-auto min-w-32 gap-1" aria-label={label}>
+					<SelectValue placeholder={allLabel} />
+				</SelectTrigger>
+				<SelectContent>
+					<SelectItem value={ALL}>{allLabel}</SelectItem>
+					{options.map((option) => (
+						<SelectItem key={option.value} value={option.value}>
+							{option.label}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+		</div>
+	)
+}
+
+const ROLE_LABELS: Record<string, string> = {
+	admin: 'Admin',
+	creator: 'Creator',
+	donor: 'Donor',
+	kinder: 'Kinder',
+	kindler: 'Kindler',
+	pending: 'Pending',
+}
+
+const WALLET_LABELS: Record<string, string> = {
+	pollar: 'Pollar wallet',
+	external: 'External wallet',
+	none: 'No wallet',
+}
+
+const PROVIDER_LABELS: Record<string, string> = {
+	legacy_passkey: 'Passkey onboarding',
+	pollar: 'Pollar onboarding',
+}
+
+const SORT_LABELS: Record<(typeof USER_SORT_OPTIONS)[number], string> = {
+	newest: 'Newest first',
+	oldest: 'Oldest first',
+	name: 'By name',
+}
+
+export function AdminUsersPage() {
+	const { params, normalizedParams, setParam, setPage, resetFilters } =
+		useAdminListParams(adminUsersQuerySchema)
+
+	const { data, isLoading, isError, refetch } = useAdminQuery<AdminListResponse<AdminUserListItem>>(
+		'users',
+		{ params: normalizedParams },
+	)
+
+	const hasActiveFilters = Object.keys(normalizedParams).some(
+		(key) => !['page', 'pageSize', 'sort'].includes(key),
+	)
+
+	return (
+		<div className="space-y-6">
+			<AdminSectionHeader
+				title="Users & KYC"
+				description="Community members with roles, wallet readiness, and normalized KYC status. Sensitive KYC data never appears here."
+			/>
+
+			<KycStatsBar activeKyc={params.kyc} onSelect={(kyc) => setParam('kyc', kyc)} />
+
+			<AdminListShell
+				searchValue={params.q ?? ''}
+				onSearchChange={(value) => setParam('q', value || undefined)}
+				searchPlaceholder="Search by name, email, handle, user ID, or wallet address…"
+				filters={
+					<>
+						<FilterSelect
+							label="Filter by role"
+							allLabel="All roles"
+							value={params.role ?? ''}
+							onChange={(value) => setParam('role', value)}
+							options={USER_ROLE_FILTERS.map((role) => ({
+								value: role,
+								label: ROLE_LABELS[role] ?? role,
+							}))}
+						/>
+						<FilterSelect
+							label="Filter by onboarding provider"
+							allLabel="All providers"
+							value={params.provider ?? ''}
+							onChange={(value) => setParam('provider', value)}
+							options={ONBOARDING_PROVIDER_FILTERS.map((provider) => ({
+								value: provider,
+								label: PROVIDER_LABELS[provider] ?? provider,
+							}))}
+						/>
+						<FilterSelect
+							label="Filter by wallet readiness"
+							allLabel="Any wallet state"
+							value={params.wallet ?? ''}
+							onChange={(value) => setParam('wallet', value)}
+							options={WALLET_READINESS_FILTERS.map((wallet) => ({
+								value: wallet,
+								label: WALLET_LABELS[wallet] ?? wallet,
+							}))}
+						/>
+						<FilterSelect
+							label="Sort users"
+							allLabel="Newest first"
+							value={params.sort === 'newest' ? '' : params.sort}
+							onChange={(value) => setParam('sort', value ?? 'newest')}
+							options={USER_SORT_OPTIONS.filter((sort) => sort !== 'newest').map((sort) => ({
+								value: sort,
+								label: SORT_LABELS[sort],
+							}))}
+						/>
+					</>
+				}
+				isLoading={isLoading}
+				isError={isError}
+				onRetry={() => refetch()}
+				total={data?.total ?? 0}
+				page={params.page}
+				pageSize={params.pageSize}
+				onPageChange={setPage}
+				emptyTitle="No users yet"
+				emptyDescription="New sign-ups appear here as the community grows."
+				hasActiveFilters={hasActiveFilters}
+				onResetFilters={resetFilters}
+				skeletonRowHeight={104}
+			>
+				<ul className="space-y-3">
+					{(data?.items ?? []).map((user) => (
+						<li key={user.id}>
+							<UserRow user={user} />
+						</li>
+					))}
+				</ul>
+			</AdminListShell>
+		</div>
+	)
+}

--- a/apps/web/components/sections/admin/users/kyc-stats-bar.tsx
+++ b/apps/web/components/sections/admin/users/kyc-stats-bar.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { Card, CardContent } from '~/components/base/card'
+import { Skeleton } from '~/components/base/skeleton'
+import { useAdminCounts } from '~/hooks/admin/use-admin-counts'
+
+interface KycStatsBarProps {
+	activeKyc: string | undefined
+	onSelect: (kyc: string | undefined) => void
+}
+
+const BUCKETS = [
+	{ key: 'not_started', label: 'Not started' },
+	{ key: 'pending', label: 'Pending review' },
+	{ key: 'approved', label: 'Approved / verified' },
+	{ key: 'rejected', label: 'Rejected' },
+] as const
+
+/**
+ * KYC status distribution. Each card toggles the corresponding list filter.
+ */
+export function KycStatsBar({ activeKyc, onSelect }: KycStatsBarProps) {
+	const { data, isLoading } = useAdminCounts()
+	const kyc = data?.stats?.kyc
+
+	return (
+		<section aria-label="KYC status distribution" className="grid grid-cols-2 gap-3 md:grid-cols-4">
+			{BUCKETS.map((bucket) => {
+				const isActive = activeKyc === bucket.key
+				const value = kyc?.[bucket.key]
+				return (
+					<Card key={bucket.key} className={isActive ? 'border-primary' : undefined}>
+						<CardContent className="p-0">
+							<button
+								type="button"
+								className="block w-full rounded-xl p-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+								onClick={() => onSelect(isActive ? undefined : bucket.key)}
+								aria-pressed={isActive}
+							>
+								{isLoading || value === undefined ? (
+									<Skeleton className="h-8 w-16" />
+								) : (
+									<p className="text-2xl font-semibold tabular-nums">
+										{value.toLocaleString('en-US')}
+									</p>
+								)}
+								<p className="mt-1 text-sm text-muted-foreground">{bucket.label}</p>
+							</button>
+						</CardContent>
+					</Card>
+				)
+			})}
+		</section>
+	)
+}

--- a/apps/web/components/sections/admin/users/kyc-stats-bar.tsx
+++ b/apps/web/components/sections/admin/users/kyc-stats-bar.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Button } from '~/components/base/button'
 import { Card, CardContent } from '~/components/base/card'
 import { Skeleton } from '~/components/base/skeleton'
 import { useAdminCounts } from '~/hooks/admin/use-admin-counts'
@@ -20,8 +21,28 @@ const BUCKETS = [
  * KYC status distribution. Each card toggles the corresponding list filter.
  */
 export function KycStatsBar({ activeKyc, onSelect }: KycStatsBarProps) {
-	const { data, isLoading } = useAdminCounts()
+	const { data, isLoading, isError, refetch } = useAdminCounts()
 	const kyc = data?.stats?.kyc
+	const countsUnavailable = isError || data?.statsError === true
+
+	const handleKycSelect = (bucketKey: string, isActive: boolean) => {
+		onSelect(isActive ? undefined : bucketKey)
+	}
+
+	if (countsUnavailable) {
+		return (
+			<div
+				role="alert"
+				className="flex items-center justify-between gap-3 rounded-lg border p-4"
+				aria-label="KYC status distribution"
+			>
+				<p className="text-sm text-muted-foreground">KYC counts could not be loaded.</p>
+				<Button type="button" variant="outline" size="sm" onClick={() => refetch()}>
+					Retry
+				</Button>
+			</div>
+		)
+	}
 
 	return (
 		<section aria-label="KYC status distribution" className="grid grid-cols-2 gap-3 md:grid-cols-4">
@@ -34,7 +55,7 @@ export function KycStatsBar({ activeKyc, onSelect }: KycStatsBarProps) {
 							<button
 								type="button"
 								className="block w-full rounded-xl p-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-								onClick={() => onSelect(isActive ? undefined : bucket.key)}
+								onClick={() => handleKycSelect(bucket.key, isActive)}
 								aria-pressed={isActive}
 							>
 								{isLoading || value === undefined ? (

--- a/apps/web/components/sections/admin/users/user-row.tsx
+++ b/apps/web/components/sections/admin/users/user-row.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { formatDistanceToNow } from 'date-fns'
+import { Wallet } from 'lucide-react'
+import Link from 'next/link'
+import { Badge } from '~/components/base/badge'
+import { Button } from '~/components/base/button'
+import { Card } from '~/components/base/card'
+import { UserAvatar } from '~/components/base/user-avatar'
+import { AdminStatusBadge } from '~/components/sections/admin/shared/admin-status-badge'
+import { CopyButton } from '~/components/sections/admin/shared/copy-button'
+import { TruncatedId } from '~/components/sections/admin/shared/truncated-id'
+import type { AdminUserListItem } from '~/lib/queries/admin/get-admin-users'
+
+const PROVIDER_LABELS: Record<string, string> = {
+	legacy_passkey: 'Passkey',
+	pollar: 'Pollar',
+}
+
+interface UserRowProps {
+	user: AdminUserListItem
+}
+
+export function UserRow({ user }: UserRowProps) {
+	const name = user.displayName || user.email || 'Unnamed user'
+
+	return (
+		<Card>
+			<div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+				<div className="flex min-w-0 items-center gap-3">
+					<UserAvatar src={user.imageUrl ?? undefined} alt={`${name} avatar`} name={name} />
+					<div className="min-w-0">
+						<div className="flex flex-wrap items-center gap-2">
+							<h3 className="truncate font-semibold">{name}</h3>
+							{user.role ? <AdminStatusBadge kind="role" status={user.role} /> : null}
+							<AdminStatusBadge kind="kyc" status={user.kyc.status} />
+							{user.onboardingProvider ? (
+								<Badge variant="secondary">
+									{PROVIDER_LABELS[user.onboardingProvider] ?? user.onboardingProvider}
+								</Badge>
+							) : null}
+						</div>
+						<p className="mt-0.5 flex flex-wrap items-center gap-x-2 text-sm text-muted-foreground">
+							{user.email ? <span className="truncate">{user.email}</span> : null}
+							{user.createdAt ? (
+								<>
+									<span aria-hidden="true">·</span>
+									<span>
+										Joined{' '}
+										<time dateTime={user.createdAt}>
+											{formatDistanceToNow(new Date(user.createdAt))} ago
+										</time>
+									</span>
+								</>
+							) : null}
+						</p>
+						<div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+							{user.pollarWalletAddress ? (
+								<span className="inline-flex items-center gap-1">
+									<Wallet className="h-3.5 w-3.5" aria-hidden="true" />
+									Pollar wallet
+									<TruncatedId value={user.pollarWalletAddress} />
+								</span>
+							) : null}
+							{user.externalWalletAddress ? (
+								<span className="inline-flex items-center gap-1">
+									<Wallet className="h-3.5 w-3.5" aria-hidden="true" />
+									External wallet
+									<TruncatedId value={user.externalWalletAddress} />
+								</span>
+							) : null}
+							{!user.pollarWalletAddress && !user.externalWalletAddress ? (
+								<span>No wallet connected</span>
+							) : null}
+						</div>
+					</div>
+				</div>
+
+				<div className="flex shrink-0 items-center gap-1">
+					<CopyButton value={user.id} label={`Copy user ID for ${name}`} />
+					{user.slug ? (
+						<Button asChild variant="outline" size="sm">
+							<Link href={`/u/${user.slug}`}>View profile</Link>
+						</Button>
+					) : null}
+				</div>
+			</div>
+		</Card>
+	)
+}

--- a/apps/web/components/sections/projects/detail/project-sidebar/components/donation-form.tsx
+++ b/apps/web/components/sections/projects/detail/project-sidebar/components/donation-form.tsx
@@ -45,8 +45,7 @@ export function DonationForm({
 	form,
 	onSubmit,
 }: DonationFormProps) {
-	const canDonate =
-		isDonationReady && isAcceptingDonations && !isGoalReached && isAuthenticated
+	const canDonate = isDonationReady && isAcceptingDonations && !isGoalReached && isAuthenticated
 
 	return (
 		<>

--- a/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar-escrow-state.ts
+++ b/apps/web/components/sections/projects/detail/project-sidebar/hooks/use-project-sidebar-escrow-state.ts
@@ -3,12 +3,12 @@ import { useCallback, useMemo } from 'react'
 import { useEscrow } from '~/hooks/contexts/use-escrow.context'
 import { useEscrowBalance } from '~/hooks/escrow/use-escrow-balance'
 import { useEscrowData } from '~/hooks/escrow/use-escrow-data'
-import type { ProjectDetail } from '~/lib/types/project/project-detail.types'
 import {
 	isProjectAcceptingDonations,
 	isProjectCampaignComplete,
 	type ProjectStatus,
 } from '~/lib/projects/project-status'
+import type { ProjectDetail } from '~/lib/types/project/project-detail.types'
 import { resolveEscrowType } from '~/lib/utils/escrow/resolve-escrow-type'
 import {
 	calculateReleasedAmountFromEscrow,

--- a/apps/web/components/sections/projects/manage/escrow/components/escrow-creation-wizard.tsx
+++ b/apps/web/components/sections/projects/manage/escrow/components/escrow-creation-wizard.tsx
@@ -6,6 +6,9 @@ import { Alert, AlertDescription, AlertTitle } from '~/components/base/alert'
 import { Button } from '~/components/base/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/base/card'
 import { TooltipProvider } from '~/components/base/tooltip'
+import { ConfirmActionDialog } from '~/components/sections/admin/shared/confirm-action-dialog'
+import { useStellarNetworkConfig } from '~/hooks/contexts/stellar-network.context'
+import { useTrustlessSigner } from '~/hooks/escrow/use-trustless-signer'
 import { useEscrowForm } from '../context/escrow-form-context'
 import {
 	ESCROW_WIZARD_STEPS,
@@ -57,8 +60,11 @@ const STEP_CONTENT: Record<
 export function EscrowCreationWizard({ projectId, projectSlug }: EscrowCreationWizardProps) {
 	const { formData } = useEscrowForm()
 	const [currentStep, setCurrentStep] = useState<EscrowWizardStep>('type')
+	const [confirmDeployOpen, setConfirmDeployOpen] = useState(false)
 	const { steps, isFullyValid } = useEscrowStepValidation(formData, projectId)
 	const { handleCreateEscrow, isSubmitting } = useEscrowTransaction({ projectId, projectSlug })
+	const { networkId } = useStellarNetworkConfig()
+	const { address: signerAddress } = useTrustlessSigner()
 
 	useWalletSync()
 
@@ -151,7 +157,7 @@ export function EscrowCreationWizard({ projectId, projectSlug }: EscrowCreationW
 					{isReviewStep ? (
 						<Button
 							type="button"
-							onClick={() => handleCreateEscrow(formData)}
+							onClick={() => setConfirmDeployOpen(true)}
 							disabled={!isFullyValid || isSubmitting}
 							className="w-full sm:w-auto"
 							size="lg"
@@ -183,6 +189,29 @@ export function EscrowCreationWizard({ projectId, projectSlug }: EscrowCreationW
 			</div>
 
 			<SyncEscrowCard projectId={projectId} projectSlug={projectSlug} variant="compact" />
+
+			<ConfirmActionDialog
+				open={confirmDeployOpen}
+				onOpenChange={setConfirmDeployOpen}
+				title="Deploy escrow contract"
+				description="Deploying asks your connected wallet to sign an initialization transaction. Review the summary before continuing."
+				summary={[
+					{ label: 'Escrow type', value: formData.selectedEscrowType },
+					{ label: 'Title', value: formData.title },
+					...(formData.selectedEscrowType === 'single-release' && formData.amount !== ''
+						? [{ label: 'Amount', value: String(formData.amount) }]
+						: []),
+					{ label: 'Releases', value: String(formData.milestones.length) },
+				]}
+				blockchain={{ networkId, signerAddress }}
+				confirmLabel="Sign & deploy"
+				pendingLabel="Deploying…"
+				isPending={isSubmitting}
+				onConfirm={() => {
+					setConfirmDeployOpen(false)
+					void handleCreateEscrow(formData)
+				}}
+			/>
 		</TooltipProvider>
 	)
 }

--- a/apps/web/components/sections/projects/manage/escrow/tabs/fund-escrow-tab.tsx
+++ b/apps/web/components/sections/projects/manage/escrow/tabs/fund-escrow-tab.tsx
@@ -11,6 +11,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/com
 import { Input } from '~/components/base/input'
 import { Label } from '~/components/base/label'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/base/tabs'
+import { ConfirmActionDialog } from '~/components/sections/admin/shared/confirm-action-dialog'
+import { useStellarNetworkConfig } from '~/hooks/contexts/stellar-network.context'
 import { useEscrow } from '~/hooks/contexts/use-escrow.context'
 import { useTrustlessSigner } from '~/hooks/escrow/use-trustless-signer'
 import { formatEscrowAmount } from '~/lib/utils/escrow/milestone-utils'
@@ -35,24 +37,29 @@ export function FundEscrowTab({
 	onSuccess,
 }: FundEscrowTabProps) {
 	const { fundEscrow, sendTransaction } = useEscrow()
-	const { ensureTrustlessSigner, signAndSubmitTrustlessTransaction } = useTrustlessSigner()
+	const { ensureTrustlessSigner, signAndSubmitTrustlessTransaction, address } = useTrustlessSigner()
+	const { networkId } = useStellarNetworkConfig()
 	const [fundAmount, setFundAmount] = useState<number | ''>('')
 	const [isProcessing, setIsProcessing] = useState(false)
+	const [confirmFundOpen, setConfirmFundOpen] = useState(false)
 
-	const handleFundEscrow = async () => {
+	const requestFundEscrow = () => {
 		if (!fundAmount || Number(fundAmount) <= 0) {
 			toast.error('Enter a valid amount greater than zero')
 			return
 		}
-
-		const amount = Number(fundAmount)
-
-		if (amount > 1_000_000) {
+		if (Number(fundAmount) > 1_000_000) {
 			toast.error('Amount too large', {
 				description: 'Enter an amount less than $1,000,000',
 			})
 			return
 		}
+		setConfirmFundOpen(true)
+	}
+
+	const handleFundEscrow = async () => {
+		setConfirmFundOpen(false)
+		const amount = Number(fundAmount)
 
 		try {
 			setIsProcessing(true)
@@ -215,7 +222,7 @@ export function FundEscrowTab({
 
 						<Button
 							type="button"
-							onClick={handleFundEscrow}
+							onClick={requestFundEscrow}
 							disabled={!fundAmount || Number(fundAmount) <= 0 || isProcessing}
 							className="w-full"
 							size="lg"
@@ -241,6 +248,23 @@ export function FundEscrowTab({
 						/>
 					</TabsContent>
 				</Tabs>
+
+				<ConfirmActionDialog
+					open={confirmFundOpen}
+					onOpenChange={setConfirmFundOpen}
+					title="Fund escrow"
+					description="Your connected wallet will be asked to sign a funding transaction for this escrow contract."
+					summary={[
+						{ label: 'Amount', value: `$${Number(fundAmount || 0).toLocaleString('en-US')} USDC` },
+						{ label: 'Escrow contract', value: `${escrowContractAddress.slice(0, 10)}…` },
+						{ label: 'Escrow type', value: escrowType },
+					]}
+					blockchain={{ networkId, signerAddress: address }}
+					confirmLabel="Sign & fund"
+					pendingLabel="Funding…"
+					isPending={isProcessing}
+					onConfirm={() => void handleFundEscrow()}
+				/>
 			</CardContent>
 		</Card>
 	)

--- a/apps/web/components/sections/projects/manage/escrow/tabs/release-tab.tsx
+++ b/apps/web/components/sections/projects/manage/escrow/tabs/release-tab.tsx
@@ -22,6 +22,8 @@ import {
 	SelectValue,
 } from '~/components/base/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/base/tabs'
+import { ConfirmActionDialog } from '~/components/sections/admin/shared/confirm-action-dialog'
+import { useStellarNetworkConfig } from '~/hooks/contexts/stellar-network.context'
 import { useEscrow } from '~/hooks/contexts/use-escrow.context'
 import { useTrustlessSigner } from '~/hooks/escrow/use-trustless-signer'
 import {
@@ -71,9 +73,11 @@ export function ReleaseTab({
 	onSuccess,
 }: ReleaseTabProps) {
 	const { releaseFunds, sendTransaction } = useEscrow()
-	const { ensureTrustlessSigner, signAndSubmitTrustlessTransaction } = useTrustlessSigner()
+	const { ensureTrustlessSigner, signAndSubmitTrustlessTransaction, address } = useTrustlessSigner()
+	const { networkId } = useStellarNetworkConfig()
 	const [selectedMilestoneIndex, setSelectedMilestoneIndex] = useState('0')
 	const [isProcessing, setIsProcessing] = useState(false)
+	const [confirmReleaseOpen, setConfirmReleaseOpen] = useState(false)
 
 	const isSingleRelease = escrowType === 'single-release'
 	const selectedIndex = Number(selectedMilestoneIndex)
@@ -281,7 +285,7 @@ export function ReleaseTab({
 
 						<Button
 							type="button"
-							onClick={handleReleaseFunds}
+							onClick={() => setConfirmReleaseOpen(true)}
 							disabled={isProcessing || !releaseReadiness.canRelease}
 							className="w-full"
 							size="lg"
@@ -314,6 +318,31 @@ export function ReleaseTab({
 						/>
 					</TabsContent>
 				</Tabs>
+
+				<ConfirmActionDialog
+					open={confirmReleaseOpen}
+					onOpenChange={setConfirmReleaseOpen}
+					title="Release escrow funds"
+					description="Releasing disburses funds from the escrow contract. Your connected wallet will be asked to sign the release transaction."
+					summary={[
+						{
+							label: 'Release',
+							value: isSingleRelease
+								? 'All funds (single release)'
+								: `Release ${selectedIndex + 1}`,
+						},
+						{ label: 'Escrow contract', value: `${escrowContractAddress.slice(0, 10)}…` },
+					]}
+					blockchain={{ networkId, signerAddress: address }}
+					confirmLabel="Sign & release"
+					pendingLabel="Releasing…"
+					isPending={isProcessing}
+					destructive
+					onConfirm={() => {
+						setConfirmReleaseOpen(false)
+						void handleReleaseFunds()
+					}}
+				/>
 			</CardContent>
 		</Card>
 	)

--- a/apps/web/components/sections/projects/manage/project-manage-command-center.tsx
+++ b/apps/web/components/sections/projects/manage/project-manage-command-center.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useMemo } from 'react'
 import {
+	IoArrowBackOutline,
 	IoDocumentTextOutline,
 	IoFlagOutline,
 	IoLockClosedOutline,
@@ -16,6 +17,7 @@ import {
 } from 'react-icons/io5'
 import { Badge } from '~/components/base/badge'
 import { Button } from '~/components/base/button'
+import { useAdminBackLink } from '~/hooks/admin/use-back-to-queue'
 import { PROJECT_STATUS_COLORS, PROJECT_STATUS_LABELS } from '~/lib/projects/project-status'
 import type { ProjectManageMeta } from '~/lib/queries/projects/get-project-manage-meta'
 import { cn } from '~/lib/utils'
@@ -56,6 +58,7 @@ export function ProjectManageCommandCenter({
 	isPlatformAdmin,
 }: ProjectManageCommandCenterProps) {
 	const pathname = usePathname()
+	const adminBackLink = useAdminBackLink()
 	const basePath = `/projects/${slug}/manage`
 	const navSections = useMemo(
 		() => getProjectManageNavSections(isPlatformAdmin, project.hasEscrow),
@@ -64,6 +67,15 @@ export function ProjectManageCommandCenter({
 
 	return (
 		<header className="sticky top-0 z-20 -mx-4 bg-background/95 px-4 py-4 shadow-[0_1px_0_0_hsl(var(--border))] backdrop-blur supports-[backdrop-filter]:bg-background/80 md:-mx-6 md:px-6">
+			{adminBackLink ? (
+				<Link
+					href={adminBackLink}
+					className="mb-2 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+				>
+					<IoArrowBackOutline className="h-4 w-4" aria-hidden />
+					Back to admin queue
+				</Link>
+			) : null}
 			<div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
 				<div className="flex min-w-0 items-start gap-3">
 					<div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-lg border border-border bg-muted">

--- a/apps/web/components/sections/projects/manage/project-status-panel.tsx
+++ b/apps/web/components/sections/projects/manage/project-status-panel.tsx
@@ -2,10 +2,12 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 import { toast } from 'sonner'
 import { Badge } from '~/components/base/badge'
 import { Button } from '~/components/base/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/base/card'
+import { ConfirmActionDialog } from '~/components/sections/admin/shared/confirm-action-dialog'
 import {
 	canManagerSubmitForReview,
 	getAdminStatusActions,
@@ -24,6 +26,7 @@ type ProjectStatusPanelProps = {
 export function ProjectStatusPanel({ slug, status, isPlatformAdmin }: ProjectStatusPanelProps) {
 	const queryClient = useQueryClient()
 	const router = useRouter()
+	const [confirmStatus, setConfirmStatus] = useState<ProjectStatus | null>(null)
 
 	const updateStatus = useMutation({
 		mutationFn: async (nextStatus: ProjectStatus) => {
@@ -51,7 +54,10 @@ export function ProjectStatusPanel({ slug, status, isPlatformAdmin }: ProjectSta
 					? `Project marked as ${payload.label.toLowerCase()}`
 					: 'Project status updated',
 			)
+			setConfirmStatus(null)
 			void queryClient.invalidateQueries({ queryKey: ['supabase', 'basic-project-info', slug] })
+			void queryClient.invalidateQueries({ queryKey: ['admin', 'nav-counts'] })
+			void queryClient.invalidateQueries({ queryKey: ['admin', 'action-queue'] })
 			router.refresh()
 		},
 		onError: (error: Error) => {
@@ -132,12 +138,41 @@ export function ProjectStatusPanel({ slug, status, isPlatformAdmin }: ProjectSta
 								variant={action.variant ?? 'outline'}
 								size="sm"
 								disabled={updateStatus.isPending}
-								onClick={() => updateStatus.mutate(action.status)}
+								onClick={() => setConfirmStatus(action.status)}
 							>
 								{action.label}
 							</Button>
 						))}
 					</div>
+				) : null}
+
+				{isPlatformAdmin ? (
+					<ConfirmActionDialog
+						open={confirmStatus !== null}
+						onOpenChange={(open) => {
+							if (!open) setConfirmStatus(null)
+						}}
+						title="Change campaign status"
+						description="This changes what creators and supporters see on the public campaign page."
+						summary={
+							confirmStatus
+								? [
+										{ label: 'Project', value: slug },
+										{
+											label: 'Status change',
+											value: `${PROJECT_STATUS_LABELS[status]} → ${PROJECT_STATUS_LABELS[confirmStatus]}`,
+										},
+									]
+								: undefined
+						}
+						confirmLabel="Change status"
+						pendingLabel="Updating…"
+						isPending={updateStatus.isPending}
+						destructive={confirmStatus === 'rejected' || confirmStatus === 'paused'}
+						onConfirm={() => {
+							if (confirmStatus) updateStatus.mutate(confirmStatus)
+						}}
+					/>
 				) : null}
 			</CardContent>
 		</Card>

--- a/apps/web/hooks/admin/use-admin-counts.ts
+++ b/apps/web/hooks/admin/use-admin-counts.ts
@@ -1,0 +1,23 @@
+'use client'
+
+import type { AdminDashboardStats } from '~/lib/validators/admin-dashboard-stats'
+import { useAdminQuery } from './use-admin-query'
+
+interface AdminCountsResponse {
+	stats: AdminDashboardStats | null
+	statsError: boolean
+}
+
+const COUNTS_STALE_MS = 60_000
+
+/**
+ * Lightweight dashboard counts (stats only, no queue items). Shared by the
+ * navigation badges and the KYC stats bar under one stable query key.
+ */
+export function useAdminCounts() {
+	return useAdminQuery<AdminCountsResponse>('nav-counts', {
+		path: 'action-queue',
+		params: { countsOnly: 'true' },
+		staleTime: COUNTS_STALE_MS,
+	})
+}

--- a/apps/web/hooks/admin/use-admin-list-params.ts
+++ b/apps/web/hooks/admin/use-admin-list-params.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type { z } from 'zod'
 import { normalizeAdminListParams, parseAdminListParams } from '~/lib/validators/admin-list-params'
 
@@ -22,9 +22,17 @@ export function useAdminListParams<Schema extends z.ZodType>(schema: Schema) {
 		[schema, searchParams],
 	)
 
+	// Patches are rebased on the latest query string (updated optimistically on
+	// every patch) so a debounced search callback cannot clobber a filter
+	// change that landed while the debounce timer was running.
+	const latestQueryRef = useRef(searchParams.toString())
+	useEffect(() => {
+		latestQueryRef.current = searchParams.toString()
+	}, [searchParams])
+
 	const applyPatch = useCallback(
 		(patch: ParamPatch) => {
-			const next = new URLSearchParams(searchParams.toString())
+			const next = new URLSearchParams(latestQueryRef.current)
 			for (const [key, value] of Object.entries(patch)) {
 				if (value === undefined || value === '') {
 					next.delete(key)
@@ -37,9 +45,10 @@ export function useAdminListParams<Schema extends z.ZodType>(schema: Schema) {
 				next.delete('page')
 			}
 			const query = next.toString()
+			latestQueryRef.current = query
 			router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
 		},
-		[pathname, router, searchParams],
+		[pathname, router],
 	)
 
 	const setParam = useCallback(

--- a/apps/web/hooks/admin/use-admin-list-params.ts
+++ b/apps/web/hooks/admin/use-admin-list-params.ts
@@ -1,0 +1,62 @@
+'use client'
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useMemo } from 'react'
+import type { z } from 'zod'
+import { normalizeAdminListParams, parseAdminListParams } from '~/lib/validators/admin-list-params'
+
+type ParamPatch = Record<string, string | number | undefined>
+
+/**
+ * URL-backed list state for admin surfaces. Search, filters, sorting, and
+ * pagination all live in the query string so views can be bookmarked and
+ * shared between administrators. Invalid values fall back to schema defaults.
+ */
+export function useAdminListParams<Schema extends z.ZodType>(schema: Schema) {
+	const router = useRouter()
+	const pathname = usePathname()
+	const searchParams = useSearchParams()
+
+	const params = useMemo(
+		() => parseAdminListParams(schema, new URLSearchParams(searchParams.toString())),
+		[schema, searchParams],
+	)
+
+	const applyPatch = useCallback(
+		(patch: ParamPatch) => {
+			const next = new URLSearchParams(searchParams.toString())
+			for (const [key, value] of Object.entries(patch)) {
+				if (value === undefined || value === '') {
+					next.delete(key)
+				} else {
+					next.set(key, String(value))
+				}
+			}
+			// Changing any filter invalidates the current page position.
+			if (!('page' in patch)) {
+				next.delete('page')
+			}
+			const query = next.toString()
+			router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+		},
+		[pathname, router, searchParams],
+	)
+
+	const setParam = useCallback(
+		(key: string, value: string | number | undefined) => applyPatch({ [key]: value }),
+		[applyPatch],
+	)
+
+	const setPage = useCallback((page: number) => applyPatch({ page }), [applyPatch])
+
+	const resetFilters = useCallback(() => {
+		router.replace(pathname, { scroll: false })
+	}, [pathname, router])
+
+	const normalizedParams = useMemo(
+		() => normalizeAdminListParams(params as Record<string, unknown>),
+		[params],
+	)
+
+	return { params, normalizedParams, setParam, setParams: applyPatch, setPage, resetFilters }
+}

--- a/apps/web/hooks/admin/use-admin-query.ts
+++ b/apps/web/hooks/admin/use-admin-query.ts
@@ -1,0 +1,54 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import {
+	buildAdminListQueryString,
+	normalizeAdminListParams,
+} from '~/lib/validators/admin-list-params'
+
+/**
+ * Builds the TanStack Query key for an admin surface. Shared by client hooks
+ * and server prefetching so hydration always matches.
+ */
+export function adminQueryKey(
+	surface: string,
+	params?: Record<string, unknown>,
+): [string, string, Record<string, string>] | [string, string] {
+	if (!params) return ['admin', surface]
+	return ['admin', surface, normalizeAdminListParams(params)]
+}
+
+async function fetchAdminApi<TData>(path: string, params?: Record<string, unknown>) {
+	const query = params ? buildAdminListQueryString(params) : ''
+	const response = await fetch(query ? `/api/admin/${path}?${query}` : `/api/admin/${path}`)
+	if (!response.ok) {
+		const body = (await response.json().catch(() => null)) as { error?: string } | null
+		throw new Error(body?.error ?? `Admin request failed (${response.status})`)
+	}
+	return (await response.json()) as TData
+}
+
+/**
+ * Fetches an admin API route with a stable `['admin', surface, params]` key.
+ * Previous data is kept while a new page/filter combination loads so list
+ * layouts do not collapse between pages.
+ */
+export function useAdminQuery<TData>(
+	surface: string,
+	options?: {
+		params?: Record<string, unknown>
+		path?: string
+		enabled?: boolean
+		staleTime?: number
+	},
+) {
+	const { params, path = surface, enabled = true, staleTime } = options ?? {}
+
+	return useQuery<TData>({
+		queryKey: adminQueryKey(surface, params),
+		queryFn: () => fetchAdminApi<TData>(path, params),
+		enabled,
+		staleTime,
+		placeholderData: (previousData) => previousData,
+	})
+}

--- a/apps/web/hooks/admin/use-admin-query.ts
+++ b/apps/web/hooks/admin/use-admin-query.ts
@@ -1,22 +1,9 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import {
-	buildAdminListQueryString,
-	normalizeAdminListParams,
-} from '~/lib/validators/admin-list-params'
+import { adminQueryKey, buildAdminListQueryString } from '~/lib/validators/admin-list-params'
 
-/**
- * Builds the TanStack Query key for an admin surface. Shared by client hooks
- * and server prefetching so hydration always matches.
- */
-export function adminQueryKey(
-	surface: string,
-	params?: Record<string, unknown>,
-): [string, string, Record<string, string>] | [string, string] {
-	if (!params) return ['admin', surface]
-	return ['admin', surface, normalizeAdminListParams(params)]
-}
+export { adminQueryKey }
 
 async function fetchAdminApi<TData>(path: string, params?: Record<string, unknown>) {
 	const query = params ? buildAdminListQueryString(params) : ''

--- a/apps/web/hooks/admin/use-back-to-queue.ts
+++ b/apps/web/hooks/admin/use-back-to-queue.ts
@@ -1,0 +1,24 @@
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+
+/**
+ * Validates a `from` back-link value: it must be an internal admin path.
+ * Anything else (external URLs, other routes) is rejected to avoid open
+ * redirects.
+ */
+export function sanitizeAdminBackLink(value: string | null): string | null {
+	if (!value) return null
+	if (!value.startsWith('/admin')) return null
+	if (value.startsWith('//')) return null
+	return value
+}
+
+/**
+ * Reads the validated `?from=` back-link that admin queue and list links
+ * attach when routing into project-management workspaces.
+ */
+export function useAdminBackLink(): string | null {
+	const searchParams = useSearchParams()
+	return sanitizeAdminBackLink(searchParams.get('from'))
+}

--- a/apps/web/hooks/admin/use-back-to-queue.ts
+++ b/apps/web/hooks/admin/use-back-to-queue.ts
@@ -9,8 +9,12 @@ import { useSearchParams } from 'next/navigation'
  */
 export function sanitizeAdminBackLink(value: string | null): string | null {
 	if (!value) return null
-	if (!value.startsWith('/admin')) return null
-	if (value.startsWith('//')) return null
+	if (value.startsWith('//') || value.includes('\\')) return null
+	// Must be exactly /admin or a canonical path under /admin/ — this also
+	// rejects siblings like /administer and traversal like /admin/../x.
+	const [path] = value.split('?')
+	if (path !== '/admin' && !path.startsWith('/admin/')) return null
+	if (path.split('/').some((segment) => segment === '..' || segment === '.')) return null
 	return value
 }
 

--- a/apps/web/lib/admin/project-actions.ts
+++ b/apps/web/lib/admin/project-actions.ts
@@ -1,0 +1,52 @@
+import type { Enums } from '@services/supabase'
+import {
+	PROJECT_MANAGE_NAV_SECTIONS,
+	type ProjectManageSectionKey,
+} from '~/components/sections/projects/manage/constants'
+
+export interface AdminAction {
+	label: string
+	href: string
+}
+
+/**
+ * Resolves a project-manage section href from the existing navigation source
+ * of truth, so admin surfaces always route into the same escrow-setup and
+ * escrow-manage workspaces the project command center uses.
+ */
+export function projectManageSectionHref(key: ProjectManageSectionKey, slug: string): string {
+	const section = PROJECT_MANAGE_NAV_SECTIONS.find((entry) => entry.key === key)
+	if (!section) return `/projects/${slug}/manage`
+	return section.href(slug)
+}
+
+/**
+ * State-driven primary action for a project in admin surfaces.
+ */
+export function getProjectPrimaryAction(project: {
+	status: Enums<'project_status'>
+	slug: string | null
+	hasEscrow: boolean
+}): AdminAction {
+	const slug = project.slug ?? ''
+	const manageHref = projectManageSectionHref('overview', slug)
+
+	switch (project.status) {
+		case 'draft':
+			return { label: 'View setup', href: manageHref }
+		case 'review':
+			return { label: 'Review project', href: manageHref }
+		case 'active':
+			return project.hasEscrow
+				? { label: 'Manage escrow', href: projectManageSectionHref('escrow-manage', slug) }
+				: { label: 'Create escrow', href: projectManageSectionHref('escrow-setup', slug) }
+		case 'paused':
+			return { label: 'Review campaign', href: manageHref }
+		case 'funded':
+			return { label: 'View campaign', href: `/projects/${slug}` }
+		case 'rejected':
+			return { label: 'View project', href: manageHref }
+		default:
+			return { label: 'View project', href: manageHref }
+	}
+}

--- a/apps/web/lib/admin/project-actions.ts
+++ b/apps/web/lib/admin/project-actions.ts
@@ -28,7 +28,13 @@ export function getProjectPrimaryAction(project: {
 	slug: string | null
 	hasEscrow: boolean
 }): AdminAction {
-	const slug = project.slug ?? ''
+	// Without a slug there is no manage route to build — fall back to the
+	// admin list instead of producing a malformed /projects//manage link.
+	if (!project.slug) {
+		return { label: 'View projects', href: '/admin/projects' }
+	}
+
+	const slug = project.slug
 	const manageHref = projectManageSectionHref('overview', slug)
 
 	switch (project.status) {

--- a/apps/web/lib/auth/require-admin-api.ts
+++ b/apps/web/lib/auth/require-admin-api.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { nextAuthOption } from '~/lib/auth/auth-options'
+import { isPlatformAdmin } from '~/lib/queries/projects/development-only-access'
+
+export type RequireAdminApiResult =
+	| { ok: true; userId: string }
+	| { ok: false; response: NextResponse }
+
+/**
+ * Server-side platform-admin guard for admin API route handlers.
+ *
+ * Every `/api/admin/*` route must call this independently — the `/admin`
+ * layout guard only protects page navigation, never API access.
+ *
+ * @example
+ * const auth = await requireAdminApi()
+ * if (!auth.ok) return auth.response
+ * // auth.userId is the verified platform admin
+ */
+export async function requireAdminApi(): Promise<RequireAdminApiResult> {
+	const session = await getServerSession(nextAuthOption)
+
+	if (!session?.user?.id) {
+		return {
+			ok: false,
+			response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+		}
+	}
+
+	if (!(await isPlatformAdmin(session.user.id))) {
+		return {
+			ok: false,
+			response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+		}
+	}
+
+	return { ok: true, userId: session.user.id }
+}

--- a/apps/web/lib/config/wallet-transfer.config.ts
+++ b/apps/web/lib/config/wallet-transfer.config.ts
@@ -1,11 +1,11 @@
-import { getDefaultUsdcContractAddress } from '~/lib/constants/escrow'
 import {
+	type ClientStellarNetworkId,
 	getClientStellarNetworkId,
 	getClientStellarNetworkPassphrase,
 	STELLAR_MAINNET_PASSPHRASE,
 	STELLAR_TESTNET_PASSPHRASE,
-	type ClientStellarNetworkId,
 } from '~/lib/config/stellar-network.config'
+import { getDefaultUsdcContractAddress } from '~/lib/constants/escrow'
 
 const USDC_ISSUER_G_ADDRESS_REGEX = /^G[A-Z2-7]{55}$/
 
@@ -31,10 +31,7 @@ export type WalletTransferConfigResult =
 	| { ok: true; config: WalletTransferConfig }
 	| WalletTransferConfigError
 
-const isPassphraseConsistent = (
-	networkId: ClientStellarNetworkId,
-	passphrase: string,
-): boolean => {
+const isPassphraseConsistent = (networkId: ClientStellarNetworkId, passphrase: string): boolean => {
 	if (networkId === 'mainnet') {
 		return passphrase === STELLAR_MAINNET_PASSPHRASE
 	}

--- a/apps/web/lib/queries/admin/get-action-queue-payload.ts
+++ b/apps/web/lib/queries/admin/get-action-queue-payload.ts
@@ -1,0 +1,29 @@
+import type { TypedSupabaseClient } from '@packages/lib/types'
+import type { AdminDashboardStats } from '~/lib/validators/admin-dashboard-stats'
+import { type AdminQueueSection, getActionQueues } from './get-action-queues'
+import { getDashboardStats } from './get-dashboard-stats'
+
+export interface AdminActionQueuePayload {
+	queues: AdminQueueSection[]
+	stats: AdminDashboardStats | null
+	statsError: boolean
+}
+
+/**
+ * Full action-center read model, shared by the API route and the server
+ * prefetch so both produce the identical payload for one query key.
+ * Stats and queues degrade independently.
+ */
+export async function getActionQueuePayload(
+	client: TypedSupabaseClient,
+): Promise<AdminActionQueuePayload> {
+	const [queues, statsResult] = await Promise.all([
+		getActionQueues(client),
+		getDashboardStats(client).then(
+			(stats) => ({ stats, statsError: false as const }),
+			() => ({ stats: null, statsError: true as const }),
+		),
+	])
+
+	return { queues, ...statsResult }
+}

--- a/apps/web/lib/queries/admin/get-action-queues.ts
+++ b/apps/web/lib/queries/admin/get-action-queues.ts
@@ -155,7 +155,7 @@ async function getMissingEscrowQueue(
 		.select('id, title, slug, status, created_at, updated_at, project_escrows!left(project_id)', {
 			count: 'exact',
 		})
-		.in('status', ['active', 'funded'])
+		.eq('status', 'active')
 		.is('project_escrows', null)
 		.order('updated_at', { ascending: true })
 		.limit(QUEUE_ITEM_LIMIT)
@@ -232,6 +232,8 @@ async function getEscrowAttentionQueue(client: TypedSupabaseClient): Promise<Adm
 			.limit(QUEUE_ITEM_LIMIT),
 		// escrow_contracts.project_id is NOT NULL, so a broken association
 		// manifests as a contract with no project_escrows join row.
+		// DISPUTED rows are excluded here so the two attention queries stay
+		// mutually exclusive and the queue total never double-counts an escrow.
 		client
 			.from('escrow_contracts')
 			.select(
@@ -241,6 +243,7 @@ async function getEscrowAttentionQueue(client: TypedSupabaseClient): Promise<Adm
 				},
 			)
 			.is('project_escrows', null)
+			.neq('current_state', 'DISPUTED')
 			.order('updated_at', { ascending: true })
 			.limit(QUEUE_ITEM_LIMIT),
 	])
@@ -322,7 +325,7 @@ async function getKycQueue(client: TypedSupabaseClient, now: Date): Promise<Admi
 		description: 'Verifications pending review or rejected.',
 		total: count ?? 0,
 		error: false,
-		viewAllHref: '/admin/users?kyc=pending',
+		viewAllHref: '/admin/users',
 		items: rows.map((row) => {
 			const profile = profilesById.get(row.user_id)
 			return {
@@ -476,7 +479,7 @@ const QUEUE_FALLBACKS: Record<
 		key: 'kyc_cases',
 		title: 'KYC cases',
 		description: 'Verifications pending review or rejected.',
-		viewAllHref: '/admin/users?kyc=pending',
+		viewAllHref: '/admin/users',
 	},
 	new_users: {
 		key: 'new_users',

--- a/apps/web/lib/queries/admin/get-action-queues.ts
+++ b/apps/web/lib/queries/admin/get-action-queues.ts
@@ -1,0 +1,528 @@
+import type { TypedSupabaseClient } from '@packages/lib/types'
+import type { Enums } from '@services/supabase'
+import type { AdminAction } from '~/lib/admin/project-actions'
+import { getProjectPrimaryAction, projectManageSectionHref } from '~/lib/admin/project-actions'
+
+export const ADMIN_QUEUE_KEYS = [
+	'project_reviews',
+	'missing_escrows',
+	'milestone_reviews',
+	'escrow_attention',
+	'kyc_cases',
+	'new_users',
+	'stale_drafts',
+	'paused_projects',
+] as const
+
+export type AdminQueueKey = (typeof ADMIN_QUEUE_KEYS)[number]
+
+export type AdminQueuePriority = 'high' | 'medium' | 'low'
+
+export interface AdminQueueItem {
+	id: string
+	queue: AdminQueueKey
+	/** What requires attention. */
+	title: string
+	/** Associated project, user, foundation, or escrow. */
+	subtitle: string | null
+	status: string
+	statusKind: 'project' | 'escrow' | 'kyc' | 'review' | 'role'
+	/** ISO timestamp the item has been waiting since. */
+	waitingSince: string | null
+	priority: AdminQueuePriority
+	primaryAction: AdminAction
+	viewHref: string | null
+}
+
+export interface AdminQueueSection {
+	key: AdminQueueKey
+	title: string
+	description: string
+	total: number
+	items: AdminQueueItem[]
+	/** Set when this queue's query failed; other queues still render. */
+	error: boolean
+	viewAllHref: string
+}
+
+const QUEUE_ITEM_LIMIT = 6
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export function daysWaiting(waitingSince: string | null, now: Date): number {
+	if (!waitingSince) return 0
+	const started = new Date(waitingSince).getTime()
+	if (Number.isNaN(started)) return 0
+	return Math.max(0, (now.getTime() - started) / DAY_MS)
+}
+
+/**
+ * Priority derivation for queue items. Pure so it can be unit-tested:
+ * urgency grows with waiting time, and inherently risky states (disputed or
+ * orphaned escrows, live campaigns without an escrow) are always high.
+ */
+export function deriveQueuePriority(queue: AdminQueueKey, days: number): AdminQueuePriority {
+	switch (queue) {
+		case 'escrow_attention':
+			return 'high'
+		case 'missing_escrows':
+			return 'high'
+		case 'project_reviews':
+			if (days >= 3) return 'high'
+			if (days >= 1) return 'medium'
+			return 'low'
+		case 'milestone_reviews':
+			if (days >= 2) return 'high'
+			return 'medium'
+		case 'kyc_cases':
+			if (days >= 3) return 'high'
+			return 'medium'
+		case 'paused_projects':
+			return 'medium'
+		default:
+			return 'low'
+	}
+}
+
+type ProjectQueueRow = {
+	id: string
+	title: string
+	slug: string | null
+	status: Enums<'project_status'>
+	created_at: string | null
+	updated_at: string | null
+}
+
+function projectQueueItem(
+	queue: AdminQueueKey,
+	row: ProjectQueueRow,
+	options: { hasEscrow: boolean; waitingSince: string | null; now: Date },
+): AdminQueueItem {
+	return {
+		id: `${queue}:${row.id}`,
+		queue,
+		title: row.title,
+		subtitle: row.slug ? `/projects/${row.slug}` : null,
+		status: row.status,
+		statusKind: 'project',
+		waitingSince: options.waitingSince,
+		priority: deriveQueuePriority(queue, daysWaiting(options.waitingSince, options.now)),
+		primaryAction: getProjectPrimaryAction({
+			status: row.status,
+			slug: row.slug,
+			hasEscrow: options.hasEscrow,
+		}),
+		viewHref: row.slug ? `/projects/${row.slug}` : null,
+	}
+}
+
+async function getProjectReviewQueue(
+	client: TypedSupabaseClient,
+	now: Date,
+): Promise<AdminQueueSection> {
+	const { data, error, count } = await client
+		.from('projects')
+		.select('id, title, slug, status, created_at, updated_at', { count: 'exact' })
+		.eq('status', 'review')
+		.order('created_at', { ascending: true })
+		.limit(QUEUE_ITEM_LIMIT)
+
+	if (error) throw error
+
+	return {
+		key: 'project_reviews',
+		title: 'Projects awaiting review',
+		description: 'Campaigns submitted for approval, oldest first.',
+		total: count ?? 0,
+		error: false,
+		viewAllHref: '/admin/projects?status=review',
+		items: (data ?? []).map((row) =>
+			projectQueueItem('project_reviews', row, {
+				hasEscrow: false,
+				waitingSince: row.created_at,
+				now,
+			}),
+		),
+	}
+}
+
+async function getMissingEscrowQueue(
+	client: TypedSupabaseClient,
+	now: Date,
+): Promise<AdminQueueSection> {
+	const { data, error, count } = await client
+		.from('projects')
+		.select('id, title, slug, status, created_at, updated_at, project_escrows!left(project_id)', {
+			count: 'exact',
+		})
+		.in('status', ['active', 'funded'])
+		.is('project_escrows', null)
+		.order('updated_at', { ascending: true })
+		.limit(QUEUE_ITEM_LIMIT)
+
+	if (error) throw error
+
+	return {
+		key: 'missing_escrows',
+		title: 'Active projects without an escrow',
+		description: 'Live campaigns that cannot receive escrowed funds yet.',
+		total: count ?? 0,
+		error: false,
+		viewAllHref: '/admin/projects?escrow=none&status=active',
+		items: (data ?? []).map((row) =>
+			projectQueueItem('missing_escrows', row, {
+				hasEscrow: false,
+				waitingSince: row.updated_at,
+				now,
+			}),
+		),
+	}
+}
+
+async function getMilestoneReviewQueue(
+	client: TypedSupabaseClient,
+	now: Date,
+): Promise<AdminQueueSection> {
+	const { data, error, count } = await client
+		.from('milestone_review_requests')
+		.select(
+			'id, status, milestone_index, milestone_title, created_at, project:projects!milestone_review_requests_project_id_fkey(title, slug)',
+			{ count: 'exact' },
+		)
+		.eq('status', 'pending')
+		.order('created_at', { ascending: true })
+		.limit(QUEUE_ITEM_LIMIT)
+
+	if (error) throw error
+
+	return {
+		key: 'milestone_reviews',
+		title: 'Pending milestone reviews',
+		description: 'Release review requests waiting for an admin decision.',
+		total: count ?? 0,
+		error: false,
+		viewAllHref: '/admin/milestone-reviews?status=pending',
+		items: (data ?? []).map((row) => ({
+			id: `milestone_reviews:${row.id}`,
+			queue: 'milestone_reviews' as const,
+			title: `Release ${row.milestone_index + 1}${row.milestone_title ? `: ${row.milestone_title}` : ''}`,
+			subtitle: row.project?.title ?? null,
+			status: row.status,
+			statusKind: 'review' as const,
+			waitingSince: row.created_at,
+			priority: deriveQueuePriority('milestone_reviews', daysWaiting(row.created_at, now)),
+			primaryAction: { label: 'Review milestone', href: '/admin/milestone-reviews?status=pending' },
+			viewHref: row.project?.slug
+				? projectManageSectionHref('escrow-manage', row.project.slug)
+				: null,
+		})),
+	}
+}
+
+async function getEscrowAttentionQueue(client: TypedSupabaseClient): Promise<AdminQueueSection> {
+	const [disputed, orphaned] = await Promise.all([
+		client
+			.from('escrow_contracts')
+			.select(
+				'id, contract_id, current_state, amount, updated_at, project:projects!escrow_contracts_project_id_fkey(title, slug)',
+				{ count: 'exact' },
+			)
+			.eq('current_state', 'DISPUTED')
+			.order('updated_at', { ascending: true })
+			.limit(QUEUE_ITEM_LIMIT),
+		// escrow_contracts.project_id is NOT NULL, so a broken association
+		// manifests as a contract with no project_escrows join row.
+		client
+			.from('escrow_contracts')
+			.select(
+				'id, contract_id, current_state, amount, updated_at, project_escrows!left(escrow_id)',
+				{
+					count: 'exact',
+				},
+			)
+			.is('project_escrows', null)
+			.order('updated_at', { ascending: true })
+			.limit(QUEUE_ITEM_LIMIT),
+	])
+
+	if (disputed.error) throw disputed.error
+	if (orphaned.error) throw orphaned.error
+
+	const disputedItems: AdminQueueItem[] = (disputed.data ?? []).map((row) => ({
+		id: `escrow_attention:${row.id}`,
+		queue: 'escrow_attention' as const,
+		title: 'Disputed escrow',
+		subtitle: row.project?.title ?? row.contract_id,
+		status: row.current_state ?? 'DISPUTED',
+		statusKind: 'escrow' as const,
+		waitingSince: row.updated_at,
+		priority: 'high' as const,
+		primaryAction: row.project?.slug
+			? {
+					label: 'Resolve dispute',
+					href: projectManageSectionHref('escrow-manage', row.project.slug),
+				}
+			: { label: 'View escrows', href: '/admin/escrows?state=DISPUTED' },
+		viewHref: '/admin/escrows?state=DISPUTED',
+	}))
+
+	const orphanedItems: AdminQueueItem[] = (orphaned.data ?? []).map((row) => ({
+		id: `escrow_attention:orphan:${row.id}`,
+		queue: 'escrow_attention' as const,
+		title: 'Escrow with a broken project association',
+		subtitle: row.contract_id,
+		status: row.current_state ?? 'NEW',
+		statusKind: 'escrow' as const,
+		waitingSince: row.updated_at,
+		priority: 'high' as const,
+		primaryAction: { label: 'Inspect escrow', href: '/admin/escrows' },
+		viewHref: '/admin/escrows',
+	}))
+
+	return {
+		key: 'escrow_attention',
+		title: 'Escrows requiring attention',
+		description: 'Disputed contracts and escrows with a broken project association.',
+		total: (disputed.count ?? 0) + (orphaned.count ?? 0),
+		error: false,
+		viewAllHref: '/admin/escrows',
+		items: [...disputedItems, ...orphanedItems].slice(0, QUEUE_ITEM_LIMIT),
+	}
+}
+
+async function getKycQueue(client: TypedSupabaseClient, now: Date): Promise<AdminQueueSection> {
+	const { data, error, count } = await client
+		.from('kyc_reviews')
+		.select('id, user_id, status, verification_level, created_at, updated_at', { count: 'exact' })
+		.in('status', ['pending', 'rejected'])
+		.order('created_at', { ascending: true })
+		.limit(QUEUE_ITEM_LIMIT)
+
+	if (error) throw error
+
+	const rows = data ?? []
+	const userIds = [...new Set(rows.map((row) => row.user_id))]
+
+	// kyc_reviews has no FK to profiles (it references auth.users), so the
+	// display name is resolved with a second lookup instead of an embed.
+	const profilesById = new Map<string, { display_name: string | null; email: string | null }>()
+	if (userIds.length > 0) {
+		const { data: profiles } = await client
+			.from('profiles')
+			.select('id, display_name, email')
+			.in('id', userIds)
+		for (const profile of profiles ?? []) {
+			profilesById.set(profile.id, profile)
+		}
+	}
+
+	return {
+		key: 'kyc_cases',
+		title: 'KYC cases',
+		description: 'Verifications pending review or rejected.',
+		total: count ?? 0,
+		error: false,
+		viewAllHref: '/admin/users?kyc=pending',
+		items: rows.map((row) => {
+			const profile = profilesById.get(row.user_id)
+			return {
+				id: `kyc_cases:${row.id}`,
+				queue: 'kyc_cases' as const,
+				title: profile?.display_name || profile?.email || 'Unknown user',
+				subtitle: `KYC ${row.status} · ${row.verification_level}`,
+				status: row.status,
+				statusKind: 'kyc' as const,
+				waitingSince: row.created_at,
+				priority: deriveQueuePriority('kyc_cases', daysWaiting(row.created_at, now)),
+				primaryAction: {
+					label: 'View KYC status',
+					href: `/admin/users?kyc=${row.status === 'rejected' ? 'rejected' : 'pending'}`,
+				},
+				viewHref: `/admin/users?q=${row.user_id}`,
+			}
+		}),
+	}
+}
+
+async function getNewUsersQueue(
+	client: TypedSupabaseClient,
+	now: Date,
+): Promise<AdminQueueSection> {
+	const since = new Date(now.getTime() - 7 * DAY_MS).toISOString()
+	const { data, error, count } = await client
+		.from('profiles')
+		.select('id, display_name, email, slug, role, created_at', { count: 'exact' })
+		.gte('created_at', since)
+		.order('created_at', { ascending: false })
+		.limit(QUEUE_ITEM_LIMIT)
+
+	if (error) throw error
+
+	return {
+		key: 'new_users',
+		title: 'New users',
+		description: 'Sign-ups from the last 7 days.',
+		total: count ?? 0,
+		error: false,
+		viewAllHref: '/admin/users?sort=newest',
+		items: (data ?? []).map((row) => ({
+			id: `new_users:${row.id}`,
+			queue: 'new_users' as const,
+			title: row.display_name || row.email || 'Unnamed user',
+			subtitle: row.email,
+			status: row.role ?? 'pending',
+			statusKind: 'role' as const,
+			waitingSince: row.created_at,
+			priority: 'low' as const,
+			primaryAction: { label: 'View user', href: `/admin/users?q=${row.id}` },
+			viewHref: row.slug ? `/u/${row.slug}` : null,
+		})),
+	}
+}
+
+const STALE_DRAFT_DAYS = 14
+
+async function getStaleDraftQueue(
+	client: TypedSupabaseClient,
+	now: Date,
+): Promise<AdminQueueSection> {
+	const cutoff = new Date(now.getTime() - STALE_DRAFT_DAYS * DAY_MS).toISOString()
+	const { data, error, count } = await client
+		.from('projects')
+		.select('id, title, slug, status, created_at, updated_at', { count: 'exact' })
+		.eq('status', 'draft')
+		.lt('created_at', cutoff)
+		.order('created_at', { ascending: true })
+		.limit(QUEUE_ITEM_LIMIT)
+
+	if (error) throw error
+
+	return {
+		key: 'stale_drafts',
+		title: 'Stalled drafts',
+		description: `Draft projects with no submission after ${STALE_DRAFT_DAYS} days.`,
+		total: count ?? 0,
+		error: false,
+		viewAllHref: '/admin/projects?status=draft&sort=oldest',
+		items: (data ?? []).map((row) =>
+			projectQueueItem('stale_drafts', row, {
+				hasEscrow: false,
+				waitingSince: row.created_at,
+				now,
+			}),
+		),
+	}
+}
+
+async function getPausedProjectsQueue(
+	client: TypedSupabaseClient,
+	now: Date,
+): Promise<AdminQueueSection> {
+	const { data, error, count } = await client
+		.from('projects')
+		.select('id, title, slug, status, created_at, updated_at', { count: 'exact' })
+		.eq('status', 'paused')
+		.order('updated_at', { ascending: true })
+		.limit(QUEUE_ITEM_LIMIT)
+
+	if (error) throw error
+
+	return {
+		key: 'paused_projects',
+		title: 'Paused campaigns',
+		description: 'Campaigns on hold that need a decision.',
+		total: count ?? 0,
+		error: false,
+		viewAllHref: '/admin/projects?status=paused',
+		items: (data ?? []).map((row) =>
+			projectQueueItem('paused_projects', row, {
+				hasEscrow: true,
+				waitingSince: row.updated_at,
+				now,
+			}),
+		),
+	}
+}
+
+const QUEUE_FALLBACKS: Record<
+	AdminQueueKey,
+	Omit<AdminQueueSection, 'total' | 'items' | 'error'>
+> = {
+	project_reviews: {
+		key: 'project_reviews',
+		title: 'Projects awaiting review',
+		description: 'Campaigns submitted for approval, oldest first.',
+		viewAllHref: '/admin/projects?status=review',
+	},
+	missing_escrows: {
+		key: 'missing_escrows',
+		title: 'Active projects without an escrow',
+		description: 'Live campaigns that cannot receive escrowed funds yet.',
+		viewAllHref: '/admin/projects?escrow=none&status=active',
+	},
+	milestone_reviews: {
+		key: 'milestone_reviews',
+		title: 'Pending milestone reviews',
+		description: 'Release review requests waiting for an admin decision.',
+		viewAllHref: '/admin/milestone-reviews?status=pending',
+	},
+	escrow_attention: {
+		key: 'escrow_attention',
+		title: 'Escrows requiring attention',
+		description: 'Disputed contracts and escrows with a broken project association.',
+		viewAllHref: '/admin/escrows',
+	},
+	kyc_cases: {
+		key: 'kyc_cases',
+		title: 'KYC cases',
+		description: 'Verifications pending review or rejected.',
+		viewAllHref: '/admin/users?kyc=pending',
+	},
+	new_users: {
+		key: 'new_users',
+		title: 'New users',
+		description: 'Sign-ups from the last 7 days.',
+		viewAllHref: '/admin/users?sort=newest',
+	},
+	stale_drafts: {
+		key: 'stale_drafts',
+		title: 'Stalled drafts',
+		description: `Draft projects with no submission after ${STALE_DRAFT_DAYS} days.`,
+		viewAllHref: '/admin/projects?status=draft&sort=oldest',
+	},
+	paused_projects: {
+		key: 'paused_projects',
+		title: 'Paused campaigns',
+		description: 'Campaigns on hold that need a decision.',
+		viewAllHref: '/admin/projects?status=paused',
+	},
+}
+
+/**
+ * Loads every action queue in parallel. Each queue degrades independently:
+ * a failed query yields `{ error: true }` for that queue only, so one broken
+ * metric never takes down the whole action center.
+ */
+export async function getActionQueues(
+	client: TypedSupabaseClient,
+	now: Date = new Date(),
+): Promise<AdminQueueSection[]> {
+	const builders: Array<[AdminQueueKey, Promise<AdminQueueSection>]> = [
+		['project_reviews', getProjectReviewQueue(client, now)],
+		['missing_escrows', getMissingEscrowQueue(client, now)],
+		['milestone_reviews', getMilestoneReviewQueue(client, now)],
+		['escrow_attention', getEscrowAttentionQueue(client)],
+		['kyc_cases', getKycQueue(client, now)],
+		['new_users', getNewUsersQueue(client, now)],
+		['stale_drafts', getStaleDraftQueue(client, now)],
+		['paused_projects', getPausedProjectsQueue(client, now)],
+	]
+
+	const settled = await Promise.allSettled(builders.map(([, promise]) => promise))
+
+	return settled.map((result, index) => {
+		if (result.status === 'fulfilled') return result.value
+		const [key] = builders[index]
+		return { ...QUEUE_FALLBACKS[key], total: 0, items: [], error: true }
+	})
+}

--- a/apps/web/lib/queries/admin/get-admin-escrows.ts
+++ b/apps/web/lib/queries/admin/get-admin-escrows.ts
@@ -3,6 +3,7 @@ import type { Enums } from '@services/supabase'
 import type { EscrowType } from '@trustless-work/escrow'
 import { readEscrowTypeFromMetadata } from '~/lib/utils/escrow/resolve-escrow-type'
 import type { AdminEscrowsQuery, AdminListResponse } from '~/lib/validators/admin-list-params'
+import { runPaginatedAdminQuery } from './run-paginated-query'
 
 export type AdminEscrowHealthIssue = 'missing_association' | 'orphaned_project'
 
@@ -37,7 +38,12 @@ function sanitizeSearchTerm(term: string): string {
 	return term.replace(/[,()%\\]/g, ' ').trim()
 }
 
-const RELATED_MATCH_LIMIT = 20
+/**
+ * PostgREST cannot ilike across embedded resources inside an or(), so
+ * project-title matches are pre-resolved to ids with a capped candidate
+ * list; beyond it, admins can narrow the term or use the project filter.
+ */
+const RELATED_MATCH_LIMIT = 50
 
 type EscrowRow = {
 	id: string
@@ -74,32 +80,23 @@ export async function getAdminEscrows(
 	client: TypedSupabaseClient,
 	params: AdminEscrowsQuery,
 ): Promise<AdminListResponse<AdminEscrowListItem>> {
-	let query = client.from('escrow_contracts').select(
-		`id, contract_id, engagement_id, current_state, amount, platform_fee, metadata,
-			 created_at, updated_at, completed_at,
-			 project:projects!escrow_contracts_project_id_fkey(id, title, slug, status, image_url),
-			 project_escrows!left(escrow_id),
-			 escrow_milestones(count)`,
-		{ count: 'exact' },
-	)
-
-	if (params.state) {
-		query = query.eq('current_state', params.state)
-	}
-
+	// Related-record lookups happen once, before the (re-runnable) builder.
+	let projectId: string | null | undefined
 	if (params.project) {
 		const { data: project } = await client
 			.from('projects')
 			.select('id')
 			.eq('slug', params.project)
 			.maybeSingle()
-		query = query.eq('project_id', project?.id ?? '00000000-0000-0000-0000-000000000000')
+		projectId = project?.id ?? '00000000-0000-0000-0000-000000000000'
 	}
 
+	let searchConditions: string | null = null
 	if (params.q) {
-		const term = sanitizeSearchTerm(params.q)
-		if (UUID_PATTERN.test(params.q.trim())) {
-			query = query.or(`id.eq.${params.q.trim()},project_id.eq.${params.q.trim()}`)
+		const raw = params.q.trim()
+		const term = sanitizeSearchTerm(raw)
+		if (UUID_PATTERN.test(raw)) {
+			searchConditions = `id.eq.${raw},project_id.eq.${raw}`
 		} else if (term) {
 			// Project-title matches are resolved to ids first (PostgREST cannot
 			// ilike across embedded resources inside an or()).
@@ -113,34 +110,47 @@ export async function getAdminEscrows(
 			if (projectIds.length > 0) {
 				conditions.push(`project_id.in.(${projectIds.join(',')})`)
 			}
-			query = query.or(conditions.join(','))
+			searchConditions = conditions.join(',')
 		}
 	}
 
-	switch (params.sort) {
-		case 'oldest':
-			query = query.order('created_at', { ascending: true })
-			break
-		case 'updated':
-			query = query.order('updated_at', { ascending: false, nullsFirst: false })
-			break
-		case 'amount':
-			query = query.order('amount', { ascending: false, nullsFirst: false })
-			break
-		default:
-			query = query.order('created_at', { ascending: false })
+	const runQuery = (from: number, to: number) => {
+		let query = client.from('escrow_contracts').select(
+			`id, contract_id, engagement_id, current_state, amount, platform_fee, metadata,
+				 created_at, updated_at, completed_at,
+				 project:projects!escrow_contracts_project_id_fkey(id, title, slug, status, image_url),
+				 project_escrows!left(escrow_id),
+				 escrow_milestones(count)`,
+			{ count: 'exact' },
+		)
+
+		if (params.state) query = query.eq('current_state', params.state)
+		if (projectId) query = query.eq('project_id', projectId)
+		if (searchConditions) query = query.or(searchConditions)
+
+		switch (params.sort) {
+			case 'oldest':
+				query = query.order('created_at', { ascending: true })
+				break
+			case 'updated':
+				query = query.order('updated_at', { ascending: false, nullsFirst: false })
+				break
+			case 'amount':
+				query = query.order('amount', { ascending: false, nullsFirst: false })
+				break
+			default:
+				query = query.order('created_at', { ascending: false })
+		}
+
+		return query.range(from, to)
 	}
 
-	const offset = (params.page - 1) * params.pageSize
-	query = query.range(offset, offset + params.pageSize - 1)
-
-	const { data, error, count } = await query
-
-	if (error) {
-		throw new Error(`Failed to load admin escrows: ${error.message}`)
-	}
-
-	const rows = (data ?? []) as unknown as EscrowRow[]
+	const { rows, total } = await runPaginatedAdminQuery<EscrowRow>(
+		runQuery,
+		params.page,
+		params.pageSize,
+		'admin escrows',
+	)
 
 	return {
 		items: rows.map((row) => {
@@ -172,7 +182,7 @@ export async function getAdminEscrows(
 				health: { healthy: issues.length === 0, issues },
 			}
 		}),
-		total: count ?? 0,
+		total,
 		page: params.page,
 		pageSize: params.pageSize,
 	}

--- a/apps/web/lib/queries/admin/get-admin-escrows.ts
+++ b/apps/web/lib/queries/admin/get-admin-escrows.ts
@@ -1,0 +1,179 @@
+import type { TypedSupabaseClient } from '@packages/lib/types'
+import type { Enums } from '@services/supabase'
+import type { EscrowType } from '@trustless-work/escrow'
+import { readEscrowTypeFromMetadata } from '~/lib/utils/escrow/resolve-escrow-type'
+import type { AdminEscrowsQuery, AdminListResponse } from '~/lib/validators/admin-list-params'
+
+export type AdminEscrowHealthIssue = 'missing_association' | 'orphaned_project'
+
+export interface AdminEscrowListItem {
+	id: string
+	contractId: string
+	engagementId: string
+	state: Enums<'escrow_status_type'> | null
+	type: EscrowType | null
+	amount: number
+	platformFee: number
+	createdAt: string | null
+	updatedAt: string | null
+	completedAt: string | null
+	releaseCount: number
+	project: {
+		id: string
+		title: string
+		slug: string | null
+		status: Enums<'project_status'>
+		imageUrl: string | null
+	} | null
+	health: {
+		healthy: boolean
+		issues: AdminEscrowHealthIssue[]
+	}
+}
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function sanitizeSearchTerm(term: string): string {
+	return term.replace(/[,()%\\]/g, ' ').trim()
+}
+
+const RELATED_MATCH_LIMIT = 20
+
+type EscrowRow = {
+	id: string
+	contract_id: string
+	engagement_id: string
+	current_state: Enums<'escrow_status_type'> | null
+	amount: number | null
+	platform_fee: number | null
+	metadata: unknown
+	created_at: string | null
+	updated_at: string | null
+	completed_at: string | null
+	project: {
+		id: string
+		title: string
+		slug: string | null
+		status: Enums<'project_status'>
+		image_url: string | null
+	} | null
+	// One-to-one embed (unique constraint on project_escrows.escrow_id).
+	project_escrows: { escrow_id: string } | null
+	escrow_milestones: Array<{ count: number }> | null
+}
+
+/**
+ * Paginated, project-oriented admin escrow list. The associated project is
+ * embedded so campaigns are recognizable at a glance, and association
+ * health is computed per row: an escrow whose `project_escrows` join row is
+ * missing (or whose project cannot be resolved) is flagged instead of being
+ * presented as an ordinary healthy escrow. No on-chain calls happen here —
+ * indexer detail loads only when a row is expanded.
+ */
+export async function getAdminEscrows(
+	client: TypedSupabaseClient,
+	params: AdminEscrowsQuery,
+): Promise<AdminListResponse<AdminEscrowListItem>> {
+	let query = client.from('escrow_contracts').select(
+		`id, contract_id, engagement_id, current_state, amount, platform_fee, metadata,
+			 created_at, updated_at, completed_at,
+			 project:projects!escrow_contracts_project_id_fkey(id, title, slug, status, image_url),
+			 project_escrows!left(escrow_id),
+			 escrow_milestones(count)`,
+		{ count: 'exact' },
+	)
+
+	if (params.state) {
+		query = query.eq('current_state', params.state)
+	}
+
+	if (params.project) {
+		const { data: project } = await client
+			.from('projects')
+			.select('id')
+			.eq('slug', params.project)
+			.maybeSingle()
+		query = query.eq('project_id', project?.id ?? '00000000-0000-0000-0000-000000000000')
+	}
+
+	if (params.q) {
+		const term = sanitizeSearchTerm(params.q)
+		if (UUID_PATTERN.test(params.q.trim())) {
+			query = query.or(`id.eq.${params.q.trim()},project_id.eq.${params.q.trim()}`)
+		} else if (term) {
+			// Project-title matches are resolved to ids first (PostgREST cannot
+			// ilike across embedded resources inside an or()).
+			const { data: projectMatches } = await client
+				.from('projects')
+				.select('id')
+				.ilike('title', `%${term}%`)
+				.limit(RELATED_MATCH_LIMIT)
+			const conditions = [`contract_id.ilike.%${term}%`, `engagement_id.ilike.%${term}%`]
+			const projectIds = (projectMatches ?? []).map((row) => row.id)
+			if (projectIds.length > 0) {
+				conditions.push(`project_id.in.(${projectIds.join(',')})`)
+			}
+			query = query.or(conditions.join(','))
+		}
+	}
+
+	switch (params.sort) {
+		case 'oldest':
+			query = query.order('created_at', { ascending: true })
+			break
+		case 'updated':
+			query = query.order('updated_at', { ascending: false, nullsFirst: false })
+			break
+		case 'amount':
+			query = query.order('amount', { ascending: false, nullsFirst: false })
+			break
+		default:
+			query = query.order('created_at', { ascending: false })
+	}
+
+	const offset = (params.page - 1) * params.pageSize
+	query = query.range(offset, offset + params.pageSize - 1)
+
+	const { data, error, count } = await query
+
+	if (error) {
+		throw new Error(`Failed to load admin escrows: ${error.message}`)
+	}
+
+	const rows = (data ?? []) as unknown as EscrowRow[]
+
+	return {
+		items: rows.map((row) => {
+			const issues: AdminEscrowHealthIssue[] = []
+			if (!row.project_escrows) issues.push('missing_association')
+			if (!row.project) issues.push('orphaned_project')
+
+			return {
+				id: row.id,
+				contractId: row.contract_id,
+				engagementId: row.engagement_id,
+				state: row.current_state,
+				type: readEscrowTypeFromMetadata(row.metadata) ?? null,
+				amount: Number(row.amount ?? 0),
+				platformFee: Number(row.platform_fee ?? 0),
+				createdAt: row.created_at,
+				updatedAt: row.updated_at,
+				completedAt: row.completed_at,
+				releaseCount: row.escrow_milestones?.[0]?.count ?? 0,
+				project: row.project
+					? {
+							id: row.project.id,
+							title: row.project.title,
+							slug: row.project.slug,
+							status: row.project.status,
+							imageUrl: row.project.image_url,
+						}
+					: null,
+				health: { healthy: issues.length === 0, issues },
+			}
+		}),
+		total: count ?? 0,
+		page: params.page,
+		pageSize: params.pageSize,
+	}
+}

--- a/apps/web/lib/queries/admin/get-admin-projects.ts
+++ b/apps/web/lib/queries/admin/get-admin-projects.ts
@@ -1,0 +1,265 @@
+import type { TypedSupabaseClient } from '@packages/lib/types'
+import type { Enums } from '@services/supabase'
+import type { EscrowType } from '@trustless-work/escrow'
+import { readEscrowTypeFromMetadata } from '~/lib/utils/escrow/resolve-escrow-type'
+import type { AdminListResponse, AdminProjectsQuery } from '~/lib/validators/admin-list-params'
+
+export interface AdminProjectListItem {
+	id: string
+	title: string
+	slug: string | null
+	status: Enums<'project_status'>
+	imageUrl: string | null
+	currentAmount: number
+	targetAmount: number
+	kinderCount: number
+	developmentOnly: boolean
+	location: string | null
+	createdAt: string | null
+	updatedAt: string | null
+	category: { id: string; name: string } | null
+	foundation: { id: string; name: string } | null
+	creator: { id: string; displayName: string | null } | null
+	escrow: { id: string; state: Enums<'escrow_status_type'> | null; type: EscrowType | null } | null
+}
+
+export interface AdminProjectFilterOptions {
+	categories: Array<{ id: string; name: string; slug: string | null }>
+	foundations: Array<{ id: string; name: string; slug: string }>
+}
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Strips characters that would break a PostgREST `or()` expression. */
+function sanitizeSearchTerm(term: string): string {
+	return term.replace(/[,()%\\]/g, ' ').trim()
+}
+
+const RELATED_MATCH_LIMIT = 20
+
+type ProjectRow = {
+	id: string
+	title: string
+	slug: string | null
+	status: Enums<'project_status'>
+	image_url: string | null
+	current_amount: number | null
+	target_amount: number | null
+	kinder_count: number | null
+	development_only: boolean
+	project_location: string | null
+	created_at: string | null
+	updated_at: string | null
+	kindler_id: string | null
+	category: { id: string; name: string } | null
+	foundation: { id: string; name: string } | null
+	// One-to-one embed: PostgREST returns an object because project_escrows
+	// has a unique constraint on project_id.
+	project_escrows: {
+		escrow: {
+			id: string
+			current_state: Enums<'escrow_status_type'> | null
+			metadata: unknown
+		} | null
+	} | null
+}
+
+/**
+ * Paginated, filterable admin project list. All filtering, searching,
+ * sorting, and pagination happen in the database — no 1,000-row fetches.
+ */
+export async function getAdminProjects(
+	client: TypedSupabaseClient,
+	params: AdminProjectsQuery,
+): Promise<AdminListResponse<AdminProjectListItem>> {
+	let query = client.from('projects').select(
+		`id, title, slug, status, image_url, current_amount, target_amount, kinder_count,
+			 development_only, project_location, created_at, updated_at,
+			 kindler_id,
+			 category:categories(id, name),
+			 foundation:foundations(id, name),
+			 project_escrows!left(escrow:escrow_contracts(id, current_state, metadata))`,
+		{ count: 'exact' },
+	)
+
+	if (params.status) {
+		query = query.eq('status', params.status)
+	}
+
+	if (params.devOnly) {
+		query = query.eq('development_only', params.devOnly === 'true')
+	}
+
+	if (params.category) {
+		const { data: category } = await client
+			.from('categories')
+			.select('id')
+			.eq('slug', params.category)
+			.maybeSingle()
+		query = query.eq('category_id', category?.id ?? '00000000-0000-0000-0000-000000000000')
+	}
+
+	if (params.foundation) {
+		const { data: foundation } = await client
+			.from('foundations')
+			.select('id')
+			.eq('slug', params.foundation)
+			.maybeSingle()
+		query = query.eq('foundation_id', foundation?.id ?? '00000000-0000-0000-0000-000000000000')
+	}
+
+	if (params.from) {
+		query = query.gte('created_at', `${params.from}T00:00:00.000Z`)
+	}
+	if (params.to) {
+		query = query.lte('created_at', `${params.to}T23:59:59.999Z`)
+	}
+
+	if (params.escrow === 'none') {
+		query = query.is('project_escrows', null)
+	} else if (params.escrow === 'any') {
+		query = query.not('project_escrows', 'is', null)
+	} else if (params.escrow) {
+		const { data: escrowProjects } = await client
+			.from('escrow_contracts')
+			.select('project_id')
+			.eq('current_state', params.escrow)
+			.limit(1000)
+		const projectIds = [
+			...new Set((escrowProjects ?? []).map((row) => row.project_id).filter(Boolean)),
+		]
+		if (projectIds.length === 0) {
+			return { items: [], total: 0, page: params.page, pageSize: params.pageSize }
+		}
+		query = query.in('id', projectIds)
+	}
+
+	if (params.q) {
+		const term = sanitizeSearchTerm(params.q)
+		if (UUID_PATTERN.test(params.q.trim())) {
+			query = query.eq('id', params.q.trim())
+		} else if (term) {
+			// Creator and foundation matches are resolved to ids first because
+			// PostgREST cannot ilike across embedded resources in an or().
+			const [foundationMatches, creatorMatches] = await Promise.all([
+				client
+					.from('foundations')
+					.select('id')
+					.ilike('name', `%${term}%`)
+					.limit(RELATED_MATCH_LIMIT),
+				client
+					.from('profiles')
+					.select('id')
+					.ilike('display_name', `%${term}%`)
+					.limit(RELATED_MATCH_LIMIT),
+			])
+			const conditions = [`title.ilike.%${term}%`, `slug.ilike.%${term}%`]
+			const foundationIds = (foundationMatches.data ?? []).map((row) => row.id)
+			if (foundationIds.length > 0) {
+				conditions.push(`foundation_id.in.(${foundationIds.join(',')})`)
+			}
+			const creatorIds = (creatorMatches.data ?? []).map((row) => row.id)
+			if (creatorIds.length > 0) {
+				conditions.push(`kindler_id.in.(${creatorIds.join(',')})`)
+			}
+			query = query.or(conditions.join(','))
+		}
+	}
+
+	switch (params.sort) {
+		case 'oldest':
+			query = query.order('created_at', { ascending: true })
+			break
+		case 'funding':
+			query = query.order('current_amount', { ascending: false, nullsFirst: false })
+			break
+		case 'target':
+			query = query.order('target_amount', { ascending: false, nullsFirst: false })
+			break
+		case 'status':
+			query = query.order('status', { ascending: true }).order('created_at', { ascending: false })
+			break
+		default:
+			query = query.order('created_at', { ascending: false })
+	}
+
+	const offset = (params.page - 1) * params.pageSize
+	query = query.range(offset, offset + params.pageSize - 1)
+
+	const { data, error, count } = await query
+
+	if (error) {
+		throw new Error(`Failed to load admin projects: ${error.message}`)
+	}
+
+	const rows = (data ?? []) as unknown as ProjectRow[]
+
+	// projects.kindler_id has no FK to profiles, so creator names are
+	// resolved with a second lookup over the current page instead of an embed.
+	const creatorIds = [...new Set(rows.map((row) => row.kindler_id).filter(Boolean))] as string[]
+	const creatorsById = new Map<string, { id: string; display_name: string | null }>()
+	if (creatorIds.length > 0) {
+		const { data: creators } = await client
+			.from('profiles')
+			.select('id, display_name')
+			.in('id', creatorIds)
+		for (const creator of creators ?? []) {
+			creatorsById.set(creator.id, creator)
+		}
+	}
+
+	return {
+		items: rows.map((row) => {
+			const escrowRelation = row.project_escrows?.escrow ?? null
+			return {
+				id: row.id,
+				title: row.title,
+				slug: row.slug,
+				status: row.status,
+				imageUrl: row.image_url,
+				currentAmount: Number(row.current_amount ?? 0),
+				targetAmount: Number(row.target_amount ?? 0),
+				kinderCount: Number(row.kinder_count ?? 0),
+				developmentOnly: row.development_only,
+				location: row.project_location,
+				createdAt: row.created_at,
+				updatedAt: row.updated_at,
+				category: row.category,
+				foundation: row.foundation,
+				creator: row.kindler_id
+					? {
+							id: row.kindler_id,
+							displayName: creatorsById.get(row.kindler_id)?.display_name ?? null,
+						}
+					: null,
+				escrow: escrowRelation
+					? {
+							id: escrowRelation.id,
+							state: escrowRelation.current_state,
+							type: readEscrowTypeFromMetadata(escrowRelation.metadata) ?? null,
+						}
+					: null,
+			}
+		}),
+		total: count ?? 0,
+		page: params.page,
+		pageSize: params.pageSize,
+	}
+}
+
+/**
+ * Option lists for the projects filter bar (small lookup tables).
+ */
+export async function getAdminProjectFilterOptions(
+	client: TypedSupabaseClient,
+): Promise<AdminProjectFilterOptions> {
+	const [categories, foundations] = await Promise.all([
+		client.from('categories').select('id, name, slug').order('name'),
+		client.from('foundations').select('id, name, slug').order('name'),
+	])
+
+	return {
+		categories: categories.data ?? [],
+		foundations: foundations.data ?? [],
+	}
+}

--- a/apps/web/lib/queries/admin/get-admin-projects.ts
+++ b/apps/web/lib/queries/admin/get-admin-projects.ts
@@ -3,6 +3,7 @@ import type { Enums } from '@services/supabase'
 import type { EscrowType } from '@trustless-work/escrow'
 import { readEscrowTypeFromMetadata } from '~/lib/utils/escrow/resolve-escrow-type'
 import type { AdminListResponse, AdminProjectsQuery } from '~/lib/validators/admin-list-params'
+import { runPaginatedAdminQuery } from './run-paginated-query'
 
 export interface AdminProjectListItem {
 	id: string
@@ -35,7 +36,13 @@ function sanitizeSearchTerm(term: string): string {
 	return term.replace(/[,()%\\]/g, ' ').trim()
 }
 
-const RELATED_MATCH_LIMIT = 20
+/**
+ * PostgREST cannot express `title ilike X OR foundation.name ilike X` across
+ * an embedded resource in a single or(), so creator/foundation name matches
+ * are pre-resolved to ids. The candidate list is capped; beyond it, admins
+ * can narrow the term or use the dedicated foundation filter.
+ */
+const RELATED_MATCH_LIMIT = 50
 
 type ProjectRow = {
 	id: string
@@ -72,72 +79,42 @@ export async function getAdminProjects(
 	client: TypedSupabaseClient,
 	params: AdminProjectsQuery,
 ): Promise<AdminListResponse<AdminProjectListItem>> {
-	let query = client.from('projects').select(
-		`id, title, slug, status, image_url, current_amount, target_amount, kinder_count,
-			 development_only, project_location, created_at, updated_at,
-			 kindler_id,
-			 category:categories(id, name),
-			 foundation:foundations(id, name),
-			 project_escrows!left(escrow:escrow_contracts(id, current_state, metadata))`,
-		{ count: 'exact' },
-	)
+	// A specific escrow-state filter (or 'any') switches the embed to an inner
+	// join so the state predicate runs in the database — no intermediate id
+	// expansion that could truncate results.
+	const escrowJoin =
+		params.escrow && params.escrow !== 'none'
+			? 'project_escrows!inner(escrow:escrow_contracts!inner(id, current_state, metadata))'
+			: 'project_escrows!left(escrow:escrow_contracts(id, current_state, metadata))'
 
-	if (params.status) {
-		query = query.eq('status', params.status)
-	}
-
-	if (params.devOnly) {
-		query = query.eq('development_only', params.devOnly === 'true')
-	}
-
+	// Related-record lookups happen once, before the (re-runnable) builder.
+	let categoryId: string | null | undefined
 	if (params.category) {
 		const { data: category } = await client
 			.from('categories')
 			.select('id')
 			.eq('slug', params.category)
 			.maybeSingle()
-		query = query.eq('category_id', category?.id ?? '00000000-0000-0000-0000-000000000000')
+		categoryId = category?.id ?? '00000000-0000-0000-0000-000000000000'
 	}
 
+	let foundationId: string | null | undefined
 	if (params.foundation) {
 		const { data: foundation } = await client
 			.from('foundations')
 			.select('id')
 			.eq('slug', params.foundation)
 			.maybeSingle()
-		query = query.eq('foundation_id', foundation?.id ?? '00000000-0000-0000-0000-000000000000')
+		foundationId = foundation?.id ?? '00000000-0000-0000-0000-000000000000'
 	}
 
-	if (params.from) {
-		query = query.gte('created_at', `${params.from}T00:00:00.000Z`)
-	}
-	if (params.to) {
-		query = query.lte('created_at', `${params.to}T23:59:59.999Z`)
-	}
-
-	if (params.escrow === 'none') {
-		query = query.is('project_escrows', null)
-	} else if (params.escrow === 'any') {
-		query = query.not('project_escrows', 'is', null)
-	} else if (params.escrow) {
-		const { data: escrowProjects } = await client
-			.from('escrow_contracts')
-			.select('project_id')
-			.eq('current_state', params.escrow)
-			.limit(1000)
-		const projectIds = [
-			...new Set((escrowProjects ?? []).map((row) => row.project_id).filter(Boolean)),
-		]
-		if (projectIds.length === 0) {
-			return { items: [], total: 0, page: params.page, pageSize: params.pageSize }
-		}
-		query = query.in('id', projectIds)
-	}
-
+	let searchConditions: string | null = null
+	let searchId: string | null = null
 	if (params.q) {
-		const term = sanitizeSearchTerm(params.q)
-		if (UUID_PATTERN.test(params.q.trim())) {
-			query = query.eq('id', params.q.trim())
+		const raw = params.q.trim()
+		const term = sanitizeSearchTerm(raw)
+		if (UUID_PATTERN.test(raw)) {
+			searchId = raw
 		} else if (term) {
 			// Creator and foundation matches are resolved to ids first because
 			// PostgREST cannot ilike across embedded resources in an or().
@@ -162,37 +139,67 @@ export async function getAdminProjects(
 			if (creatorIds.length > 0) {
 				conditions.push(`kindler_id.in.(${creatorIds.join(',')})`)
 			}
-			query = query.or(conditions.join(','))
+			searchConditions = conditions.join(',')
 		}
 	}
 
-	switch (params.sort) {
-		case 'oldest':
-			query = query.order('created_at', { ascending: true })
-			break
-		case 'funding':
-			query = query.order('current_amount', { ascending: false, nullsFirst: false })
-			break
-		case 'target':
-			query = query.order('target_amount', { ascending: false, nullsFirst: false })
-			break
-		case 'status':
-			query = query.order('status', { ascending: true }).order('created_at', { ascending: false })
-			break
-		default:
-			query = query.order('created_at', { ascending: false })
+	const runQuery = (from: number, to: number) => {
+		let query = client.from('projects').select(
+			`id, title, slug, status, image_url, current_amount, target_amount, kinder_count,
+				 development_only, project_location, created_at, updated_at,
+				 kindler_id,
+				 category:categories(id, name),
+				 foundation:foundations(id, name),
+				 ${escrowJoin}`,
+			{ count: 'exact' },
+		)
+
+		if (params.status) query = query.eq('status', params.status)
+		if (params.devOnly) query = query.eq('development_only', params.devOnly === 'true')
+		if (categoryId) query = query.eq('category_id', categoryId)
+		if (foundationId) query = query.eq('foundation_id', foundationId)
+		if (params.from) query = query.gte('created_at', `${params.from}T00:00:00.000Z`)
+		if (params.to) query = query.lte('created_at', `${params.to}T23:59:59.999Z`)
+
+		if (params.escrow === 'none') {
+			query = query.is('project_escrows', null)
+		} else if (params.escrow && params.escrow !== 'any') {
+			// 'any' needs no extra predicate — the inner join already restricts to
+			// projects with an escrow.
+			query = query.eq('project_escrows.escrow.current_state', params.escrow)
+		}
+
+		if (searchId) query = query.eq('id', searchId)
+		if (searchConditions) query = query.or(searchConditions)
+
+		switch (params.sort) {
+			case 'oldest':
+				query = query.order('created_at', { ascending: true })
+				break
+			case 'funding':
+				query = query.order('current_amount', { ascending: false, nullsFirst: false })
+				break
+			case 'target':
+				query = query.order('target_amount', { ascending: false, nullsFirst: false })
+				break
+			case 'status':
+				query = query.order('status', { ascending: true }).order('created_at', { ascending: false })
+				break
+			default:
+				query = query.order('created_at', { ascending: false })
+		}
+
+		return query.range(from, to)
 	}
 
-	const offset = (params.page - 1) * params.pageSize
-	query = query.range(offset, offset + params.pageSize - 1)
+	const { rows: rawRows, total } = await runPaginatedAdminQuery<ProjectRow>(
+		runQuery,
+		params.page,
+		params.pageSize,
+		'admin projects',
+	)
 
-	const { data, error, count } = await query
-
-	if (error) {
-		throw new Error(`Failed to load admin projects: ${error.message}`)
-	}
-
-	const rows = (data ?? []) as unknown as ProjectRow[]
+	const rows = rawRows
 
 	// projects.kindler_id has no FK to profiles, so creator names are
 	// resolved with a second lookup over the current page instead of an embed.
@@ -241,7 +248,7 @@ export async function getAdminProjects(
 					: null,
 			}
 		}),
-		total: count ?? 0,
+		total,
 		page: params.page,
 		pageSize: params.pageSize,
 	}

--- a/apps/web/lib/queries/admin/get-admin-users.ts
+++ b/apps/web/lib/queries/admin/get-admin-users.ts
@@ -1,0 +1,158 @@
+import type { TypedSupabaseClient } from '@packages/lib/types'
+import type { AdminListResponse, AdminUsersQuery } from '~/lib/validators/admin-list-params'
+
+export type AdminUserKycStatus =
+	| 'not_started'
+	| 'pending'
+	| 'approved'
+	| 'verified'
+	| 'rejected'
+	| 'unknown'
+
+export interface AdminUserListItem {
+	id: string
+	displayName: string | null
+	email: string | null
+	imageUrl: string | null
+	slug: string | null
+	role: string | null
+	onboardingProvider: string | null
+	/** Wallet readiness indicators — truncated is done in the UI. */
+	externalWalletAddress: string | null
+	pollarWalletAddress: string | null
+	createdAt: string | null
+	kyc: {
+		status: AdminUserKycStatus
+		verificationLevel: string | null
+		updatedAt: string | null
+	}
+}
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function sanitizeSearchTerm(term: string): string {
+	return term.replace(/[,()%\\]/g, ' ').trim()
+}
+
+const KNOWN_KYC_STATUSES: ReadonlySet<string> = new Set([
+	'not_started',
+	'pending',
+	'approved',
+	'verified',
+	'rejected',
+])
+
+function normalizeKycStatus(status: string | null): AdminUserKycStatus {
+	if (!status) return 'not_started'
+	return KNOWN_KYC_STATUSES.has(status) ? (status as AdminUserKycStatus) : 'unknown'
+}
+
+/**
+ * Paginated, filterable admin user list served from the
+ * `admin_users_overview` view (profiles + latest KYC review status). Only
+ * operational fields are selected — never KYC notes or provider payloads.
+ */
+export async function getAdminUsers(
+	client: TypedSupabaseClient,
+	params: AdminUsersQuery,
+): Promise<AdminListResponse<AdminUserListItem>> {
+	let query = client.from('admin_users_overview').select(
+		`id, display_name, email, image_url, slug, role, onboarding_provider,
+			 external_wallet_address, pollar_wallet_address, created_at,
+			 kyc_status, kyc_verification_level, kyc_updated_at`,
+		{ count: 'exact' },
+	)
+
+	if (params.role) {
+		query = query.eq('role', params.role)
+	}
+
+	if (params.provider) {
+		query = query.eq('onboarding_provider', params.provider)
+	}
+
+	if (params.kyc === 'approved') {
+		// The approved bucket includes the legacy 'verified' status.
+		query = query.in('kyc_status', ['approved', 'verified'])
+	} else if (params.kyc) {
+		query = query.eq('kyc_status', params.kyc)
+	}
+
+	if (params.wallet === 'pollar') {
+		query = query.not('pollar_wallet_address', 'is', null)
+	} else if (params.wallet === 'external') {
+		query = query.not('external_wallet_address', 'is', null)
+	} else if (params.wallet === 'none') {
+		query = query.is('pollar_wallet_address', null).is('external_wallet_address', null)
+	}
+
+	if (params.from) {
+		query = query.gte('created_at', `${params.from}T00:00:00.000Z`)
+	}
+	if (params.to) {
+		query = query.lte('created_at', `${params.to}T23:59:59.999Z`)
+	}
+
+	if (params.q) {
+		const raw = params.q.trim()
+		if (UUID_PATTERN.test(raw)) {
+			query = query.eq('id', raw)
+		} else {
+			const term = sanitizeSearchTerm(raw)
+			if (term) {
+				query = query.or(
+					[
+						`display_name.ilike.%${term}%`,
+						`email.ilike.%${term}%`,
+						`slug.ilike.%${term}%`,
+						`external_wallet_address.ilike.%${term}%`,
+						`pollar_wallet_address.ilike.%${term}%`,
+					].join(','),
+				)
+			}
+		}
+	}
+
+	switch (params.sort) {
+		case 'oldest':
+			query = query.order('created_at', { ascending: true, nullsFirst: false })
+			break
+		case 'name':
+			query = query.order('display_name', { ascending: true, nullsFirst: false })
+			break
+		default:
+			query = query.order('created_at', { ascending: false, nullsFirst: false })
+	}
+
+	const offset = (params.page - 1) * params.pageSize
+	query = query.range(offset, offset + params.pageSize - 1)
+
+	const { data, error, count } = await query
+
+	if (error) {
+		throw new Error(`Failed to load admin users: ${error.message}`)
+	}
+
+	return {
+		items: (data ?? []).map((row) => ({
+			id: row.id as string,
+			displayName: row.display_name,
+			email: row.email,
+			imageUrl: row.image_url,
+			slug: row.slug,
+			role: row.role,
+			onboardingProvider: row.onboarding_provider,
+			externalWalletAddress: row.external_wallet_address,
+			pollarWalletAddress: row.pollar_wallet_address,
+			createdAt: row.created_at,
+			kyc: {
+				status: normalizeKycStatus(row.kyc_status),
+				verificationLevel: row.kyc_verification_level,
+				updatedAt: row.kyc_updated_at,
+			},
+		})),
+		total: count ?? 0,
+		page: params.page,
+		pageSize: params.pageSize,
+	}
+}

--- a/apps/web/lib/queries/admin/get-admin-users.ts
+++ b/apps/web/lib/queries/admin/get-admin-users.ts
@@ -1,5 +1,6 @@
 import type { TypedSupabaseClient } from '@packages/lib/types'
 import type { AdminListResponse, AdminUsersQuery } from '~/lib/validators/admin-list-params'
+import { runPaginatedAdminQuery } from './run-paginated-query'
 
 export type AdminUserKycStatus =
 	| 'not_started'
@@ -56,85 +57,94 @@ export async function getAdminUsers(
 	client: TypedSupabaseClient,
 	params: AdminUsersQuery,
 ): Promise<AdminListResponse<AdminUserListItem>> {
-	let query = client.from('admin_users_overview').select(
-		`id, display_name, email, image_url, slug, role, onboarding_provider,
-			 external_wallet_address, pollar_wallet_address, created_at,
-			 kyc_status, kyc_verification_level, kyc_updated_at`,
-		{ count: 'exact' },
-	)
+	const runQuery = (from: number, to: number) => {
+		let query = client.from('admin_users_overview').select(
+			`id, display_name, email, image_url, slug, role, onboarding_provider,
+				 external_wallet_address, pollar_wallet_address, created_at,
+				 kyc_status, kyc_verification_level, kyc_updated_at`,
+			{ count: 'exact' },
+		)
 
-	if (params.role) {
-		query = query.eq('role', params.role)
-	}
+		if (params.role) query = query.eq('role', params.role)
+		if (params.provider) query = query.eq('onboarding_provider', params.provider)
 
-	if (params.provider) {
-		query = query.eq('onboarding_provider', params.provider)
-	}
+		if (params.kyc === 'approved') {
+			// The approved bucket includes the legacy 'verified' status.
+			query = query.in('kyc_status', ['approved', 'verified'])
+		} else if (params.kyc) {
+			query = query.eq('kyc_status', params.kyc)
+		}
 
-	if (params.kyc === 'approved') {
-		// The approved bucket includes the legacy 'verified' status.
-		query = query.in('kyc_status', ['approved', 'verified'])
-	} else if (params.kyc) {
-		query = query.eq('kyc_status', params.kyc)
-	}
+		if (params.wallet === 'pollar') {
+			query = query.not('pollar_wallet_address', 'is', null)
+		} else if (params.wallet === 'external') {
+			query = query.not('external_wallet_address', 'is', null)
+		} else if (params.wallet === 'none') {
+			query = query.is('pollar_wallet_address', null).is('external_wallet_address', null)
+		}
 
-	if (params.wallet === 'pollar') {
-		query = query.not('pollar_wallet_address', 'is', null)
-	} else if (params.wallet === 'external') {
-		query = query.not('external_wallet_address', 'is', null)
-	} else if (params.wallet === 'none') {
-		query = query.is('pollar_wallet_address', null).is('external_wallet_address', null)
-	}
+		if (params.from) query = query.gte('created_at', `${params.from}T00:00:00.000Z`)
+		if (params.to) query = query.lte('created_at', `${params.to}T23:59:59.999Z`)
 
-	if (params.from) {
-		query = query.gte('created_at', `${params.from}T00:00:00.000Z`)
-	}
-	if (params.to) {
-		query = query.lte('created_at', `${params.to}T23:59:59.999Z`)
-	}
-
-	if (params.q) {
-		const raw = params.q.trim()
-		if (UUID_PATTERN.test(raw)) {
-			query = query.eq('id', raw)
-		} else {
-			const term = sanitizeSearchTerm(raw)
-			if (term) {
-				query = query.or(
-					[
-						`display_name.ilike.%${term}%`,
-						`email.ilike.%${term}%`,
-						`slug.ilike.%${term}%`,
-						`external_wallet_address.ilike.%${term}%`,
-						`pollar_wallet_address.ilike.%${term}%`,
-					].join(','),
-				)
+		if (params.q) {
+			const raw = params.q.trim()
+			if (UUID_PATTERN.test(raw)) {
+				query = query.eq('id', raw)
+			} else {
+				const term = sanitizeSearchTerm(raw)
+				if (term) {
+					query = query.or(
+						[
+							`display_name.ilike.%${term}%`,
+							`email.ilike.%${term}%`,
+							`slug.ilike.%${term}%`,
+							`external_wallet_address.ilike.%${term}%`,
+							`pollar_wallet_address.ilike.%${term}%`,
+						].join(','),
+					)
+				}
 			}
 		}
+
+		switch (params.sort) {
+			case 'oldest':
+				query = query.order('created_at', { ascending: true, nullsFirst: false })
+				break
+			case 'name':
+				query = query.order('display_name', { ascending: true, nullsFirst: false })
+				break
+			default:
+				query = query.order('created_at', { ascending: false, nullsFirst: false })
+		}
+
+		return query.range(from, to)
 	}
 
-	switch (params.sort) {
-		case 'oldest':
-			query = query.order('created_at', { ascending: true, nullsFirst: false })
-			break
-		case 'name':
-			query = query.order('display_name', { ascending: true, nullsFirst: false })
-			break
-		default:
-			query = query.order('created_at', { ascending: false, nullsFirst: false })
+	type UserRow = {
+		id: string | null
+		display_name: string | null
+		email: string | null
+		image_url: string | null
+		slug: string | null
+		role: string | null
+		onboarding_provider: string | null
+		external_wallet_address: string | null
+		pollar_wallet_address: string | null
+		created_at: string | null
+		kyc_status: string | null
+		kyc_verification_level: string | null
+		kyc_updated_at: string | null
 	}
 
-	const offset = (params.page - 1) * params.pageSize
-	query = query.range(offset, offset + params.pageSize - 1)
-
-	const { data, error, count } = await query
-
-	if (error) {
-		throw new Error(`Failed to load admin users: ${error.message}`)
-	}
+	const { rows, total } = await runPaginatedAdminQuery<UserRow>(
+		runQuery,
+		params.page,
+		params.pageSize,
+		'admin users',
+	)
 
 	return {
-		items: (data ?? []).map((row) => ({
+		items: rows.map((row) => ({
 			id: row.id as string,
 			displayName: row.display_name,
 			email: row.email,
@@ -151,7 +161,7 @@ export async function getAdminUsers(
 				updatedAt: row.kyc_updated_at,
 			},
 		})),
-		total: count ?? 0,
+		total,
 		page: params.page,
 		pageSize: params.pageSize,
 	}

--- a/apps/web/lib/queries/admin/get-dashboard-stats.ts
+++ b/apps/web/lib/queries/admin/get-dashboard-stats.ts
@@ -1,0 +1,20 @@
+import type { TypedSupabaseClient } from '@packages/lib/types'
+import {
+	type AdminDashboardStats,
+	adminDashboardStatsSchema,
+} from '~/lib/validators/admin-dashboard-stats'
+
+/**
+ * Fetches all admin dashboard counts through the `get_admin_dashboard_stats`
+ * RPC — a single aggregate query instead of downloading full tables and
+ * counting rows in application code.
+ */
+export async function getDashboardStats(client: TypedSupabaseClient): Promise<AdminDashboardStats> {
+	const { data, error } = await client.rpc('get_admin_dashboard_stats')
+
+	if (error) {
+		throw new Error(`Failed to load admin dashboard stats: ${error.message}`)
+	}
+
+	return adminDashboardStatsSchema.parse(data)
+}

--- a/apps/web/lib/queries/admin/run-paginated-query.ts
+++ b/apps/web/lib/queries/admin/run-paginated-query.ts
@@ -1,0 +1,34 @@
+interface PaginatedQueryResponse {
+	data: unknown
+	error: { code?: string; message: string } | null
+	count: number | null
+}
+
+/**
+ * Executes a paginated admin query. When the requested page lies beyond the
+ * result set, PostgREST rejects the range (PGRST103); instead of failing the
+ * request, the query re-runs against the first row to recover the real total
+ * so the UI can show an out-of-range state with navigation back into range.
+ */
+export async function runPaginatedAdminQuery<Row>(
+	run: (from: number, to: number) => PromiseLike<PaginatedQueryResponse>,
+	page: number,
+	pageSize: number,
+	label: string,
+): Promise<{ rows: Row[]; total: number }> {
+	const offset = (page - 1) * pageSize
+	const result = await run(offset, offset + pageSize - 1)
+
+	if (!result.error) {
+		return { rows: (result.data ?? []) as Row[], total: result.count ?? 0 }
+	}
+
+	if (result.error.code === 'PGRST103') {
+		const fallback = await run(0, 0)
+		if (!fallback.error) {
+			return { rows: [], total: fallback.count ?? 0 }
+		}
+	}
+
+	throw new Error(`Failed to load ${label}: ${result.error.message}`)
+}

--- a/apps/web/lib/services/admin-audit.ts
+++ b/apps/web/lib/services/admin-audit.ts
@@ -1,0 +1,79 @@
+import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import { logger } from '@/lib/logger'
+
+export type AdminAuditOperation =
+	| 'admin_milestone_review_approved'
+	| 'admin_milestone_review_rejected'
+	| 'admin_project_status_changed'
+	| 'admin_gamification_triggered'
+	| 'admin_quest_backfill_run'
+	| 'admin_governance_round_created'
+	| 'admin_escrow_synced'
+
+export type AdminAuditResourceType =
+	| 'project'
+	| 'escrow'
+	| 'milestone'
+	| 'user'
+	| 'governance_round'
+	| 'quest'
+	| 'gamification_module'
+
+export interface AdminAuditEntry {
+	operation: AdminAuditOperation
+	resourceType: AdminAuditResourceType
+	resourceId: string
+	/** The admin performing the action. */
+	actorId: string
+	status: 'success' | 'failure'
+	previousState?: string | null
+	newState?: string | null
+	txHash?: string | null
+	/** Short failure description — never raw errors with secrets. */
+	failureReason?: string | null
+	/** Additional non-sensitive details. */
+	details?: Record<string, unknown>
+}
+
+export function buildAdminAuditRow(entry: AdminAuditEntry) {
+	return {
+		correlation_id: crypto.randomUUID(),
+		operation: entry.operation,
+		resource_type: entry.resourceType,
+		resource_id: entry.resourceId,
+		actor_id: entry.actorId,
+		status: entry.status,
+		error_code: entry.status === 'failure' ? (entry.failureReason ?? 'unknown') : null,
+		metadata: {
+			...(entry.details ?? {}),
+			...(entry.previousState !== undefined ? { previous_state: entry.previousState } : {}),
+			...(entry.newState !== undefined ? { new_state: entry.newState } : {}),
+			...(entry.txHash ? { tx_hash: entry.txHash } : {}),
+		},
+	}
+}
+
+/**
+ * Append-only audit trail for consequential admin actions, written to
+ * `public.audit_logs` with the server-only service-role client.
+ *
+ * The table is readable by any authenticated user under its current RLS
+ * policy, so entries must stay free of secrets and PII: record ids, status
+ * transitions, and transaction hashes only — never emails, KYC data,
+ * private keys, or raw provider payloads.
+ *
+ * Never throws: a failed audit write must not block the admin action it
+ * describes (the failure is logged server-side instead).
+ */
+export async function recordAdminAudit(entry: AdminAuditEntry): Promise<void> {
+	try {
+		const { error } = await supabaseServiceRole.from('audit_logs').insert(buildAdminAuditRow(entry))
+		if (error) throw error
+	} catch (err) {
+		logger.error('[admin-audit] Failed to record audit entry', {
+			operation: entry.operation,
+			resourceType: entry.resourceType,
+			error: err instanceof Error ? err.message : String(err),
+		})
+	}
+}

--- a/apps/web/lib/supabase/prefetch-admin-query.ts
+++ b/apps/web/lib/supabase/prefetch-admin-query.ts
@@ -1,8 +1,27 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
 import type { TypedSupabaseClient } from '@packages/lib/types'
 import type { QueryClient } from '@tanstack/react-query'
+import { adminQueryKey } from '~/lib/validators/admin-list-params'
 
 type AdminQueryFn<TData> = (client: TypedSupabaseClient) => Promise<TData>
+
+/**
+ * Prefetch a redesigned admin surface using the service-role client under
+ * the same `['admin', surface, params]` key the client hooks derive, so
+ * hydration always matches. Admin layouts already enforce platform-admin
+ * authorization.
+ */
+export async function prefetchAdminSurface<TData>(
+	queryClient: QueryClient,
+	surface: string,
+	params: Record<string, unknown> | undefined,
+	queryFn: AdminQueryFn<TData>,
+) {
+	await queryClient.prefetchQuery({
+		queryKey: adminQueryKey(surface, params),
+		queryFn: () => queryFn(supabaseServiceRole),
+	})
+}
 
 /**
  * Prefetch admin data using the service-role client.

--- a/apps/web/lib/validators/admin-dashboard-stats.ts
+++ b/apps/web/lib/validators/admin-dashboard-stats.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod'
 
-const countRecord = z.record(z.string(), z.number()).catch({})
+// No .catch() here: a malformed count record must fail the parse so the
+// dashboard reports statsError instead of silently rendering zeros.
+const countRecord = z.record(z.string(), z.number())
 
 /**
  * Shape of the `get_admin_dashboard_stats` RPC payload. Parsed with Zod so

--- a/apps/web/lib/validators/admin-dashboard-stats.ts
+++ b/apps/web/lib/validators/admin-dashboard-stats.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+
+const countRecord = z.record(z.string(), z.number()).catch({})
+
+/**
+ * Shape of the `get_admin_dashboard_stats` RPC payload. Parsed with Zod so
+ * schema drift fails loudly instead of rendering wrong numbers.
+ */
+export const adminDashboardStatsSchema = z.object({
+	projects: z.object({
+		total: z.number(),
+		by_status: countRecord,
+		dev_only: z.number(),
+		without_escrow: z.number(),
+	}),
+	escrows: z.object({
+		total: z.number(),
+		by_state: countRecord,
+	}),
+	users: z.object({
+		total: z.number(),
+		by_role: countRecord,
+		new_today: z.number(),
+		new_week: z.number(),
+		new_month: z.number(),
+	}),
+	kyc: z.object({
+		not_started: z.number(),
+		pending: z.number(),
+		approved: z.number(),
+		rejected: z.number(),
+	}),
+	milestone_reviews: z.object({
+		pending: z.number(),
+	}),
+	contributions: z.object({
+		count: z.number(),
+		total_amount: z.number(),
+	}),
+	foundations: z.object({
+		total: z.number(),
+	}),
+	governance: z.object({
+		rounds_total: z.number(),
+		rounds_active: z.number(),
+	}),
+	generated_at: z.string(),
+})
+
+export type AdminDashboardStats = z.infer<typeof adminDashboardStatsSchema>

--- a/apps/web/lib/validators/admin-list-params.ts
+++ b/apps/web/lib/validators/admin-list-params.ts
@@ -181,3 +181,15 @@ export function buildAdminListQueryString(params: Record<string, unknown>): stri
 	const search = new URLSearchParams(normalized)
 	return search.toString()
 }
+
+/**
+ * TanStack Query key for an admin surface. Shared by the client hooks and
+ * server prefetching so hydration always matches.
+ */
+export function adminQueryKey(
+	surface: string,
+	params?: Record<string, unknown>,
+): [string, string, Record<string, string>] | [string, string] {
+	if (!params) return ['admin', surface]
+	return ['admin', surface, normalizeAdminListParams(params)]
+}

--- a/apps/web/lib/validators/admin-list-params.ts
+++ b/apps/web/lib/validators/admin-list-params.ts
@@ -59,9 +59,19 @@ const optionalTrimmedString = z
 	.optional()
 	.catch(() => undefined)
 
+/** True only for real calendar dates (rejects e.g. 2026-02-30). */
+function isValidCalendarDate(value: string): boolean {
+	const [year, month, day] = value.split('-').map(Number)
+	const date = new Date(Date.UTC(year, month - 1, day))
+	return (
+		date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+	)
+}
+
 const optionalIsoDate = z
 	.string()
 	.regex(/^\d{4}-\d{2}-\d{2}$/)
+	.refine(isValidCalendarDate)
 	.optional()
 	.catch(() => undefined)
 

--- a/apps/web/lib/validators/admin-list-params.ts
+++ b/apps/web/lib/validators/admin-list-params.ts
@@ -1,0 +1,183 @@
+import { z } from 'zod'
+
+/**
+ * Query-parameter schemas shared by the admin API routes and the admin list
+ * UIs. Every field uses `.catch()` so an invalid or hand-edited URL falls
+ * back to a safe default instead of failing the request.
+ */
+
+export const ADMIN_DEFAULT_PAGE_SIZE = 20
+export const ADMIN_MAX_PAGE_SIZE = 50
+
+export const PROJECT_STATUS_FILTERS = [
+	'draft',
+	'review',
+	'active',
+	'paused',
+	'funded',
+	'rejected',
+] as const
+
+export const ESCROW_STATE_FILTERS = [
+	'NEW',
+	'FUNDED',
+	'ACTIVE',
+	'COMPLETED',
+	'DISPUTED',
+	'CANCELLED',
+] as const
+
+/** Escrow availability filter for project lists: none, any, or a specific state. */
+export const PROJECT_ESCROW_FILTERS = ['none', 'any', ...ESCROW_STATE_FILTERS] as const
+
+export const USER_ROLE_FILTERS = [
+	'admin',
+	'creator',
+	'donor',
+	'kinder',
+	'kindler',
+	'pending',
+] as const
+
+/** Normalized KYC buckets — `approved` includes the `verified` DB status. */
+export const KYC_STATUS_FILTERS = ['not_started', 'pending', 'approved', 'rejected'] as const
+
+export const ONBOARDING_PROVIDER_FILTERS = ['legacy_passkey', 'pollar'] as const
+
+export const WALLET_READINESS_FILTERS = ['pollar', 'external', 'none'] as const
+
+export const PROJECT_SORT_OPTIONS = ['newest', 'oldest', 'funding', 'target', 'status'] as const
+
+export const ESCROW_SORT_OPTIONS = ['newest', 'oldest', 'updated', 'amount'] as const
+
+export const USER_SORT_OPTIONS = ['newest', 'oldest', 'name'] as const
+
+const optionalTrimmedString = z
+	.string()
+	.trim()
+	.max(120)
+	.optional()
+	.catch(() => undefined)
+
+const optionalIsoDate = z
+	.string()
+	.regex(/^\d{4}-\d{2}-\d{2}$/)
+	.optional()
+	.catch(() => undefined)
+
+export const adminPaginationSchema = z.object({
+	page: z.coerce.number().int().min(1).catch(1),
+	pageSize: z.coerce.number().int().min(1).max(ADMIN_MAX_PAGE_SIZE).catch(ADMIN_DEFAULT_PAGE_SIZE),
+})
+
+export const adminProjectsQuerySchema = adminPaginationSchema.extend({
+	q: optionalTrimmedString,
+	status: z
+		.enum(PROJECT_STATUS_FILTERS)
+		.optional()
+		.catch(() => undefined),
+	escrow: z
+		.enum(PROJECT_ESCROW_FILTERS)
+		.optional()
+		.catch(() => undefined),
+	category: optionalTrimmedString,
+	foundation: optionalTrimmedString,
+	devOnly: z
+		.enum(['true', 'false'])
+		.optional()
+		.catch(() => undefined),
+	from: optionalIsoDate,
+	to: optionalIsoDate,
+	sort: z.enum(PROJECT_SORT_OPTIONS).catch('newest'),
+})
+
+export const adminEscrowsQuerySchema = adminPaginationSchema.extend({
+	q: optionalTrimmedString,
+	state: z
+		.enum(ESCROW_STATE_FILTERS)
+		.optional()
+		.catch(() => undefined),
+	project: optionalTrimmedString,
+	sort: z.enum(ESCROW_SORT_OPTIONS).catch('newest'),
+})
+
+export const adminUsersQuerySchema = adminPaginationSchema.extend({
+	q: optionalTrimmedString,
+	role: z
+		.enum(USER_ROLE_FILTERS)
+		.optional()
+		.catch(() => undefined),
+	kyc: z
+		.enum(KYC_STATUS_FILTERS)
+		.optional()
+		.catch(() => undefined),
+	provider: z
+		.enum(ONBOARDING_PROVIDER_FILTERS)
+		.optional()
+		.catch(() => undefined),
+	wallet: z
+		.enum(WALLET_READINESS_FILTERS)
+		.optional()
+		.catch(() => undefined),
+	from: optionalIsoDate,
+	to: optionalIsoDate,
+	sort: z.enum(USER_SORT_OPTIONS).catch('newest'),
+})
+
+export const adminActionQueueQuerySchema = z.object({
+	countsOnly: z
+		.enum(['true', 'false'])
+		.optional()
+		.catch(() => undefined),
+})
+
+export type AdminProjectsQuery = z.infer<typeof adminProjectsQuerySchema>
+export type AdminEscrowsQuery = z.infer<typeof adminEscrowsQuerySchema>
+export type AdminUsersQuery = z.infer<typeof adminUsersQuerySchema>
+export type AdminActionQueueQuery = z.infer<typeof adminActionQueueQuerySchema>
+
+export interface AdminListResponse<T> {
+	items: T[]
+	total: number
+	page: number
+	pageSize: number
+}
+
+/**
+ * Parses raw search params (from a URL or a Next.js request) with the given
+ * schema. Unknown keys are ignored; invalid values fall back to defaults.
+ */
+export function parseAdminListParams<Schema extends z.ZodType>(
+	schema: Schema,
+	searchParams: URLSearchParams,
+): z.infer<Schema> {
+	const raw: Record<string, string> = {}
+	for (const [key, value] of searchParams.entries()) {
+		if (!(key in raw)) raw[key] = value
+	}
+	return schema.parse(raw)
+}
+
+/**
+ * Produces a stable, serializable representation of parsed params for use in
+ * TanStack Query keys. Keys are sorted and `undefined` values dropped so the
+ * server prefetch and the client hook always derive the identical key.
+ */
+export function normalizeAdminListParams(params: Record<string, unknown>): Record<string, string> {
+	const normalized: Record<string, string> = {}
+	for (const key of Object.keys(params).sort()) {
+		const value = params[key]
+		if (value === undefined || value === null || value === '') continue
+		normalized[key] = String(value)
+	}
+	return normalized
+}
+
+/**
+ * Serializes parsed params into a query string for `/api/admin/*` requests.
+ */
+export function buildAdminListQueryString(params: Record<string, unknown>): string {
+	const normalized = normalizeAdminListParams(params)
+	const search = new URLSearchParams(normalized)
+	return search.toString()
+}

--- a/apps/web/test/admin-action-queue.test.ts
+++ b/apps/web/test/admin-action-queue.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test'
+import { getProjectPrimaryAction } from '~/lib/admin/project-actions'
+import { daysWaiting, deriveQueuePriority } from '~/lib/queries/admin/get-action-queues'
+
+const NOW = new Date('2026-08-24T12:00:00Z')
+
+const daysAgo = (days: number) => new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000).toISOString()
+
+describe('daysWaiting', () => {
+	test('computes fractional days since the timestamp', () => {
+		expect(daysWaiting(daysAgo(2), NOW)).toBeCloseTo(2)
+		expect(daysWaiting(daysAgo(0.5), NOW)).toBeCloseTo(0.5)
+	})
+
+	test('handles null and invalid timestamps as zero', () => {
+		expect(daysWaiting(null, NOW)).toBe(0)
+		expect(daysWaiting('not-a-date', NOW)).toBe(0)
+	})
+
+	test('never returns negative values for future timestamps', () => {
+		expect(daysWaiting(daysAgo(-3), NOW)).toBe(0)
+	})
+})
+
+describe('deriveQueuePriority', () => {
+	test('escrow attention and missing escrows are always high', () => {
+		expect(deriveQueuePriority('escrow_attention', 0)).toBe('high')
+		expect(deriveQueuePriority('missing_escrows', 0)).toBe('high')
+	})
+
+	test('project reviews escalate with waiting time', () => {
+		expect(deriveQueuePriority('project_reviews', 0)).toBe('low')
+		expect(deriveQueuePriority('project_reviews', 1.5)).toBe('medium')
+		expect(deriveQueuePriority('project_reviews', 4)).toBe('high')
+	})
+
+	test('milestone reviews start medium and escalate', () => {
+		expect(deriveQueuePriority('milestone_reviews', 0)).toBe('medium')
+		expect(deriveQueuePriority('milestone_reviews', 3)).toBe('high')
+	})
+
+	test('kyc cases escalate after three days', () => {
+		expect(deriveQueuePriority('kyc_cases', 1)).toBe('medium')
+		expect(deriveQueuePriority('kyc_cases', 3)).toBe('high')
+	})
+
+	test('informational queues stay low', () => {
+		expect(deriveQueuePriority('new_users', 30)).toBe('low')
+		expect(deriveQueuePriority('stale_drafts', 30)).toBe('low')
+	})
+})
+
+describe('getProjectPrimaryAction', () => {
+	test('routes review projects to the manage workspace', () => {
+		const action = getProjectPrimaryAction({
+			status: 'review',
+			slug: 'save-the-bees',
+			hasEscrow: false,
+		})
+		expect(action.label).toBe('Review project')
+		expect(action.href).toBe('/projects/save-the-bees/manage')
+	})
+
+	test('routes active projects without escrow to escrow setup', () => {
+		const action = getProjectPrimaryAction({
+			status: 'active',
+			slug: 'save-the-bees',
+			hasEscrow: false,
+		})
+		expect(action.label).toBe('Create escrow')
+		expect(action.href).toBe('/projects/save-the-bees/manage/settings')
+	})
+
+	test('routes active projects with escrow to escrow ops', () => {
+		const action = getProjectPrimaryAction({
+			status: 'active',
+			slug: 'save-the-bees',
+			hasEscrow: true,
+		})
+		expect(action.label).toBe('Manage escrow')
+		expect(action.href).toBe('/projects/save-the-bees/manage/settings/manage')
+	})
+
+	test('routes funded projects to the public campaign page', () => {
+		const action = getProjectPrimaryAction({
+			status: 'funded',
+			slug: 'save-the-bees',
+			hasEscrow: true,
+		})
+		expect(action.label).toBe('View campaign')
+		expect(action.href).toBe('/projects/save-the-bees')
+	})
+})

--- a/apps/web/test/admin-audit.test.ts
+++ b/apps/web/test/admin-audit.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test'
+import { buildAdminAuditRow } from '~/lib/services/admin-audit'
+
+describe('buildAdminAuditRow', () => {
+	test('maps a successful state change with previous and new state', () => {
+		const row = buildAdminAuditRow({
+			operation: 'admin_project_status_changed',
+			resourceType: 'project',
+			resourceId: 'project-1',
+			actorId: 'admin-1',
+			status: 'success',
+			previousState: 'review',
+			newState: 'active',
+		})
+
+		expect(row.operation).toBe('admin_project_status_changed')
+		expect(row.resource_type).toBe('project')
+		expect(row.resource_id).toBe('project-1')
+		expect(row.actor_id).toBe('admin-1')
+		expect(row.status).toBe('success')
+		expect(row.error_code).toBeNull()
+		expect(row.metadata).toEqual({ previous_state: 'review', new_state: 'active' })
+		expect(row.correlation_id).toMatch(/^[0-9a-f-]{36}$/)
+	})
+
+	test('records tx hashes for blockchain operations', () => {
+		const row = buildAdminAuditRow({
+			operation: 'admin_gamification_triggered',
+			resourceType: 'gamification_module',
+			resourceId: 'streak',
+			actorId: 'admin-1',
+			status: 'success',
+			txHash: 'abc123',
+			details: { action: 'record_donation', network: 'testnet' },
+		})
+
+		expect(row.metadata).toEqual({
+			action: 'record_donation',
+			network: 'testnet',
+			tx_hash: 'abc123',
+		})
+	})
+
+	test('failures carry a short reason in error_code', () => {
+		const row = buildAdminAuditRow({
+			operation: 'admin_escrow_synced',
+			resourceType: 'escrow',
+			resourceId: 'CCONTRACT',
+			actorId: 'admin-1',
+			status: 'failure',
+			failureReason: 'Indexer returned no escrow',
+		})
+
+		expect(row.status).toBe('failure')
+		expect(row.error_code).toBe('Indexer returned no escrow')
+	})
+
+	test('omits absent optional fields from metadata', () => {
+		const row = buildAdminAuditRow({
+			operation: 'admin_quest_backfill_run',
+			resourceType: 'quest',
+			resourceId: 'all',
+			actorId: 'admin-1',
+			status: 'success',
+		})
+
+		expect(row.metadata).toEqual({})
+		expect(Object.keys(row.metadata)).not.toContain('tx_hash')
+	})
+})

--- a/apps/web/test/admin-list-params.test.ts
+++ b/apps/web/test/admin-list-params.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test'
+import {
+	ADMIN_DEFAULT_PAGE_SIZE,
+	ADMIN_MAX_PAGE_SIZE,
+	adminProjectsQuerySchema,
+	adminUsersQuerySchema,
+	buildAdminListQueryString,
+	normalizeAdminListParams,
+	parseAdminListParams,
+} from '~/lib/validators/admin-list-params'
+
+describe('admin list params', () => {
+	test('applies defaults when no params are provided', () => {
+		const params = parseAdminListParams(adminProjectsQuerySchema, new URLSearchParams())
+		expect(params.page).toBe(1)
+		expect(params.pageSize).toBe(ADMIN_DEFAULT_PAGE_SIZE)
+		expect(params.sort).toBe('newest')
+		expect(params.status).toBeUndefined()
+		expect(params.q).toBeUndefined()
+	})
+
+	test('parses valid filters', () => {
+		const params = parseAdminListParams(
+			adminProjectsQuerySchema,
+			new URLSearchParams('status=review&escrow=none&sort=funding&page=3&q=water'),
+		)
+		expect(params.status).toBe('review')
+		expect(params.escrow).toBe('none')
+		expect(params.sort).toBe('funding')
+		expect(params.page).toBe(3)
+		expect(params.q).toBe('water')
+	})
+
+	test('invalid values fall back safely instead of failing', () => {
+		const params = parseAdminListParams(
+			adminProjectsQuerySchema,
+			new URLSearchParams('status=bogus&sort=nope&page=-4&pageSize=9999&from=not-a-date'),
+		)
+		expect(params.status).toBeUndefined()
+		expect(params.sort).toBe('newest')
+		expect(params.page).toBe(1)
+		expect(params.pageSize).toBe(ADMIN_DEFAULT_PAGE_SIZE)
+		expect(params.from).toBeUndefined()
+	})
+
+	test('caps pageSize at the maximum', () => {
+		const params = parseAdminListParams(
+			adminProjectsQuerySchema,
+			new URLSearchParams(`pageSize=${ADMIN_MAX_PAGE_SIZE + 1}`),
+		)
+		expect(params.pageSize).toBe(ADMIN_DEFAULT_PAGE_SIZE)
+	})
+
+	test('users schema validates kyc and wallet filters', () => {
+		const valid = parseAdminListParams(
+			adminUsersQuerySchema,
+			new URLSearchParams('kyc=not_started&wallet=pollar&provider=pollar&role=admin'),
+		)
+		expect(valid.kyc).toBe('not_started')
+		expect(valid.wallet).toBe('pollar')
+		expect(valid.provider).toBe('pollar')
+		expect(valid.role).toBe('admin')
+
+		const invalid = parseAdminListParams(
+			adminUsersQuerySchema,
+			new URLSearchParams('kyc=hacked&wallet=all'),
+		)
+		expect(invalid.kyc).toBeUndefined()
+		expect(invalid.wallet).toBeUndefined()
+	})
+
+	test('normalizeAdminListParams sorts keys and drops empty values', () => {
+		const normalized = normalizeAdminListParams({
+			sort: 'newest',
+			page: 2,
+			q: undefined,
+			status: '',
+			escrow: 'none',
+		})
+		expect(Object.keys(normalized)).toEqual(['escrow', 'page', 'sort'])
+		expect(normalized.page).toBe('2')
+	})
+
+	test('normalization is stable regardless of insertion order', () => {
+		const a = normalizeAdminListParams({ page: 1, sort: 'newest', status: 'review' })
+		const b = normalizeAdminListParams({ status: 'review', sort: 'newest', page: 1 })
+		expect(JSON.stringify(a)).toBe(JSON.stringify(b))
+	})
+
+	test('buildAdminListQueryString produces a canonical query string', () => {
+		const query = buildAdminListQueryString({ sort: 'newest', page: 2, q: 'clean water' })
+		expect(query).toBe('page=2&q=clean+water&sort=newest')
+	})
+})

--- a/apps/web/test/project-donation-status.test.ts
+++ b/apps/web/test/project-donation-status.test.ts
@@ -5,14 +5,7 @@ import {
 	type ProjectStatus,
 } from '~/lib/projects/project-status'
 
-const ALL_STATUSES: ProjectStatus[] = [
-	'draft',
-	'review',
-	'active',
-	'paused',
-	'funded',
-	'rejected',
-]
+const ALL_STATUSES: ProjectStatus[] = ['draft', 'review', 'active', 'paused', 'funded', 'rejected']
 
 describe('isProjectAcceptingDonations', () => {
 	test('returns true only for active campaigns', () => {

--- a/apps/web/test/wallet-transfer.config.test.ts
+++ b/apps/web/test/wallet-transfer.config.test.ts
@@ -7,7 +7,10 @@ import {
 	getWalletTransferConfig,
 	WALLET_TRANSFER_HORIZON_URLS,
 } from '~/lib/config/wallet-transfer.config'
-import { MAINNET_USDC_TRUSTLINE_ADDRESS, TESTNET_USDC_TRUSTLINE_ADDRESS } from '~/lib/constants/escrow'
+import {
+	MAINNET_USDC_TRUSTLINE_ADDRESS,
+	TESTNET_USDC_TRUSTLINE_ADDRESS,
+} from '~/lib/constants/escrow'
 
 describe('getWalletTransferConfig', () => {
 	test('returns testnet config when Trustless Work network is development', async () => {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -70,6 +70,10 @@
 		"./pollar": {
 			"import": "./src/pollar/index.ts",
 			"require": "./src/pollar/index.ts"
+		},
+		"./admin": {
+			"import": "./src/admin/index.ts",
+			"require": "./src/admin/index.ts"
 		}
 	},
 	"main": "./src/index.ts",

--- a/packages/lib/src/admin/feature.ts
+++ b/packages/lib/src/admin/feature.ts
@@ -1,0 +1,22 @@
+import { appEnvConfig } from '../config'
+
+const ADMIN_OPS_DASHBOARD_DISABLED_MESSAGE =
+	'The admin operations dashboard is disabled. Set NEXT_PUBLIC_ADMIN_OPS_DASHBOARD=true to enable.'
+
+/**
+ * Returns whether the redesigned admin operations dashboard is enabled.
+ * Always enabled in development; opt-in elsewhere via the env flag.
+ */
+export const isAdminOpsDashboardEnabled = (): boolean =>
+	appEnvConfig('web').features.enableAdminOpsDashboard
+
+/**
+ * Throws when the admin operations dashboard is disabled.
+ */
+export const assertAdminOpsDashboardEnabled = (): void => {
+	if (!isAdminOpsDashboardEnabled()) {
+		throw new Error(ADMIN_OPS_DASHBOARD_DISABLED_MESSAGE)
+	}
+}
+
+export const ADMIN_OPS_DASHBOARD_FEATURE_FLAG = 'NEXT_PUBLIC_ADMIN_OPS_DASHBOARD' as const

--- a/packages/lib/src/admin/index.ts
+++ b/packages/lib/src/admin/index.ts
@@ -1,0 +1,1 @@
+export * from './feature'

--- a/packages/lib/src/config/app-env.config.ts
+++ b/packages/lib/src/config/app-env.config.ts
@@ -40,6 +40,8 @@ export function transformEnv(): AppEnvInterface {
 				data.NODE_ENV === 'development' || data.NEXT_PUBLIC_ENABLE_ESCROW_FEATURE === 'true',
 			enableSmartAccountCreation: data.NEXT_PUBLIC_ENABLE_SMART_ACCOUNT_CREATION === 'true', // Must stay false on Mainnet production
 			enablePollarOnboarding: data.NEXT_PUBLIC_ENABLE_POLLAR_ONBOARDING === 'true',
+			enableAdminOpsDashboard:
+				data.NODE_ENV === 'development' || data.NEXT_PUBLIC_ADMIN_OPS_DASHBOARD === 'true',
 		},
 		vapid: {
 			email: data.VAPID_EMAIL || '',
@@ -153,6 +155,7 @@ function createAppConfigSchema<T extends keyof typeof appRequirements>(appName: 
 			enableEscrowFeature: z.boolean(),
 			enableSmartAccountCreation: z.boolean(),
 			enablePollarOnboarding: z.boolean(),
+			enableAdminOpsDashboard: z.boolean(),
 		}),
 		vapid: z.object({
 			email: z.string(),
@@ -418,6 +421,7 @@ export const baseEnvSchema = z.object({
 	NEXT_PUBLIC_ENABLE_ESCROW_FEATURE: z.enum(['true', 'false']).optional(),
 	NEXT_PUBLIC_ENABLE_SMART_ACCOUNT_CREATION: z.enum(['true', 'false']).optional(),
 	NEXT_PUBLIC_ENABLE_POLLAR_ONBOARDING: z.enum(['true', 'false']).optional(),
+	NEXT_PUBLIC_ADMIN_OPS_DASHBOARD: z.enum(['true', 'false']).optional(),
 	NEXT_PUBLIC_POLLAR_PUBLISHABLE_KEY: z.string().optional(),
 	POLLAR_SECRET_KEY: z.string().optional(),
 	POLLAR_API_BASE_URL: z.string().url('Invalid Pollar API base URL format').optional(),
@@ -536,6 +540,7 @@ export const appRequirements = {
 			'STELLAR_SIGNATURE_MAX_ATTEMPTS',
 			'STELLAR_SIGNATURE_WINDOW_MS',
 			'NEXT_PUBLIC_ENABLE_POLLAR_ONBOARDING',
+			'NEXT_PUBLIC_ADMIN_OPS_DASHBOARD',
 			'NEXT_PUBLIC_POLLAR_PUBLISHABLE_KEY',
 			'POLLAR_SECRET_KEY',
 			'POLLAR_API_BASE_URL',

--- a/packages/lib/src/types/config.types.ts
+++ b/packages/lib/src/types/config.types.ts
@@ -31,6 +31,7 @@ export interface AppEnvInterface {
 		enableEscrowFeature: boolean
 		enableSmartAccountCreation: boolean
 		enablePollarOnboarding: boolean
+		enableAdminOpsDashboard: boolean
 	}
 	vapid: {
 		email: string

--- a/services/supabase/migrations/20260824000000_admin_ops_dashboard.sql
+++ b/services/supabase/migrations/20260824000000_admin_ops_dashboard.sql
@@ -1,0 +1,163 @@
+/*
+  migration: admin operations dashboard aggregates
+  purpose:
+    - Provide a single aggregate RPC (public.get_admin_dashboard_stats) so the
+      admin dashboard can render counts without downloading full tables and
+      aggregating in application code.
+    - Add indexes backing the new server-side admin list filters (project
+      status/category/foundation, escrow state, profile signup date/role,
+      latest KYC review per user).
+  affected objects:
+    - function: public.get_admin_dashboard_stats()
+    - indexes on: public.projects, public.escrow_contracts, public.profiles,
+      public.kyc_reviews
+  safety:
+    - additive only; idempotent (CREATE INDEX IF NOT EXISTS / CREATE OR REPLACE).
+    - the RPC is SECURITY DEFINER and rejects callers that are neither the
+      service role nor a platform admin. EXECUTE is revoked from anon.
+*/
+
+CREATE OR REPLACE FUNCTION public.get_admin_dashboard_stats()
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  result jsonb;
+BEGIN
+  -- Callable only by the server (service role) or an authenticated platform admin.
+  IF NOT (coalesce(auth.role(), '') = 'service_role' OR public.is_platform_admin()) THEN
+    RAISE EXCEPTION 'forbidden: platform admin required' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT jsonb_build_object(
+    'projects', jsonb_build_object(
+      'total', (SELECT count(*) FROM public.projects),
+      'by_status', (
+        SELECT coalesce(jsonb_object_agg(s.status, s.cnt), '{}'::jsonb)
+        FROM (
+          SELECT status::text AS status, count(*) AS cnt
+          FROM public.projects
+          GROUP BY status
+        ) s
+      ),
+      'dev_only', (SELECT count(*) FROM public.projects WHERE development_only),
+      'without_escrow', (
+        SELECT count(*)
+        FROM public.projects p
+        WHERE p.status IN ('active', 'funded')
+          AND NOT EXISTS (
+            SELECT 1 FROM public.project_escrows pe WHERE pe.project_id = p.id
+          )
+      )
+    ),
+    'escrows', jsonb_build_object(
+      'total', (SELECT count(*) FROM public.escrow_contracts),
+      'by_state', (
+        SELECT coalesce(jsonb_object_agg(e.state, e.cnt), '{}'::jsonb)
+        FROM (
+          SELECT current_state::text AS state, count(*) AS cnt
+          FROM public.escrow_contracts
+          GROUP BY current_state
+        ) e
+      )
+    ),
+    'users', jsonb_build_object(
+      'total', (SELECT count(*) FROM public.profiles),
+      'by_role', (
+        SELECT coalesce(jsonb_object_agg(r.role, r.cnt), '{}'::jsonb)
+        FROM (
+          SELECT role::text AS role, count(*) AS cnt
+          FROM public.profiles
+          GROUP BY role
+        ) r
+      ),
+      'new_today', (
+        SELECT count(*) FROM public.profiles
+        WHERE created_at >= date_trunc('day', now())
+      ),
+      'new_week', (
+        SELECT count(*) FROM public.profiles
+        WHERE created_at >= now() - interval '7 days'
+      ),
+      'new_month', (
+        SELECT count(*) FROM public.profiles
+        WHERE created_at >= now() - interval '30 days'
+      )
+    ),
+    'kyc', (
+      WITH latest AS (
+        SELECT DISTINCT ON (user_id) user_id, status
+        FROM public.kyc_reviews
+        ORDER BY user_id, created_at DESC
+      )
+      SELECT jsonb_build_object(
+        'not_started', (
+          SELECT count(*) FROM public.profiles pr
+          WHERE NOT EXISTS (SELECT 1 FROM latest l WHERE l.user_id = pr.id)
+        ),
+        'pending', (SELECT count(*) FROM latest WHERE status = 'pending'),
+        'approved', (SELECT count(*) FROM latest WHERE status IN ('approved', 'verified')),
+        'rejected', (SELECT count(*) FROM latest WHERE status = 'rejected')
+      )
+    ),
+    'milestone_reviews', jsonb_build_object(
+      'pending', (
+        SELECT count(*) FROM public.milestone_review_requests WHERE status = 'pending'
+      )
+    ),
+    'contributions', jsonb_build_object(
+      'count', (SELECT count(*) FROM public.contributions),
+      'total_amount', (SELECT coalesce(sum(amount), 0) FROM public.contributions)
+    ),
+    'foundations', jsonb_build_object(
+      'total', (SELECT count(*) FROM public.foundations)
+    ),
+    'governance', jsonb_build_object(
+      'rounds_total', (SELECT count(*) FROM public.governance_rounds),
+      'rounds_active', (
+        SELECT count(*) FROM public.governance_rounds WHERE status = 'active'
+      )
+    ),
+    'generated_at', now()
+  )
+  INTO result;
+
+  RETURN result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_admin_dashboard_stats() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_admin_dashboard_stats() FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_admin_dashboard_stats() TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.get_admin_dashboard_stats() IS
+  'Aggregate counts for the admin operations dashboard. Admin/service-role only.';
+
+-- Indexes backing the new admin list filters. kyc_reviews(user_id) and
+-- milestone_review_requests(status) already exist from earlier migrations.
+CREATE INDEX IF NOT EXISTS idx_projects_status_created_at
+  ON public.projects (status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_projects_category_id
+  ON public.projects (category_id);
+
+CREATE INDEX IF NOT EXISTS idx_projects_foundation_id
+  ON public.projects (foundation_id);
+
+CREATE INDEX IF NOT EXISTS idx_escrow_contracts_current_state
+  ON public.escrow_contracts (current_state);
+
+CREATE INDEX IF NOT EXISTS idx_escrow_contracts_project_id
+  ON public.escrow_contracts (project_id);
+
+CREATE INDEX IF NOT EXISTS idx_profiles_created_at
+  ON public.profiles (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_profiles_role
+  ON public.profiles (role);
+
+CREATE INDEX IF NOT EXISTS idx_kyc_reviews_user_created_at
+  ON public.kyc_reviews (user_id, created_at DESC);

--- a/services/supabase/migrations/20260824000000_admin_ops_dashboard.sql
+++ b/services/supabase/migrations/20260824000000_admin_ops_dashboard.sql
@@ -45,9 +45,11 @@ BEGIN
       ),
       'dev_only', (SELECT count(*) FROM public.projects WHERE development_only),
       'without_escrow', (
+        -- Active (live) campaigns only, matching the action-center queue and
+        -- the pre-filtered destination (/admin/projects?escrow=none&status=active).
         SELECT count(*)
         FROM public.projects p
-        WHERE p.status IN ('active', 'funded')
+        WHERE p.status = 'active'
           AND NOT EXISTS (
             SELECT 1 FROM public.project_escrows pe WHERE pe.project_id = p.id
           )

--- a/services/supabase/migrations/20260824000001_admin_users_overview_view.sql
+++ b/services/supabase/migrations/20260824000001_admin_users_overview_view.sql
@@ -1,0 +1,43 @@
+/*
+  migration: admin users overview view
+  purpose:
+    - Provide a single relation the admin user list can filter server-side:
+      profile fields joined with each user's latest KYC review status
+      (kyc_reviews.user_id is not unique, so "latest" needs SQL).
+    - kyc_status is normalized: users with no review row read as
+      'not_started'.
+  safety:
+    - security_invoker: the view runs with the caller's permissions, so the
+      RLS policies of profiles and kyc_reviews still apply to non-service
+      callers. It exposes no KYC notes or provider payloads — only the
+      status, level, and review timestamp.
+*/
+
+CREATE OR REPLACE VIEW public.admin_users_overview
+WITH (security_invoker = on) AS
+SELECT
+	p.id,
+	p.display_name,
+	p.email,
+	p.image_url,
+	p.slug,
+	p.role,
+	p.onboarding_provider,
+	p.external_wallet_address,
+	p.pollar_wallet_address,
+	p.created_at,
+	p.updated_at,
+	COALESCE(k.status::text, 'not_started') AS kyc_status,
+	k.verification_level::text AS kyc_verification_level,
+	k.updated_at AS kyc_updated_at
+FROM public.profiles p
+LEFT JOIN LATERAL (
+	SELECT kr.status, kr.verification_level, kr.updated_at
+	FROM public.kyc_reviews kr
+	WHERE kr.user_id = p.id
+	ORDER BY kr.created_at DESC
+	LIMIT 1
+) k ON true;
+
+COMMENT ON VIEW public.admin_users_overview IS
+	'Profiles joined with the latest KYC review status. Backs the admin user list; no sensitive KYC payloads.';

--- a/services/supabase/src/database.schemas.ts
+++ b/services/supabase/src/database.schemas.ts
@@ -419,20 +419,21 @@ export const foundationEscrowsUpdateSchema = z.object({
   updated_at: z.string().optional(),
 });
 
-export const projectMemberRoleSchema = z.union([
-  z.literal("admin"),
-  z.literal("editor"),
-  z.literal("advisor"),
-  z.literal("community"),
-  z.literal("core"),
-  z.literal("others"),
-]);
+export const foundationMembersRowSchema = z.object({
+  foundation_id: z.string(),
+  id: z.string(),
+  joined_at: z.string(),
+  role: z.string(),
+  title: z.string(),
+  updated_at: z.string(),
+  user_id: z.string(),
+});
 
 export const foundationMembersInsertSchema = z.object({
   foundation_id: z.string(),
   id: z.string().optional(),
   joined_at: z.string().optional(),
-  role: projectMemberRoleSchema.optional(),
+  role: z.string(),
   title: z.string().optional(),
   updated_at: z.string().optional(),
   user_id: z.string(),
@@ -442,7 +443,7 @@ export const foundationMembersUpdateSchema = z.object({
   foundation_id: z.string().optional(),
   id: z.string().optional(),
   joined_at: z.string().optional(),
-  role: projectMemberRoleSchema.optional(),
+  role: z.string().optional(),
   title: z.string().optional(),
   updated_at: z.string().optional(),
   user_id: z.string().optional(),
@@ -954,16 +955,17 @@ export const onboardingProviderSchema = z.union([
 ]);
 
 export const userRoleSchema = z.union([
-  z.literal("donor"),
-  z.literal("creator"),
-  z.literal("pending"),
-  z.literal("admin"),
   z.literal("kinder"),
   z.literal("kindler"),
+  z.literal("pending"),
+  z.literal("admin"),
+  z.literal("donor"),
+  z.literal("creator"),
 ]);
 
 export const profilesInsertSchema = z.object({
   bio: z.string().optional().nullable(),
+  compliance_admin: z.boolean().optional(),
   country: z.string().optional().nullable(),
   created_at: z.string().optional(),
   creator_entity_type: creatorEntityTypeSchema.optional().nullable(),
@@ -991,6 +993,7 @@ export const profilesInsertSchema = z.object({
 
 export const profilesUpdateSchema = z.object({
   bio: z.string().optional().nullable(),
+  compliance_admin: z.boolean().optional(),
   country: z.string().optional().nullable(),
   created_at: z.string().optional(),
   creator_entity_type: creatorEntityTypeSchema.optional().nullable(),
@@ -1037,15 +1040,14 @@ export const projectEscrowsUpdateSchema = z.object({
   updated_at: z.string().optional(),
 });
 
-export const projectMembersRowSchema = z.object({
-  id: z.string(),
-  joined_at: z.string(),
-  project_id: z.string(),
-  role: projectMemberRoleSchema,
-  title: z.string(),
-  updated_at: z.string(),
-  user_id: z.string(),
-});
+export const projectMemberRoleSchema = z.union([
+  z.literal("admin"),
+  z.literal("editor"),
+  z.literal("advisor"),
+  z.literal("community"),
+  z.literal("core"),
+  z.literal("others"),
+]);
 
 export const projectMembersInsertSchema = z.object({
   id: z.string().optional(),
@@ -1307,6 +1309,33 @@ export const questDefinitionsUpdateSchema = z.object({
   updated_at: z.string().optional(),
 });
 
+export const referralProfilesRowSchema = z.object({
+  activated_at: z.string(),
+  created_at: z.string(),
+  on_chain_ready: z.boolean(),
+  referral_code: z.string(),
+  stellar_address: z.string().nullable(),
+  user_id: z.string(),
+});
+
+export const referralProfilesInsertSchema = z.object({
+  activated_at: z.string().optional(),
+  created_at: z.string().optional(),
+  on_chain_ready: z.boolean().optional(),
+  referral_code: z.string(),
+  stellar_address: z.string().optional().nullable(),
+  user_id: z.string(),
+});
+
+export const referralProfilesUpdateSchema = z.object({
+  activated_at: z.string().optional(),
+  created_at: z.string().optional(),
+  on_chain_ready: z.boolean().optional(),
+  referral_code: z.string().optional(),
+  stellar_address: z.string().optional().nullable(),
+  user_id: z.string().optional(),
+});
+
 export const referralStatusSchema = z.union([
   z.literal("pending"),
   z.literal("onboarded"),
@@ -1410,7 +1439,7 @@ export const userNftsInsertSchema = z.object({
   metadata_ipfs_hash: z.string().optional().nullable(),
   minted_at: z.string().optional(),
   stellar_address: z.string(),
-  tier: z.string().optional(),
+  tier: z.string(),
   token_id: z.number(),
   updated_at: z.string().optional(),
   user_id: z.string(),
@@ -1535,6 +1564,8 @@ export const waitlistInterestsUpdateSchema = z.object({
   source: z.string().optional().nullable(),
 });
 
+export const getAdminDashboardStatsReturnsSchema = jsonSchema;
+
 export const questStatusSchema = z.union([
   z.literal("active"),
   z.literal("completed"),
@@ -1585,16 +1616,6 @@ export const escrowContractsRowSchema = z.object({
   project_id: z.string(),
   receiver_address: z.string(),
   updated_at: z.string().nullable(),
-});
-
-export const foundationMembersRowSchema = z.object({
-  foundation_id: z.string(),
-  id: z.string(),
-  joined_at: z.string(),
-  role: projectMemberRoleSchema,
-  title: z.string(),
-  updated_at: z.string(),
-  user_id: z.string(),
 });
 
 export const foundationsRowSchema = z.object({
@@ -1682,6 +1703,7 @@ export const notificationsRowSchema = z.object({
 
 export const profilesRowSchema = z.object({
   bio: z.string().nullable(),
+  compliance_admin: z.boolean(),
   country: z.string().nullable(),
   created_at: z.string(),
   creator_entity_type: creatorEntityTypeSchema.nullable(),
@@ -1705,6 +1727,16 @@ export const profilesRowSchema = z.object({
   social_links: jsonSchema,
   updated_at: z.string(),
   website_url: z.string().nullable(),
+});
+
+export const projectMembersRowSchema = z.object({
+  id: z.string(),
+  joined_at: z.string(),
+  project_id: z.string(),
+  role: projectMemberRoleSchema,
+  title: z.string(),
+  updated_at: z.string(),
+  user_id: z.string(),
 });
 
 export const projectsRowSchema = z.object({

--- a/services/supabase/src/database.schemas.ts
+++ b/services/supabase/src/database.schemas.ts
@@ -1564,6 +1564,23 @@ export const waitlistInterestsUpdateSchema = z.object({
   source: z.string().optional().nullable(),
 });
 
+export const adminUsersOverviewRowSchema = z.object({
+  created_at: z.string().nullable(),
+  display_name: z.string().nullable(),
+  email: z.string().nullable(),
+  external_wallet_address: z.string().nullable(),
+  id: z.string().nullable(),
+  image_url: z.string().nullable(),
+  kyc_status: z.string().nullable(),
+  kyc_updated_at: z.string().nullable(),
+  kyc_verification_level: z.string().nullable(),
+  onboarding_provider: onboardingProviderSchema.nullable(),
+  pollar_wallet_address: z.string().nullable(),
+  role: userRoleSchema.nullable(),
+  slug: z.string().nullable(),
+  updated_at: z.string().nullable(),
+});
+
 export const getAdminDashboardStatsReturnsSchema = jsonSchema;
 
 export const questStatusSchema = z.union([

--- a/services/supabase/src/database.types.ts
+++ b/services/supabase/src/database.types.ts
@@ -809,6 +809,13 @@ export type Database = {
             foreignKeyName: "foundation_members_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
+            referencedRelation: "admin_users_overview"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "foundation_members_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
             referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
@@ -982,6 +989,13 @@ export type Database = {
           website_url?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "foundations_founder_id_fkey"
+            columns: ["founder_id"]
+            isOneToOne: false
+            referencedRelation: "admin_users_overview"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "foundations_founder_id_fkey"
             columns: ["founder_id"]
@@ -1263,7 +1277,21 @@ export type Database = {
             foreignKeyName: "milestone_review_requests_requester_id_fkey"
             columns: ["requester_id"]
             isOneToOne: false
+            referencedRelation: "admin_users_overview"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "milestone_review_requests_requester_id_fkey"
+            columns: ["requester_id"]
+            isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "milestone_review_requests_reviewer_id_fkey"
+            columns: ["reviewer_id"]
+            isOneToOne: false
+            referencedRelation: "admin_users_overview"
             referencedColumns: ["id"]
           },
           {
@@ -2037,7 +2065,21 @@ export type Database = {
             foreignKeyName: "user_follows_follower_id_fkey"
             columns: ["follower_id"]
             isOneToOne: false
+            referencedRelation: "admin_users_overview"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_follows_follower_id_fkey"
+            columns: ["follower_id"]
+            isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_follows_following_id_fkey"
+            columns: ["following_id"]
+            isOneToOne: false
+            referencedRelation: "admin_users_overview"
             referencedColumns: ["id"]
           },
           {
@@ -2093,6 +2135,13 @@ export type Database = {
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "user_nfts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "admin_users_overview"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "user_nfts_user_id_fkey"
             columns: ["user_id"]
@@ -2231,7 +2280,27 @@ export type Database = {
       }
     }
     Views: {
-      [_ in never]: never
+      admin_users_overview: {
+        Row: {
+          created_at: string | null
+          display_name: string | null
+          email: string | null
+          external_wallet_address: string | null
+          id: string | null
+          image_url: string | null
+          kyc_status: string | null
+          kyc_updated_at: string | null
+          kyc_verification_level: string | null
+          onboarding_provider:
+            | Database["public"]["Enums"]["onboarding_provider"]
+            | null
+          pollar_wallet_address: string | null
+          role: Database["public"]["Enums"]["user_role"] | null
+          slug: string | null
+          updated_at: string | null
+        }
+        Relationships: []
+      }
     }
     Functions: {
       activate_governance_rounds: { Args: never; Returns: undefined }

--- a/services/supabase/src/database.types.ts
+++ b/services/supabase/src/database.types.ts
@@ -7,10 +7,179 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.1"
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  next_auth: {
+    Tables: {
+      accounts: {
+        Row: {
+          access_token: string | null
+          expires_at: number | null
+          id: string
+          id_token: string | null
+          oauth_token: string | null
+          oauth_token_secret: string | null
+          provider: string
+          provider_account_id: string
+          refresh_token: string | null
+          scope: string | null
+          session_state: string | null
+          token_type: string | null
+          type: string
+          user_id: string | null
+        }
+        Insert: {
+          access_token?: string | null
+          expires_at?: number | null
+          id?: string
+          id_token?: string | null
+          oauth_token?: string | null
+          oauth_token_secret?: string | null
+          provider: string
+          provider_account_id: string
+          refresh_token?: string | null
+          scope?: string | null
+          session_state?: string | null
+          token_type?: string | null
+          type: string
+          user_id?: string | null
+        }
+        Update: {
+          access_token?: string | null
+          expires_at?: number | null
+          id?: string
+          id_token?: string | null
+          oauth_token?: string | null
+          oauth_token_secret?: string | null
+          provider?: string
+          provider_account_id?: string
+          refresh_token?: string | null
+          scope?: string | null
+          session_state?: string | null
+          token_type?: string | null
+          type?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      sessions: {
+        Row: {
+          expires: string
+          id: string
+          session_token: string
+          user_id: string | null
+        }
+        Insert: {
+          expires: string
+          id?: string
+          session_token: string
+          user_id?: string | null
+        }
+        Update: {
+          expires?: string
+          id?: string
+          session_token?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "sessions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      users: {
+        Row: {
+          email: string | null
+          email_verified: string | null
+          emailVerified: string | null
+          id: string
+          image: string | null
+          name: string | null
+        }
+        Insert: {
+          email?: string | null
+          email_verified?: string | null
+          emailVerified?: string | null
+          id?: string
+          image?: string | null
+          name?: string | null
+        }
+        Update: {
+          email?: string | null
+          email_verified?: string | null
+          emailVerified?: string | null
+          id?: string
+          image?: string | null
+          name?: string | null
+        }
+        Relationships: []
+      }
+      verification_tokens: {
+        Row: {
+          expires: string
+          identifier: string | null
+          token: string
+        }
+        Insert: {
+          expires: string
+          identifier?: string | null
+          token: string
+        }
+        Update: {
+          expires?: string
+          identifier?: string | null
+          token?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      uid: { Args: never; Returns: string }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
   }
   public: {
     Tables: {
@@ -605,7 +774,7 @@ export type Database = {
           foundation_id: string
           id: string
           joined_at: string
-          role: Database["public"]["Enums"]["project_member_role"]
+          role: string
           title: string
           updated_at: string
           user_id: string
@@ -614,7 +783,7 @@ export type Database = {
           foundation_id: string
           id?: string
           joined_at?: string
-          role?: Database["public"]["Enums"]["project_member_role"]
+          role: string
           title?: string
           updated_at?: string
           user_id: string
@@ -623,7 +792,7 @@ export type Database = {
           foundation_id?: string
           id?: string
           joined_at?: string
-          role?: Database["public"]["Enums"]["project_member_role"]
+          role?: string
           title?: string
           updated_at?: string
           user_id?: string
@@ -634,6 +803,13 @@ export type Database = {
             columns: ["foundation_id"]
             isOneToOne: false
             referencedRelation: "foundations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "foundation_members_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
         ]
@@ -805,7 +981,15 @@ export type Database = {
           vision?: string | null
           website_url?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "foundations_founder_id_fkey"
+            columns: ["founder_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       governance_options: {
         Row: {
@@ -1263,6 +1447,7 @@ export type Database = {
       profiles: {
         Row: {
           bio: string | null
+          compliance_admin: boolean
           country: string | null
           created_at: string
           creator_entity_type:
@@ -1291,6 +1476,7 @@ export type Database = {
         }
         Insert: {
           bio?: string | null
+          compliance_admin?: boolean
           country?: string | null
           created_at?: string
           creator_entity_type?:
@@ -1319,6 +1505,7 @@ export type Database = {
         }
         Update: {
           bio?: string | null
+          compliance_admin?: boolean
           country?: string | null
           created_at?: string
           creator_entity_type?:
@@ -1736,6 +1923,33 @@ export type Database = {
         }
         Relationships: []
       }
+      referral_profiles: {
+        Row: {
+          activated_at: string
+          created_at: string
+          on_chain_ready: boolean
+          referral_code: string
+          stellar_address: string | null
+          user_id: string
+        }
+        Insert: {
+          activated_at?: string
+          created_at?: string
+          on_chain_ready?: boolean
+          referral_code: string
+          stellar_address?: string | null
+          user_id: string
+        }
+        Update: {
+          activated_at?: string
+          created_at?: string
+          on_chain_ready?: boolean
+          referral_code?: string
+          stellar_address?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
       referral_records: {
         Row: {
           contract_address: string | null
@@ -1769,33 +1983,6 @@ export type Database = {
           referrer_id?: string
           status?: Database["public"]["Enums"]["referral_status"]
           total_donations?: number
-        }
-        Relationships: []
-      }
-      referral_profiles: {
-        Row: {
-          activated_at: string
-          created_at: string
-          on_chain_ready: boolean
-          referral_code: string
-          stellar_address: string | null
-          user_id: string
-        }
-        Insert: {
-          activated_at?: string
-          created_at?: string
-          on_chain_ready?: boolean
-          referral_code: string
-          stellar_address?: string | null
-          user_id: string
-        }
-        Update: {
-          activated_at?: string
-          created_at?: string
-          on_chain_ready?: boolean
-          referral_code?: string
-          stellar_address?: string | null
-          user_id?: string
         }
         Relationships: []
       }
@@ -1886,7 +2073,7 @@ export type Database = {
           metadata_ipfs_hash?: string | null
           minted_at?: string
           stellar_address: string
-          tier?: string
+          tier: string
           token_id: number
           updated_at?: string
           user_id: string
@@ -1905,7 +2092,15 @@ export type Database = {
           updated_at?: string
           user_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "user_nfts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       user_quest_progress: {
         Row: {
@@ -2055,6 +2250,7 @@ export type Database = {
         Returns: string
       }
       current_auth_user_id: { Args: never; Returns: string }
+      get_admin_dashboard_stats: { Args: never; Returns: Json }
       get_current_user_profile: {
         Args: never
         Returns: {
@@ -2148,12 +2344,12 @@ export type Database = {
       streak_period: "weekly" | "monthly"
       translation_status: "pending" | "complete" | "failed" | "stale"
       user_role:
-        | "donor"
-        | "creator"
-        | "pending"
-        | "admin"
         | "kinder"
         | "kindler"
+        | "pending"
+        | "admin"
+        | "donor"
+        | "creator"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -2279,6 +2475,12 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  next_auth: {
+    Enums: {},
+  },
   public: {
     Enums: {
       backup_state: ["not_backed_up", "backed_up"],
@@ -2338,7 +2540,8 @@ export const Constants = {
       referral_status: ["pending", "onboarded", "first_donation", "active"],
       streak_period: ["weekly", "monthly"],
       translation_status: ["pending", "complete", "failed", "stale"],
-      user_role: ["donor", "creator", "pending", "admin", "kinder", "kindler"],
+      user_role: ["kinder", "kindler", "pending", "admin", "donor", "creator"],
     },
   },
 } as const
+


### PR DESCRIPTION
Closes #1005

## What this does

Refactors `/admin` into an action-oriented operations dashboard that answers *"what requires admin attention right now, and where do I resolve it?"* — while preserving every existing admin capability, the existing authorization model, and the existing Trustless Work transaction paths.

The redesign ships behind a feature flag (`NEXT_PUBLIC_ADMIN_OPS_DASHBOARD`, always on in development). With the flag off, the legacy admin UI renders exactly as before — legacy components are untouched, so rollback is a single env change.

## Action center (`/admin`)

- Eight pending-work queues loaded in parallel: projects awaiting review, active projects without an escrow, pending milestone reviews, disputed escrows and broken escrow associations, KYC cases, new users, stalled drafts, and paused campaigns.
- Every queue item shows what needs attention, the associated entity, waiting time, derived priority, current status, and a **direct primary action** that routes into the existing resolution workflow (project manage, escrow setup/ops via `PROJECT_MANAGE_NAV_SECTIONS`, the milestone review queue, or a pre-filtered user list).
- Each queue degrades independently (`Promise.allSettled`) — one failed query never takes down the dashboard, and failed queues render a retry control.
- Platform metrics are reorganized below the queues; **every metric card links to a pre-filtered management view** (e.g. *KYC pending* → `/admin/users?kyc=pending`).
- Counts come from a new `get_admin_dashboard_stats()` RPC (SECURITY DEFINER, guarded by `is_platform_admin()`, EXECUTE revoked from `anon`) instead of downloading up to four full tables and aggregating in JS.

## Projects

- Visual cards with cover image (and fallback), title, creator/foundation, category, location, status + escrow badges, dev-only badge, funding progress, and supporter count.
- State-driven primary action: draft → *View setup*, review → *Review project*, active without escrow → *Create escrow*, active with escrow → *Manage escrow*, paused → *Review campaign*, funded → *View campaign*. All hrefs come from the existing project-manage navigation helpers.
- Server-side search (title, slug, project ID, creator/foundation names resolved to ids), filters (status, escrow availability/state, category, foundation, dev-only, date range), sorting, and `range()`-based pagination — replacing the previous 1,000-row fetch.
- All list state lives in the URL, so filtered views can be bookmarked and shared. Invalid filter values fall back to safe defaults.
- Status changes keep flowing through the existing authorized lifecycle endpoint and `isAllowedStatusTransition` state machine — untouched.

## Escrows

- The associated project (image, title, slug, status) now leads each row; the contract address is a copyable, middle-truncated secondary identifier.
- Association health is computed per row: an escrow without a `project_escrows` join row (or with an unresolvable project) is visibly flagged — never presented as an ordinary healthy escrow.
- Actions: *Manage escrow* (routes to the project's `escrow-manage` workspace), *View project*, Stellar Explorer link that **passes the configured network** (no more `NODE_ENV` fallback on admin surfaces), copy address, and *Sync* via an audited admin wrapper around the existing `syncEscrowToDatabaseAction`.
- On-chain/indexer detail (balance, release approvals, dispute/release flags, indexer gaps) loads **only when a row is expanded** — never for the whole list at once.

## Users & KYC

- New `admin_users_overview` view (security invoker) joins profiles with each user's **latest** KYC review (`kyc_reviews.user_id` is not unique, so "latest per user" needs SQL). Users without a review row read as `not_started`.
- KYC stat cards (not started / pending / approved+verified / rejected) toggle the list filter; dashboard stats include new users today/this week/this month.
- Filters: role, KYC bucket, onboarding provider, wallet readiness (Pollar / external / none), signup date. Search: name, email, handle, user ID (UUID), wallet address.
- The API response and the view expose only operational fields — **never `kyc_reviews.notes`** (which holds Didit session tokens) or provider payloads. There is deliberately no KYC detail view in list surfaces.

## Navigation & layout

- Ops-oriented order: Overview & Queue, Projects, Escrows, Milestone Reviews, Users & KYC, Foundations, then Governance / Gamification / Compliance / Analytics / Settings.
- Pending-work badges on nav items, fed by a shared `countsOnly` stats query and invalidated when admin mutations complete.
- Mobile no longer stacks the full nav above every page: small screens get a compact bar + sheet menu that closes on navigation.
- Breadcrumbs derived from the admin path, and a validated `?from=` back-link: queue actions that route into a project's manage workspace show *Back to admin queue* in the command center (only `/admin`-prefixed values are accepted — no open redirects).
- The milestone-review status filter moved into the URL so the action center can deep-link `?status=pending`.

## Blockchain safety & auditability

- Shared `ConfirmActionDialog` for high-impact actions: shows the entity, the `current → new` state, and — for blockchain mutations — the **active Stellar network and connected signer** before anything is signed or submitted. The confirm button disables while pending, so duplicate submissions cannot happen.
- Wired into: milestone review approve/reject, campaign status changes, escrow **deploy / fund / release** (wrapping the existing submit handlers only — signing and submission logic unchanged), gamification contract triggers, quest backfills, and governance round creation.
- No auto-connect, no auto-sign, no auto-submit anywhere; smart-account C-address restrictions and escrow type resolution are untouched.
- New server-only `recordAdminAudit()` writes consequential admin actions to `public.audit_logs` (`admin_*` operations): admin, action, target, previous/new state, tx hash, and failure details — with metadata deliberately kept free of secrets and PII. It never throws, so a failed audit write cannot block the action it describes.
- The duplicated per-route admin guards in the gamification routes were replaced with a single shared `requireAdminApi()`, used by every `/api/admin/*` route.

## Data & performance

- All redesigned lists use one consistent data path: validated query params → `requireAdminApi()` → service-role queries → `{ items, total, page, pageSize }`, with stable `['admin', surface, params]` query keys shared between server prefetch and client hooks (hydration always matches).
- This also removes the previous pattern where admin data was refetched client-side with the **anon** Supabase key.
- New idempotent indexes back the new filters (project status/category/foundation, escrow state/project, profile signup date/role, latest KYC review per user).
- Supabase types and Zod schemas regenerated (`bun run gen`) — the regen also catches the generated files up with migrations that landed since the last generation.
- Only affected query keys are invalidated after mutations; on-chain escrow data is fetched per-row on expand, never in bulk.

## Accessibility

Text labels on every status (never color alone), accessible names on icon-only controls, `aria-valuenow` funding progress bars, `<time>` elements for relative dates, visible focus rings, keyboard-navigable dialogs/menus/pagination, layout-preserving skeletons, empty states that explain why, error states with retry, truncation-safe layouts for long emails/titles/addresses, and `prefers-reduced-motion` support.

## Verification

- `bun test`: 349 tests — all pre-existing passes intact, 24 new unit tests (query param validation and fallbacks, queue priority derivation, state-driven project actions, audit row mapping).
- `tsc --noEmit`: no new type errors versus the `develop` baseline.
- Biome clean on all touched files.
- The new migration was applied to a local Supabase stack and the RPC verified as service role (works), authenticated non-admin (`forbidden`), and anon (`permission denied`).
- Every new list query was exercised live against seeded local data (filters, search by title/creator/UUID/contract, escrow-state and association-health cases, KYC buckets including `not_started`).
- End-to-end smoke test with a real admin session against the local stack: the action center, filtered project/escrow/user views, and milestone queue all render server-side with correct data; `/api/admin/*` returns 401/403 without an admin session; the users API response was inspected to confirm no sensitive KYC fields leak.

## Rollout & rollback

1. Apply the two migrations (`20260824000000_admin_ops_dashboard.sql`, `20260824000001_admin_users_overview_view.sql`) — both additive and idempotent.
2. The new UI is on by default only in development. Enable in production with `NEXT_PUBLIC_ADMIN_OPS_DASHBOARD=true`.
3. Rollback at any time by unsetting the flag — the legacy UI and its data paths are fully intact.

## Follow-ups (out of scope, worth tracking)

- The temporary `USING (true)` RLS policy on `profiles` (marked ⚠️ in `20250220114242_create_rls_policies.sql`) is what lets the *legacy* flag-off admin lists read data with the anon key. Once the legacy UI is removed, that policy should be tightened.
- `public.audit_logs` is readable by any authenticated user under its current RLS; consider restricting SELECT to admins.
- `pg_trgm` indexes if `ilike` search needs to scale beyond current volumes.
- A fresh `supabase db reset` cannot replay the historical migration chain (pre-existing ordering issues and remote-only tables such as `foundations` — unrelated to this PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional Admin Operations Dashboard with action queues, metrics, searchable and filterable project, escrow, and user lists.
  - Added responsive admin navigation, breadcrumbs, status badges, pagination, copy controls, and back-to-queue links.
  - Added escrow detail inspection and administrator synchronization tools.
  - Added audit logging for key administrative and governance actions.
  - Added confirmation dialogs for high-impact actions, including blockchain network and signer details.
- **Documentation**
  - Documented dashboard access, feature configuration, safeguards, and audit logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->