### PR TITLE
docs(kyc): document Didit check-status canonical fields

### DIFF
--- a/docs/kyc-integration/api-endpoints.md
+++ b/docs/kyc-integration/api-endpoints.md
@@ -151,11 +151,31 @@ Decision payloads, documents, and biometrics are not stored or logged.
 ```typescript
 {
   success: boolean
-  status?: 'pending' | 'approved' | 'rejected' | 'verified'
+  status?: CanonicalKycStatus | null
+  canonicalStatus?: CanonicalKycStatus
+  storedCanonicalStatus?: CanonicalKycStatus
   diditStatus?: string
   message?: string
 }
+
+type CanonicalKycStatus =
+  | 'not_started'
+  | 'pending'
+  | 'in_review'
+  | 'approved'
+  | 'rejected'
+  | 'expired'
+  | 'manual_review'
+  | 'provider_unavailable'
 ```
+
+These HTTP 200 bodies are the contract clients should switch on:
+
+- **Didit reachable**: `success: true`. `status` and `canonicalStatus` are the mapped KindFi status. `diditStatus` is the raw Didit session value (for example `Approved`, `In Review`). `message` is omitted.
+- **No session**: `success: false`, `status: null`, `canonicalStatus: "not_started"`, `message: "No KYC session found"`.
+- **`provider_unavailable`**: `success: false` when the Didit API cannot be reached. `canonicalStatus` is `"provider_unavailable"`. `status` and `storedCanonicalStatus` are the last persisted canonical status. `message` is `"Didit status is temporarily unavailable"`. The stored session row is not overwritten.
+
+`storedCanonicalStatus` is present only on the `provider_unavailable` outcome. Use it (or `status`) to keep showing the last known decision; do not treat `canonicalStatus: "provider_unavailable"` as a new Didit result.
 
 **Flow**:
 
@@ -168,8 +188,8 @@ Decision payloads, documents, and biometrics are not stored or logged.
 **Error Handling**:
 
 - `401`: Unauthorized
-- `404`: No KYC session found
-- `500`: Didit API error or database error
+- `500`: Unexpected database or server error
+- Provider and missing-session cases above return HTTP 200 with `success: false` (not 4xx/5xx)
 
 ---
 


### PR DESCRIPTION
## Summary
- Document `canonicalStatus` and `storedCanonicalStatus` on `POST /api/kyc/didit/check-status`.
- Document the `provider_unavailable` HTTP 200 outcome (Didit unreachable; stored status is not overwritten).
- Keep existing `success`, `status`, `diditStatus`, and `message` fields in the contract.

Closes #1041

Follow-up to the CodeRabbit review on #1019.

## Test plan
- [ ] Read `docs/kyc-integration/api-endpoints.md` section 4 and confirm the response schema matches `apps/web/app/api/kyc/didit/check-status/route.ts`.
- [ ] Confirm success, no-session, and `provider_unavailable` outcomes are all described.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the KYC status-check API documentation with the new canonical status fields.
  * Clarified successful response scenarios, including unavailable providers and missing sessions.
  * Revised error-handling guidance for server and database failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->