### PR TITLE
fix(kyc): keep authorization decisions available when audit write fails

### DIFF
--- a/apps/web/lib/kyc/authorization-service.ts
+++ b/apps/web/lib/kyc/authorization-service.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger'
 import type { KycAuthorizationAuditEvent } from './audit-log'
 import { getKycEnforcedActions, getKycEnforcementMode } from './enforcement-config'
 import { isApprovedKycStatus, reasonCodeForStatus, requiredActionForStatus } from './status'
@@ -92,19 +93,28 @@ export const authorizeFinancialAction = async (
 	const allowed = enforced ? hypothetical.policyResult === 'allow' : true
 
 	const recordAudit = deps.recordAudit ?? (await import('./audit-log')).recordKycAuthorizationEvent
-	await recordAudit({
-		userId: input.userId,
-		action: input.action,
-		currentKycStatus,
-		mode,
-		decisionAllowed: allowed,
-		hypotheticalAllowed: hypothetical.policyResult === 'allow',
-		policyResult: hypothetical.policyResult,
-		reasonCode: hypothetical.reasonCode,
-		amount: input.amount,
-		asset: input.asset,
-		network: input.network,
-	})
+	try {
+		await recordAudit({
+			userId: input.userId,
+			action: input.action,
+			currentKycStatus,
+			mode,
+			decisionAllowed: allowed,
+			hypotheticalAllowed: hypothetical.policyResult === 'allow',
+			policyResult: hypothetical.policyResult,
+			reasonCode: hypothetical.reasonCode,
+			amount: input.amount,
+			asset: input.asset,
+			network: input.network,
+		})
+	} catch (auditError) {
+		logger.warn('[kyc] Failed to record authorization audit', {
+			error: auditError instanceof Error ? auditError.message : 'unknown',
+			userId: input.userId,
+			action: input.action,
+			mode,
+		})
+	}
 
 	return {
 		allowed,

--- a/apps/web/test/authorization-service.test.ts
+++ b/apps/web/test/authorization-service.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+
+import { authorizeFinancialAction } from '../lib/kyc/authorization-service'
+import type {
+	AuthorizeFinancialActionDeps,
+	AuthorizeFinancialActionInput,
+	CanonicalKycStatus,
+	KycEnforcementMode,
+	KycFinancialAction,
+} from '../lib/kyc/types'
+import { logger } from '../lib/logger'
+
+const baseInput: AuthorizeFinancialActionInput = {
+	userId: 'user-1',
+	action: 'donate',
+	amount: 100,
+	asset: 'XLM',
+	network: 'testnet',
+}
+
+function buildDeps(overrides: {
+	mode: KycEnforcementMode
+	status: CanonicalKycStatus
+	enforced?: KycFinancialAction[]
+	recordAudit: AuthorizeFinancialActionDeps['recordAudit']
+}): AuthorizeFinancialActionDeps {
+	return {
+		getMode: () => overrides.mode,
+		getEnforcedActions: () => overrides.enforced ?? ['donate'],
+		getStatus: async () => overrides.status,
+		recordAudit: overrides.recordAudit,
+	}
+}
+
+describe('authorizeFinancialAction audit resilience', () => {
+	let warnSpy: ReturnType<typeof spyOn>
+
+	beforeEach(() => {
+		warnSpy = spyOn(logger, 'warn').mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		warnSpy.mockRestore()
+	})
+
+	test('monitor mode returns the computed decision when audit fails', async () => {
+		const recordAudit = mock(() => Promise.reject(new Error('supabase down')))
+
+		const result = await authorizeFinancialAction(
+			baseInput,
+			buildDeps({ mode: 'monitor', status: 'not_started', recordAudit }),
+		)
+
+		expect(recordAudit).toHaveBeenCalledTimes(1)
+		expect(result.allowed).toBe(true)
+		expect(result.enforced).toBe(false)
+		expect(result.mode).toBe('monitor')
+		expect(result.currentKycStatus).toBe('not_started')
+		expect(result.policyResult).toBe('deny')
+	})
+
+	test('enforced mode preserves an already-approved allow decision when audit fails', async () => {
+		const recordAudit = mock(() => Promise.reject(new Error('write timeout')))
+
+		const result = await authorizeFinancialAction(
+			baseInput,
+			buildDeps({ mode: 'enforced', status: 'approved', recordAudit }),
+		)
+
+		expect(recordAudit).toHaveBeenCalledTimes(1)
+		expect(result.allowed).toBe(true)
+		expect(result.enforced).toBe(true)
+		expect(result.policyResult).toBe('allow')
+		expect(result.reasonCode).toBe('kyc_approved')
+	})
+
+	test('enforced mode preserves a deny decision when audit fails', async () => {
+		const recordAudit = mock(() => Promise.reject(new Error('rls violation')))
+
+		const result = await authorizeFinancialAction(
+			baseInput,
+			buildDeps({ mode: 'enforced', status: 'pending', recordAudit }),
+		)
+
+		expect(recordAudit).toHaveBeenCalledTimes(1)
+		expect(result.allowed).toBe(false)
+		expect(result.enforced).toBe(true)
+		expect(result.policyResult).toBe('deny')
+		expect(result.reasonCode).toBe('kyc_pending')
+		expect(result.requiredAction).toBe('wait_for_review')
+	})
+
+	test('successful audit path still returns the same decision object', async () => {
+		const recordAudit = mock(() => Promise.resolve())
+
+		const result = await authorizeFinancialAction(
+			baseInput,
+			buildDeps({ mode: 'enforced', status: 'approved', recordAudit }),
+		)
+
+		expect(recordAudit).toHaveBeenCalledTimes(1)
+		expect(result.allowed).toBe(true)
+		expect(result.policyResult).toBe('allow')
+		expect(warnSpy).not.toHaveBeenCalled()
+	})
+
+	test('audit failure log includes limited context and omits amount, asset, and network', async () => {
+		const recordAudit = mock(() => Promise.reject(new Error('supabase down')))
+
+		await authorizeFinancialAction(
+			baseInput,
+			buildDeps({ mode: 'enforced', status: 'approved', recordAudit }),
+		)
+
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+		const [message, data] = warnSpy.mock.calls[0]
+		expect(message).toBe('[kyc] Failed to record authorization audit')
+		expect(data).toEqual({
+			error: 'supabase down',
+			userId: 'user-1',
+			action: 'donate',
+			mode: 'enforced',
+		})
+		expect(data).not.toHaveProperty('amount')
+		expect(data).not.toHaveProperty('asset')
+		expect(data).not.toHaveProperty('network')
+	})
+})


### PR DESCRIPTION
## Summary
- `authorizeFinancialAction` in `apps/web/lib/kyc/authorization-service.ts` now wraps the `recordAudit` call in a try/catch, so an audit-storage failure no longer propagates and no longer changes the decision returned to the caller.
- On audit failure, logs `[kyc] Failed to record authorization audit` via `logger.warn` with `userId`, `action`, `mode`, and the error message. `amount`, `asset`, and `network` are intentionally omitted per the "limited context" requirement.

## Why
Before this change, if the audit write to Supabase threw, the entire `authorizeFinancialAction` promise rejected. In `monitor` mode that turned into an HTTP 500 for a decision that was supposed to be non-authoritative; in `enforced` mode it blocked already-approved actions purely because logging failed. Audit availability should not gate authorization outcomes.

Fixes #1032

## How it was tested
Ran from `apps/web`:

`bun test test/authorization-service.test.ts`

- Monitor mode + `recordAudit` rejects: returns `allowed: true` with the computed hypothetical, does not throw.
- Enforced mode + approved user + `recordAudit` rejects: returns `allowed: true`, does not throw.
- Enforced mode + non-approved user + `recordAudit` rejects: returns `allowed: false` with the correct `reasonCode` and `requiredAction`, does not throw.
- Successful audit path still returns the same decision object and does not log a warning.
- Audit failure log carries only `userId`, `action`, `mode`, and error message; no `amount`, `asset`, or `network`.

Also ran `bunx biome ci` on the two touched files.

## Notes
- Zero changes to the public `authorizeFinancialAction` signature, the `AuthorizeFinancialActionDeps` shape, or the `KycAuthorizationResult` return object.
- The existing `logger.warn` singleton at `apps/web/lib/logger.ts` already sanitises log payloads, so redaction remains centralized.
- No schema, migration, or `audit-log.ts` changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization decisions now proceed even when audit logging fails.
  * Allow and deny outcomes remain consistent in both monitoring and enforced modes.
  * Audit failures generate warnings without exposing sensitive transaction details.

* **Tests**
  * Added coverage for audit failures, successful logging, authorization outcomes, and warning content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->