### PR TITLE
fix(kyc): preserve approved status over newer non-approved sessions

### DIFF
--- a/apps/web/lib/kyc/session-service.ts
+++ b/apps/web/lib/kyc/session-service.ts
@@ -143,9 +143,38 @@ export const resolveKycStatus = (params: {
 	return params.sessionStatus ?? canonicalFromDbStatus(params.reviewStatus)
 }
 
+export const hasAnyApprovedSessionForUser = async (userId: string): Promise<boolean> => {
+	const { data, error } = await getKycSchemaClient()
+		.from('didit_sessions')
+		.select('id')
+		.eq('user_id', userId)
+		.eq('canonical_status', 'approved')
+		.limit(1)
+		.maybeSingle()
+
+	if (error) {
+		logger.error('[kyc] Failed to check for approved sessions', {
+			error: error.message,
+		})
+		return false
+	}
+
+	return data !== null
+}
+
 export const getCanonicalKycStatusForUser = async (userId: string): Promise<CanonicalKycStatus> => {
 	const session = await findLatestDiditSessionForUser(userId)
 	if (session?.canonicalStatus === 'approved') {
+		return 'approved'
+	}
+
+	/**
+	 * Guard: if any older session is approved, preserve that status even
+	 * when the newest session is non-approved (e.g. a new verification
+	 * attempt still in progress). A newer non-approved session must not
+	 * downgrade a previously approved user.
+	 */
+	if (await hasAnyApprovedSessionForUser(userId)) {
 		return 'approved'
 	}
 

--- a/apps/web/lib/kyc/session-service.ts
+++ b/apps/web/lib/kyc/session-service.ts
@@ -129,14 +129,32 @@ const findLatestKycReview = async (
 	return { id: data.id, status: data.status as KycDbStatus }
 }
 
+export const resolveKycStatus = (params: {
+	sessionStatus: CanonicalKycStatus | null
+	reviewStatus: KycDbStatus | null
+}): CanonicalKycStatus => {
+	if (
+		params.sessionStatus === 'approved' ||
+		canonicalFromDbStatus(params.reviewStatus) === 'approved'
+	) {
+		return 'approved'
+	}
+
+	return params.sessionStatus ?? canonicalFromDbStatus(params.reviewStatus)
+}
+
 export const getCanonicalKycStatusForUser = async (userId: string): Promise<CanonicalKycStatus> => {
 	const session = await findLatestDiditSessionForUser(userId)
-	if (session) {
-		return session.canonicalStatus
+	if (session?.canonicalStatus === 'approved') {
+		return 'approved'
 	}
 
 	const review = await findLatestKycReview(userId)
-	return canonicalFromDbStatus(review?.status)
+
+	return resolveKycStatus({
+		sessionStatus: session?.canonicalStatus ?? null,
+		reviewStatus: review?.status ?? null,
+	})
 }
 
 export const upsertKycReviewStatus = async (params: {

--- a/apps/web/test/kyc-session-preservation.test.ts
+++ b/apps/web/test/kyc-session-preservation.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, mock } from 'bun:test'
+
+/**
+ * Mock Supabase clients before importing session-service.
+ * The module-level imports trigger Supabase client creation which requires
+ * env vars. We mock them so the pure functions can be tested in isolation.
+ */
+mock.module('@packages/lib/supabase', () => ({
+	supabase: { from: () => ({}) },
+}))
+
+mock.module('~/lib/logger', () => ({
+	logger: { error: () => {}, warn: () => {}, info: () => {} },
+}))
+
+mock.module('~/lib/kyc/supabase-kyc-client', () => ({
+	getKycSchemaClient: () => ({ from: () => ({}) }),
+}))
+
+const { resolveKycStatus } = await import('~/lib/kyc/session-service')
+
+/**
+ * Regression tests for #1035: Preserve approved KYC status over newer
+ * non-approved sessions.
+ *
+ * The resolution logic must ensure that an approved KYC review (or session)
+ * is never downgraded by a newer non-approved Didit session.
+ */
+
+describe('resolveKycStatus', () => {
+	it('returns approved when session is approved', () => {
+		const result = resolveKycStatus({
+			sessionStatus: 'approved',
+			reviewStatus: null,
+		})
+		expect(result).toBe('approved')
+	})
+
+	it('returns approved when review is approved and session is non-approved', () => {
+		/**
+		 * Regression scenario: user has an approved review but started a new
+		 * verification session that is still pending. The approved review must
+		 * take precedence over the newer non-approved session.
+		 */
+		const result = resolveKycStatus({
+			sessionStatus: 'pending',
+			reviewStatus: 'approved',
+		})
+		expect(result).toBe('approved')
+	})
+
+	it('returns approved when review is approved and session is rejected', () => {
+		/**
+		 * An approved review should still take precedence even if the newer
+		 * session was explicitly rejected.
+		 */
+		const result = resolveKycStatus({
+			sessionStatus: 'rejected',
+			reviewStatus: 'approved',
+		})
+		expect(result).toBe('approved')
+	})
+
+	it('returns approved when review is approved and session is not_started', () => {
+		const result = resolveKycStatus({
+			sessionStatus: 'not_started',
+			reviewStatus: 'approved',
+		})
+		expect(result).toBe('approved')
+	})
+
+	it('preserves session-first resolution for non-approved cases', () => {
+		/**
+		 * When neither session nor review is approved, session status should
+		 * take precedence (current session-first behavior preserved).
+		 */
+		const result = resolveKycStatus({
+			sessionStatus: 'pending',
+			reviewStatus: null,
+		})
+		expect(result).toBe('pending')
+	})
+
+	it('returns not_started when both are null', () => {
+		const result = resolveKycStatus({
+			sessionStatus: null,
+			reviewStatus: null,
+		})
+		expect(result).toBe('not_started')
+	})
+
+	it('returns review status as fallback when session is null', () => {
+		const result = resolveKycStatus({
+			sessionStatus: null,
+			reviewStatus: 'rejected',
+		})
+		expect(result).toBe('rejected')
+	})
+
+	it('returns session status when review is null and session is non-approved', () => {
+		const result = resolveKycStatus({
+			sessionStatus: 'in_review',
+			reviewStatus: null,
+		})
+		expect(result).toBe('in_review')
+	})
+
+	it('returns session status when both are non-approved (session-first)', () => {
+		const result = resolveKycStatus({
+			sessionStatus: 'expired',
+			reviewStatus: 'pending',
+		})
+		expect(result).toBe('expired')
+	})
+
+	it('returns approved when both session and review are approved', () => {
+		const result = resolveKycStatus({
+			sessionStatus: 'approved',
+			reviewStatus: 'approved',
+		})
+		expect(result).toBe('approved')
+	})
+
+	it('returns approved when review is verified (legacy alias) and session is pending', () => {
+		/**
+		 * 'verified' maps to 'approved' via canonicalFromDbStatus, so this
+		 * is another form of the regression scenario.
+		 */
+		const result = resolveKycStatus({
+			sessionStatus: 'pending',
+			reviewStatus: 'verified',
+		})
+		expect(result).toBe('approved')
+	})
+
+	it('returns approved when session is rejected but review is approved', () => {
+		/**
+		 * Even if a newer session was declined, an approved review must
+		 * preserve the approved state.
+		 */
+		const result = resolveKycStatus({
+			sessionStatus: 'rejected',
+			reviewStatus: 'approved',
+		})
+		expect(result).toBe('approved')
+	})
+
+	it('returns approved when session is expired but review is approved', () => {
+		const result = resolveKycStatus({
+			sessionStatus: 'expired',
+			reviewStatus: 'approved',
+		})
+		expect(result).toBe('approved')
+	})
+})

--- a/apps/web/test/kyc-session-service.test.ts
+++ b/apps/web/test/kyc-session-service.test.ts
@@ -1,0 +1,24 @@
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key'
+
+import { describe, expect, test } from 'bun:test'
+import { resolveKycStatus } from '../lib/kyc/session-service'
+
+describe('resolveKycStatus', () => {
+	test('preserves an approved review over a newer pending session', () => {
+		expect(resolveKycStatus({ sessionStatus: 'pending', reviewStatus: 'approved' })).toBe(
+			'approved',
+		)
+	})
+
+	test('keeps the latest non-approved session as the current status', () => {
+		expect(resolveKycStatus({ sessionStatus: 'rejected', reviewStatus: 'pending' })).toBe(
+			'rejected',
+		)
+	})
+
+	test('falls back to the review when there is no session', () => {
+		expect(resolveKycStatus({ sessionStatus: null, reviewStatus: 'rejected' })).toBe('rejected')
+	})
+})


### PR DESCRIPTION
closes #1035 

## Summary

Fixes KYC status resolution so that an already-approved user is not downgraded when a newer Didit session comes back with a non-approved status. Approved review now takes precedence over session recency.


## Problem

The current resolution logic in `session-service.ts` is session-first: it resolves KYC status based on the most recent Didit session, regardless of prior approval. This means a user who has already been approved via review can be effectively downgraded if a subsequent session (e.g. a re-verification attempt, retry, or abandoned flow) comes back `pending`, `declined`, or otherwise non-approved. This is a regression risk flagged during CodeRabbit review of the original KYC enforcement changes in #1019.

## Root Cause

Status resolution didn't distinguish *why* a session is newer — it treated "latest session" as authoritative even when an earlier session had already reached a terminal `approved` review state. There was no precedence rule protecting an approved outcome from being overwritten by a subsequently-created, less-conclusive session.

## Changes

- Updated KYC status resolution in `apps/web/lib/kyc/session-service.ts` so that an **approved** review is preserved and takes precedence over a newer session that is non-approved.
- Preserved existing session-first resolution behavior for all non-approved cases (i.e. this change only special-cases the "already approved" path — it doesn't otherwise alter how the latest session is selected).
- Added regression test coverage for the specific scenario: user has an approved review, then a newer session with `pending` (or other non-approved) status arrives — status must remain `approved`.

## Why this approach

Rather than rewriting the resolution logic wholesale, this adds a targeted precedence check: approval is treated as a terminal, sticky state that shouldn't be reversed by session churn (retries, abandoned re-verifications, etc.). This keeps the fix minimal and scoped to the exact regression called out in review, without changing behavior for the non-approved paths that were working correctly.

## Testing

- New regression test: approved review + newer non-approved session → status resolves to `approved`.
- Existing tests confirming session-first resolution still passes for non-approved cases.

## References

- Follow-up to review recommendation on PR #1019 (https://github.com/kindfi-org/kindfi/pull/1019#discussion_r3849953490)
- Requested in https://github.com/kindfi-org/kindfi/pull/1019#issuecomment-5412080597

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KYC status accuracy by considering both session and review outcomes.
  * Approved KYC results now take precedence, while the latest relevant status is preserved when approval is unavailable.

* **Tests**
  * Added coverage for approval precedence, session status retention, and review-status fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->