### PR TITLE
extract Didit status documentation type

### DIFF
--- a/apps/web/lib/kyc/status.ts
+++ b/apps/web/lib/kyc/status.ts
@@ -2,6 +2,19 @@ import type { CanonicalKycStatus, KycDbStatus, KycReasonCode, KycRequiredAction 
 import { CANONICAL_KYC_STATUSES } from './types'
 
 /**
+ * Documentation entry mapping Didit provider status strings to canonical
+ * KindFi KYC statuses with explanatory notes.
+ */
+export interface DiditStatusDocumentationEntry {
+	/** Raw Didit status string as returned by the provider API */
+	diditStatus: string
+	/** Canonical KindFi KYC status this maps to */
+	canonical: CanonicalKycStatus
+	/** Human-readable explanation of the mapping and status meaning */
+	notes: string
+}
+
+/**
  * Didit session statuses observed in the KindFi integration and Didit v3 API.
  * Unknown values fall through to `pending` unless they match an alias below.
  */
@@ -28,11 +41,7 @@ export const DIDIT_STATUS_ALIASES: Record<string, CanonicalKycStatus> = {
 	manualreview: 'manual_review',
 }
 
-export const DIDIT_TO_CANONICAL_DOCUMENTATION: Array<{
-	diditStatus: string
-	canonical: CanonicalKycStatus
-	notes: string
-}> = [
+export const DIDIT_TO_CANONICAL_DOCUMENTATION: DiditStatusDocumentationEntry[] = [
 	{
 		diditStatus: 'Not Started',
 		canonical: 'not_started',


### PR DESCRIPTION
Refactored the Didit KYC status documentation typing in apps/web/lib/kyc/status.ts to improve code readability, maintainability, and type reuse.

Changes Made
Introduced a named DiditStatusDocumentationEntry interface for Didit-to-canonical status documentation entries.
Replaced the previous inline object type definition used by DIDIT_TO_CANONICAL_DOCUMENTATION.
Kept the existing diditStatus, canonical, and notes fields while moving their structure into an explicit reusable interface.
Exported the interface where appropriate to support reuse across related KYC modules.
Preserved the existing status mapping behavior without changing the underlying KYC logic.
Result

The KYC status documentation now uses a clear, named domain type instead of an inline object definition. This makes the code easier to understand, simplifies future maintenance, and provides a reusable type for other Didit status-related functionality.

The refactor also addresses the CodeRabbit review feedback raised during PR #1019 without introducing behavioral changes to the KYC status handling.

Closes #1037 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the structure of KYC status documentation while preserving existing behavior and documentation content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->