### PR TITLE
handle KYC metric query errors

### DIFF
--- a/apps/web/lib/kyc/metrics.ts
+++ b/apps/web/lib/kyc/metrics.ts
@@ -80,6 +80,21 @@ export const getKycEnforcementMetrics = async (sinceDays = 30): Promise<KycEnfor
 		logger.error('[kyc] Failed to load authorization metrics', {
 			error: eventsResult.error.message,
 		})
+		throw new Error(`Failed to load authorization metrics: ${eventsResult.error.message}`)
+	}
+
+	if (failuresResult.error) {
+		logger.error('[kyc] Failed to load webhook failure metrics', {
+			error: failuresResult.error.message,
+		})
+		throw new Error(`Failed to load webhook failure metrics: ${failuresResult.error.message}`)
+	}
+
+	if (sessionsResult.error) {
+		logger.error('[kyc] Failed to load session status metrics', {
+			error: sessionsResult.error.message,
+		})
+		throw new Error(`Failed to load session status metrics: ${sessionsResult.error.message}`)
 	}
 
 	const events = (eventsResult.data ?? []) as AuthorizationEventRow[]

--- a/apps/web/test/kyc-metrics.test.ts
+++ b/apps/web/test/kyc-metrics.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { getKycEnforcementMetrics } from '../lib/kyc/metrics'
+
+// Define a global to hold our mock responses per-test
+declare global {
+	var __mockSupabaseClient: any
+}
+
+mock.module('../lib/kyc/supabase-kyc-client', () => {
+	return {
+		getKycSchemaClient: () => globalThis.__mockSupabaseClient,
+	}
+})
+
+describe('getKycEnforcementMetrics', () => {
+	let mockEventsResult: any
+	let mockFailuresResult: any
+	let mockSessionsResult: any
+
+	beforeEach(() => {
+		mockEventsResult = { data: [], error: null }
+		mockFailuresResult = { data: [], error: null }
+		mockSessionsResult = { data: [], error: null }
+
+		globalThis.__mockSupabaseClient = {
+			from: (table: string) => {
+				if (table === 'authorization_events') {
+					return {
+						select: () => ({
+							gte: () => Promise.resolve(mockEventsResult),
+						}),
+					}
+				}
+				if (table === 'webhook_events') {
+					return {
+						select: () => ({
+							in: () => ({
+								gte: () => Promise.resolve(mockFailuresResult),
+							}),
+						}),
+					}
+				}
+				if (table === 'didit_sessions') {
+					return {
+						select: () => Promise.resolve(mockSessionsResult),
+					}
+				}
+				throw new Error(`Unexpected table mock: ${table}`)
+			},
+		}
+	})
+
+	test('throws error if authorization_events query fails', async () => {
+		mockEventsResult = { error: { message: 'db connection failed' } }
+		await expect(getKycEnforcementMetrics()).rejects.toThrow(
+			'Failed to load authorization metrics: db connection failed',
+		)
+	})
+
+	test('throws error if webhook_events query fails', async () => {
+		mockFailuresResult = { error: { message: 'timeout' } }
+		await expect(getKycEnforcementMetrics()).rejects.toThrow(
+			'Failed to load webhook failure metrics: timeout',
+		)
+	})
+
+	test('throws error if didit_sessions query fails', async () => {
+		mockSessionsResult = { error: { message: 'internal server error' } }
+		await expect(getKycEnforcementMetrics()).rejects.toThrow(
+			'Failed to load session status metrics: internal server error',
+		)
+	})
+
+	test('returns metrics when all queries succeed', async () => {
+		mockEventsResult = {
+			data: [
+				{
+					action: 'donate',
+					current_kyc_status: 'approved',
+					hypothetical_allowed: true,
+					decision_allowed: true,
+					created_at: new Date().toISOString(),
+				},
+			],
+			error: null,
+		}
+
+		const metrics = await getKycEnforcementMetrics()
+		expect(metrics).toBeDefined()
+		expect(metrics.byAction).toBeDefined()
+		expect(metrics.periodDays).toBe(30)
+		expect(metrics.actionsWithoutApprovedKyc).toBe(0)
+		expect(metrics.wouldHaveBlocked).toBe(0)
+	})
+})


### PR DESCRIPTION
Closes #1033 

## Summary

Handled query errors in KYC metric queries to prevent failed requests from appearing as valid empty metrics.

### Changes

* Added explicit error handling for authorization, webhook, and Didit session queries.
* Added failure coverage for each query.
* Ensured unavailable metrics are handled correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved KYC enforcement metrics reliability by detecting and reporting failures across all underlying data queries.
  - Prevented incomplete or misleading metrics from being returned when query errors occur.

- **Tests**
  - Added coverage for authorization-event, webhook-event, and session-status query failures.
  - Added validation for successful metrics generation, including the default 30-day reporting period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->