### PR TITLE
feat(kyc): add rate limiting to KYC status endpoint

### DIFF
--- a/apps/web/app/api/kyc/status/route.ts
+++ b/apps/web/app/api/kyc/status/route.ts
@@ -1,4 +1,5 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { logger } from '@/lib/logger'
@@ -8,6 +9,7 @@ import {
 	findLatestDiditSessionForUser,
 	getCanonicalKycStatusForUser,
 } from '~/lib/kyc/session-service'
+import { withRateLimit } from '~/lib/middleware/rate-limit'
 
 /**
  * GET /api/kyc/status
@@ -15,7 +17,7 @@ import {
  * Returns the authenticated user's Didit-normalized KYC status plus a derived
  * enforcement hint for UI. The hint is never an authorization boundary.
  */
-export async function GET() {
+async function getKycStatusHandler(_req: NextRequest) {
 	try {
 		const session = await getServerSession(nextAuthOption)
 
@@ -56,3 +58,15 @@ export async function GET() {
 		return NextResponse.json({ error: 'Failed to fetch KYC status' }, { status: 500 })
 	}
 }
+
+export const GET = withRateLimit(
+	{
+		preset: 'moderate',
+		identifier: async (req) => {
+			const ip = req.headers.get('x-forwarded-for')
+			const session = await getServerSession(nextAuthOption)
+			return session?.user?.id ?? ip ?? 'anonymous'
+		},
+	},
+	getKycStatusHandler,
+)

--- a/apps/web/lib/middleware/rate-limit.ts
+++ b/apps/web/lib/middleware/rate-limit.ts
@@ -47,6 +47,7 @@
  * - `POST /api/foundations/create`
  * - `POST /api/projects/create`
  * - `POST /api/notifications/push`
+ * - `GET  /api/kyc/status`
  *
  * ### Previously protected
  * - `POST /api/nfts/mint` (strict)

--- a/apps/web/test/kyc-status-route.test.ts
+++ b/apps/web/test/kyc-status-route.test.ts
@@ -1,0 +1,186 @@
+/**
+ * GET /api/kyc/status rate limiting.
+ *
+ * The limiter must run before KYC database work and return the repository
+ * 429 body. Auth and KYC query behavior stay the same when the request is allowed.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import type { NextRequest } from 'next/server'
+
+const mockIncrement = mock(async (_id: string, _action: string) => ({
+	isBlocked: false,
+	attemptsRemaining: 9,
+}))
+
+const mockGetCanonicalKycStatusForUser = mock(async () => 'not_started')
+const mockFindLatestDiditSessionForUser = mock(async () => null)
+const mockMaybeSingle = mock(async () => ({
+	data: { status: 'pending', updated_at: '2026-08-25T00:00:00.000Z' },
+	error: null,
+}))
+
+let mockSession: { user: { id: string } } | null = { user: { id: 'user-1' } }
+
+mock.module('next/server', () => ({
+	NextResponse: {
+		json: (body: unknown, init?: ResponseInit) => {
+			const headersMap = new Map<string, string>(
+				Object.entries((init?.headers as Record<string, string>) ?? {}),
+			)
+			return {
+				status: init?.status ?? 200,
+				headers: {
+					set: (k: string, v: string) => headersMap.set(k, v),
+					get: (k: string) => headersMap.get(k) ?? null,
+				},
+				json: async () => JSON.parse(JSON.stringify(body)),
+			}
+		},
+	},
+}))
+
+mock.module('~/lib/auth/rate-limiter', () => ({
+	RateLimiter: class {
+		increment = mockIncrement
+	},
+}))
+
+mock.module('@/lib/logger', () => ({
+	logger: { warn: () => {}, error: () => {}, info: () => {} },
+}))
+
+mock.module('next-auth', () => ({
+	getServerSession: async () => mockSession,
+}))
+mock.module('~/lib/auth/auth-options', () => ({ nextAuthOption: {} }))
+
+mock.module('~/lib/kyc/enforcement-config', () => ({
+	getKycEnforcementMode: () => 'disabled',
+	getKycEnforcedActions: () => [],
+}))
+
+mock.module('~/lib/kyc/session-service', () => ({
+	getCanonicalKycStatusForUser: mockGetCanonicalKycStatusForUser,
+	findLatestDiditSessionForUser: mockFindLatestDiditSessionForUser,
+}))
+
+mock.module('@packages/lib/supabase', () => ({
+	supabase: {
+		from: () => ({
+			select: () => ({
+				eq: () => ({
+					order: () => ({
+						limit: () => ({
+							maybeSingle: mockMaybeSingle,
+						}),
+					}),
+				}),
+			}),
+		}),
+	},
+}))
+
+const { GET } = await import('../app/api/kyc/status/route')
+
+const makeRequest = (path = '/api/kyc/status'): NextRequest =>
+	({
+		nextUrl: { pathname: path },
+		headers: {
+			get: (key: string) => (key === 'x-forwarded-for' ? '127.0.0.1' : null),
+		},
+	}) as unknown as NextRequest
+
+describe('GET /api/kyc/status', () => {
+	beforeEach(() => {
+		mockSession = { user: { id: 'user-1' } }
+		mockIncrement.mockReset()
+		mockGetCanonicalKycStatusForUser.mockReset()
+		mockFindLatestDiditSessionForUser.mockReset()
+		mockMaybeSingle.mockReset()
+		mockGetCanonicalKycStatusForUser.mockImplementation(async () => 'not_started')
+		mockFindLatestDiditSessionForUser.mockImplementation(async () => null)
+		mockMaybeSingle.mockImplementation(async () => ({
+			data: { status: 'pending', updated_at: '2026-08-25T00:00:00.000Z' },
+			error: null,
+		}))
+	})
+
+	test('returns 429 with the standard rate-limit body and skips KYC queries', async () => {
+		mockIncrement.mockImplementation(async () => ({
+			isBlocked: true,
+			attemptsRemaining: 0,
+		}))
+
+		const res = await GET(makeRequest())
+		const body = await res.json()
+
+		expect(res.status).toBe(429)
+		expect(body).toEqual({ error: 'Too many requests. Please try again later.' })
+		expect(res.headers.get('Retry-After')).toBe('1800')
+		expect(mockGetCanonicalKycStatusForUser).not.toHaveBeenCalled()
+		expect(mockFindLatestDiditSessionForUser).not.toHaveBeenCalled()
+		expect(mockMaybeSingle).not.toHaveBeenCalled()
+	})
+
+	test('keys the limiter to the authenticated user', async () => {
+		mockIncrement.mockImplementation(async () => ({
+			isBlocked: false,
+			attemptsRemaining: 9,
+		}))
+
+		await GET(makeRequest())
+
+		expect(mockIncrement).toHaveBeenCalledWith('user-1', '/api/kyc/status')
+	})
+
+	test('keys the limiter to the request IP when unauthenticated', async () => {
+		mockSession = null
+		mockIncrement.mockImplementation(async () => ({
+			isBlocked: false,
+			attemptsRemaining: 9,
+		}))
+
+		await GET(makeRequest())
+
+		expect(mockIncrement).toHaveBeenCalledWith('127.0.0.1', '/api/kyc/status')
+	})
+
+	test('still returns 401 when not authenticated', async () => {
+		mockSession = null
+		mockIncrement.mockImplementation(async () => ({
+			isBlocked: false,
+			attemptsRemaining: 9,
+		}))
+
+		const res = await GET(makeRequest())
+		const body = await res.json()
+
+		expect(res.status).toBe(401)
+		expect(body).toEqual({ error: 'Unauthorized' })
+		expect(mockGetCanonicalKycStatusForUser).not.toHaveBeenCalled()
+		expect(mockMaybeSingle).not.toHaveBeenCalled()
+	})
+
+	test('returns KYC status when the limiter allows the request', async () => {
+		mockIncrement.mockImplementation(async () => ({
+			isBlocked: false,
+			attemptsRemaining: 9,
+		}))
+
+		const res = await GET(makeRequest())
+		const body = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(body).toEqual({
+			status: 'pending',
+			canonicalStatus: 'not_started',
+			updatedAt: '2026-08-25T00:00:00.000Z',
+			hasActiveSession: false,
+			enforcement: { mode: 'disabled', enforcedActions: [] },
+		})
+		expect(mockGetCanonicalKycStatusForUser).toHaveBeenCalledWith('user-1')
+		expect(mockFindLatestDiditSessionForUser).toHaveBeenCalledWith('user-1')
+		expect(mockMaybeSingle).toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
## Summary
- Rate-limit `GET /api/kyc/status` with the existing `withRateLimit` middleware before any KYC database reads.
- Identify callers by authenticated user id, falling back to request IP.
- Return the standard 429 `{ error: 'Too many requests. Please try again later.' }` with `Retry-After` when the limit is exceeded. Auth, KYC queries, and success payloads are unchanged when the request is allowed.

## Why
The KYC status endpoint hit the database without a limiter, which left it open to request flooding. This closes that gap from the KYC enforcement review.

## How it was tested
- `bun test test/kyc-status-route.test.ts` (from `apps/web`) — 5 pass
- New tests assert:
  - blocked requests return 429 with the standard body and skip KYC queries
  - the limiter is keyed to the user when signed in, and to IP when not
  - unauthenticated callers still get 401
  - allowed requests still return the existing KYC status payload

Closes #1047

## Test plan
- [x] Call `GET /api/kyc/status` while signed in and confirm the existing status JSON still returns (200)
- [x] Call the same endpoint without a session and confirm 401 `Unauthorized`
- [x] Exceed 10 requests in a minute for the same user/IP and confirm 429 plus `Retry-After`
- [x] Confirm a blocked request does not query KYC status data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added rate limiting to the KYC status endpoint to help prevent excessive requests.
  * Requests exceeding the limit now receive a standard rate-limit response without triggering KYC lookups.
  * Unauthenticated requests continue to require authentication.

* **Tests**
  * Added coverage for rate-limit handling, request identification, authentication, and successful KYC status responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->