### PR TITLE
fix(kyc): normalize legacy Didit status aliases in migration backfill

### DIFF
--- a/apps/web/test/kyc-status.test.ts
+++ b/apps/web/test/kyc-status.test.ts
@@ -32,6 +32,10 @@ describe('toCanonicalKycStatus', () => {
 		expect(toCanonicalKycStatus('inreview')).toBe('in_review')
 		expect(toCanonicalKycStatus('manual-review')).toBe('manual_review')
 		expect(toCanonicalKycStatus('notstarted')).toBe('not_started')
+		expect(toCanonicalKycStatus('veri-fied')).toBe('approved')
+		expect(toCanonicalKycStatus('de-clined')).toBe('rejected')
+		expect(toCanonicalKycStatus('ex-pired')).toBe('expired')
+		expect(toCanonicalKycStatus('provider-unavailable')).toBe('provider_unavailable')
 	})
 
 	test('treats missing status as not_started', () => {

--- a/apps/web/test/kyc-status.test.ts
+++ b/apps/web/test/kyc-status.test.ts
@@ -25,6 +25,13 @@ describe('toCanonicalKycStatus', () => {
 		expect(toCanonicalKycStatus('approved')).toBe('approved')
 		expect(toCanonicalKycStatus('verified')).toBe('approved')
 		expect(toCanonicalKycStatus('VERIFIED')).toBe('approved')
+		expect(toCanonicalKycStatus('  Approved  ')).toBe('approved')
+	})
+
+	test('normalizes compact and separator variants', () => {
+		expect(toCanonicalKycStatus('inreview')).toBe('in_review')
+		expect(toCanonicalKycStatus('manual-review')).toBe('manual_review')
+		expect(toCanonicalKycStatus('notstarted')).toBe('not_started')
 	})
 
 	test('treats missing status as not_started', () => {

--- a/services/supabase/migrations/20260825000000_kyc_didit_enforcement_infrastructure.sql
+++ b/services/supabase/migrations/20260825000000_kyc_didit_enforcement_infrastructure.sql
@@ -198,6 +198,96 @@ EXCEPTION WHEN others THEN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION kyc.to_canonical_status(status text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  status_key text;
+  compact_key text;
+BEGIN
+  IF status IS NULL OR status = '' THEN
+    RETURN 'not_started';
+  END IF;
+
+  status_key := lower(regexp_replace(btrim(status), '\s+', ' ', 'g'));
+  compact_key := regexp_replace(status_key, '[\s_-]', '', 'g');
+
+  IF status_key IN ('approved', 'verified') THEN RETURN 'approved'; END IF;
+  IF status_key IN ('declined', 'rejected', 'denied') THEN RETURN 'rejected'; END IF;
+  IF status_key IN ('in review', 'in_review') OR compact_key = 'inreview' THEN
+    RETURN 'in_review';
+  END IF;
+  IF status_key IN ('not started', 'not_started') OR compact_key = 'notstarted' THEN
+    RETURN 'not_started';
+  END IF;
+  IF status_key IN ('in progress', 'in_progress', 'pending')
+    OR compact_key IN ('inprogress', 'pending') THEN
+    RETURN 'pending';
+  END IF;
+  IF status_key IN ('abandoned', 'expired') THEN RETURN 'expired'; END IF;
+  IF status_key IN ('manual review', 'manual_review') OR compact_key = 'manualreview' THEN
+    RETURN 'manual_review';
+  END IF;
+  IF status_key = 'provider_unavailable' OR compact_key = 'providerunavailable' THEN
+    RETURN 'provider_unavailable';
+  END IF;
+
+  RETURN 'pending';
+END;
+$$;
+
+-- Do not let malformed or unknown production notes silently become pending.
+DO $$
+DECLARE
+  legacy_row record;
+  parsed_notes jsonb;
+  status_value text;
+  status_key text;
+  compact_key text;
+BEGIN
+  FOR legacy_row IN
+    SELECT id, notes
+    FROM public.kyc_reviews
+    WHERE notes IS NOT NULL AND btrim(notes) <> ''
+  LOOP
+    BEGIN
+      parsed_notes := legacy_row.notes::jsonb;
+    EXCEPTION WHEN others THEN
+      RAISE EXCEPTION 'Cannot enable KYC backfill: kyc_reviews.id % has malformed notes JSON', legacy_row.id;
+    END;
+
+    IF jsonb_typeof(parsed_notes) <> 'object' THEN
+      RAISE EXCEPTION 'Cannot enable KYC backfill: kyc_reviews.id % notes must be a JSON object', legacy_row.id;
+    END IF;
+
+    IF parsed_notes ? 'diditSessionId'
+      AND NULLIF(btrim(parsed_notes->>'diditSessionId'), '') IS NULL THEN
+      RAISE EXCEPTION 'Cannot enable KYC backfill: kyc_reviews.id % has an empty diditSessionId', legacy_row.id;
+    END IF;
+
+    status_value := NULLIF(parsed_notes->>'diditStatus', '');
+    IF status_value IS NOT NULL THEN
+      status_key := lower(regexp_replace(btrim(status_value), '\s+', ' ', 'g'));
+      compact_key := regexp_replace(status_key, '[\s_-]', '', 'g');
+      IF status_key NOT IN (
+        'not started', 'not_started', 'notstarted', 'in progress', 'in_progress',
+        'inprogress', 'pending', 'in review', 'in_review', 'inreview', 'approved',
+        'verified', 'declined', 'rejected', 'denied', 'abandoned', 'expired',
+        'manual review', 'manual_review', 'manualreview', 'provider_unavailable',
+        'providerunavailable'
+      ) AND compact_key NOT IN (
+        'notstarted', 'inprogress', 'pending', 'inreview', 'manualreview',
+        'providerunavailable'
+      ) THEN
+        RAISE EXCEPTION 'Cannot enable KYC backfill: kyc_reviews.id % has unknown Didit status %', legacy_row.id, status_value;
+      END IF;
+    END IF;
+  END LOOP;
+END;
+$$;
+
 INSERT INTO kyc.didit_sessions (
   user_id,
   kyc_review_id,
@@ -215,17 +305,7 @@ SELECT
   notes.didit_session_id,
   notes.didit_session_token,
   notes.didit_status,
-  CASE
-    WHEN lower(coalesce(notes.didit_status, kr.status::text)) IN ('approved', 'verified') THEN 'approved'
-    WHEN lower(coalesce(notes.didit_status, kr.status::text)) IN ('declined', 'rejected', 'denied') THEN 'rejected'
-    WHEN lower(notes.didit_status) IN ('in review', 'in_review') THEN 'in_review'
-    WHEN lower(notes.didit_status) IN ('not started', 'not_started') THEN 'not_started'
-    WHEN lower(notes.didit_status) IN ('abandoned', 'expired') THEN 'expired'
-    WHEN lower(notes.didit_status) IN ('manual review', 'manual_review') THEN 'manual_review'
-    WHEN kr.status::text IN ('approved', 'verified') THEN 'approved'
-    WHEN kr.status::text = 'rejected' THEN 'rejected'
-    ELSE 'pending'
-  END,
+  kyc.to_canonical_status(COALESCE(notes.didit_status, kr.status::text)),
   notes.last_updated,
   kr.created_at,
   kr.updated_at

--- a/services/supabase/migrations/20260825000000_kyc_didit_enforcement_infrastructure.sql
+++ b/services/supabase/migrations/20260825000000_kyc_didit_enforcement_infrastructure.sql
@@ -214,23 +214,22 @@ BEGIN
   status_key := lower(regexp_replace(btrim(status), '\s+', ' ', 'g'));
   compact_key := regexp_replace(status_key, '[\s_-]', '', 'g');
 
-  IF status_key IN ('approved', 'verified') THEN RETURN 'approved'; END IF;
-  IF status_key IN ('declined', 'rejected', 'denied') THEN RETURN 'rejected'; END IF;
-  IF status_key IN ('in review', 'in_review') OR compact_key = 'inreview' THEN
+  IF compact_key IN ('approved', 'verified') THEN RETURN 'approved'; END IF;
+  IF compact_key IN ('declined', 'rejected', 'denied') THEN RETURN 'rejected'; END IF;
+  IF compact_key = 'inreview' THEN
     RETURN 'in_review';
   END IF;
-  IF status_key IN ('not started', 'not_started') OR compact_key = 'notstarted' THEN
+  IF compact_key = 'notstarted' THEN
     RETURN 'not_started';
   END IF;
-  IF status_key IN ('in progress', 'in_progress', 'pending')
-    OR compact_key IN ('inprogress', 'pending') THEN
+  IF compact_key IN ('inprogress', 'pending') THEN
     RETURN 'pending';
   END IF;
-  IF status_key IN ('abandoned', 'expired') THEN RETURN 'expired'; END IF;
-  IF status_key IN ('manual review', 'manual_review') OR compact_key = 'manualreview' THEN
+  IF compact_key IN ('abandoned', 'expired') THEN RETURN 'expired'; END IF;
+  IF compact_key = 'manualreview' THEN
     RETURN 'manual_review';
   END IF;
-  IF status_key = 'provider_unavailable' OR compact_key = 'providerunavailable' THEN
+  IF compact_key = 'providerunavailable' THEN
     RETURN 'provider_unavailable';
   END IF;
 
@@ -271,14 +270,9 @@ BEGIN
     IF status_value IS NOT NULL THEN
       status_key := lower(regexp_replace(btrim(status_value), '\s+', ' ', 'g'));
       compact_key := regexp_replace(status_key, '[\s_-]', '', 'g');
-      IF status_key NOT IN (
-        'not started', 'not_started', 'notstarted', 'in progress', 'in_progress',
-        'inprogress', 'pending', 'in review', 'in_review', 'inreview', 'approved',
-        'verified', 'declined', 'rejected', 'denied', 'abandoned', 'expired',
-        'manual review', 'manual_review', 'manualreview', 'provider_unavailable',
-        'providerunavailable'
-      ) AND compact_key NOT IN (
-        'notstarted', 'inprogress', 'pending', 'inreview', 'manualreview',
+      IF compact_key NOT IN (
+        'notstarted', 'inprogress', 'pending', 'inreview', 'approved', 'verified',
+        'declined', 'rejected', 'denied', 'abandoned', 'expired', 'manualreview',
         'providerunavailable'
       ) THEN
         RAISE EXCEPTION 'Cannot enable KYC backfill: kyc_reviews.id % has unknown Didit status %', legacy_row.id, status_value;


### PR DESCRIPTION
Closes #1043.

## Summary
Aligns the migration's SQL status normalization with `toCanonicalKycStatus` in `apps/web/lib/kyc/status.ts`, so both code paths treat legacy Didit statuses and alias variants identically. Follow-up from review of #1019 ([discussion](https://github.com/kindfi-org/kindfi/pull/1019#discussion_r3849953548)).

## Acceptance criteria
- [x] Map values such as `Approved` to `approved`
- [x] Map compact aliases such as `manualreview` to `manual_review`
- [x] Normalize both legacy Didit status and fallback review status consistently
- [x] Validate production legacy notes values before enabling enforcement

## Changes
- Added `kyc.to_canonical_status()`, a SQL function mirroring the TS normalizer: trims whitespace, lowercases, and handles spaced/underscored forms (`in review` / `in_review`) as well as compact aliases (`manualreview`, `inreview`, etc.).
- Replaced the inline `CASE` expression in the backfill `INSERT` with `kyc.to_canonical_status(COALESCE(notes.didit_status, kr.status::text))`, so the Didit status and `kyc_reviews.status` fallback go through the same logic.
- Added a fail-closed validation block that runs before the backfill: rejects the migration if any `kyc_reviews.notes` row is non-empty but not valid JSON, not an object, has an empty `diditSessionId`, or has an unrecognized `diditStatus`.
- Added regression tests in `kyc-status.test.ts` for trimmed input and compact/separator alias variants.

## Testing
- [x] `bun test apps/web/test/kyc-status.test.ts` — 11 pass, 0 fail
- [x] `bunx biome check` on both changed files — clean
- [x] Migration executed against a live/local database 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KYC status handling so padded, compact, and separator-formatted statuses are consistently recognized.
  * Added validation to prevent malformed or unknown legacy KYC records from being processed silently.
  * KYC status backfills now use consistent canonical status values and fail safely when invalid data is encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->