### PR TITLE
refactor(kyc): centralize Didit session columns and active statuses

### DIFF
--- a/apps/web/lib/kyc/session-service.ts
+++ b/apps/web/lib/kyc/session-service.ts
@@ -1,6 +1,7 @@
 import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
 import { logger } from '@/lib/logger'
 import {
+	ACTIVE_DIDIT_SESSION_STATUSES,
 	canonicalFromDbStatus,
 	isActiveDiditSessionStatus,
 	toCanonicalKycStatus,
@@ -33,6 +34,9 @@ interface DiditSessionRow {
 	last_provider_event_at: string | null
 }
 
+const DIDIT_SESSION_COLUMNS =
+	'id, user_id, kyc_review_id, session_id, verification_url, didit_status, canonical_status, last_provider_event_id, last_provider_event_at'
+
 const mapSessionRow = (row: DiditSessionRow): DiditSessionRecord => ({
 	id: row.id,
 	userId: row.user_id,
@@ -50,9 +54,7 @@ export const findDiditSessionBySessionId = async (
 ): Promise<DiditSessionRecord | null> => {
 	const { data, error } = await getKycSchemaClient()
 		.from('didit_sessions')
-		.select(
-			'id, user_id, kyc_review_id, session_id, verification_url, didit_status, canonical_status, last_provider_event_id, last_provider_event_at',
-		)
+		.select(DIDIT_SESSION_COLUMNS)
 		.eq('session_id', sessionId)
 		.maybeSingle()
 
@@ -69,9 +71,7 @@ export const findLatestDiditSessionForUser = async (
 ): Promise<DiditSessionRecord | null> => {
 	const { data, error } = await getKycSchemaClient()
 		.from('didit_sessions')
-		.select(
-			'id, user_id, kyc_review_id, session_id, verification_url, didit_status, canonical_status, last_provider_event_id, last_provider_event_at',
-		)
+		.select(DIDIT_SESSION_COLUMNS)
 		.eq('user_id', userId)
 		.order('created_at', { ascending: false })
 		.limit(1)
@@ -90,11 +90,9 @@ export const findActiveDiditSessionForUser = async (
 ): Promise<DiditSessionRecord | null> => {
 	const { data, error } = await getKycSchemaClient()
 		.from('didit_sessions')
-		.select(
-			'id, user_id, kyc_review_id, session_id, verification_url, didit_status, canonical_status, last_provider_event_id, last_provider_event_at',
-		)
+		.select(DIDIT_SESSION_COLUMNS)
 		.eq('user_id', userId)
-		.in('canonical_status', ['not_started', 'pending', 'in_review', 'manual_review'])
+		.in('canonical_status', ACTIVE_DIDIT_SESSION_STATUSES)
 		.order('created_at', { ascending: false })
 		.limit(1)
 		.maybeSingle()
@@ -228,9 +226,7 @@ export const saveDiditSession = async (params: {
 			},
 			{ onConflict: 'session_id' },
 		)
-		.select(
-			'id, user_id, kyc_review_id, session_id, verification_url, didit_status, canonical_status, last_provider_event_id, last_provider_event_at',
-		)
+		.select(DIDIT_SESSION_COLUMNS)
 		.maybeSingle()
 
 	if (error) {

--- a/apps/web/lib/kyc/status.ts
+++ b/apps/web/lib/kyc/status.ts
@@ -176,8 +176,12 @@ export const requiredActionForStatus = (
 	}
 }
 
+export const ACTIVE_DIDIT_SESSION_STATUSES: readonly CanonicalKycStatus[] = [
+	'not_started',
+	'pending',
+	'in_review',
+	'manual_review',
+] as const
+
 export const isActiveDiditSessionStatus = (status: CanonicalKycStatus): boolean =>
-	status === 'not_started' ||
-	status === 'pending' ||
-	status === 'in_review' ||
-	status === 'manual_review'
+	(ACTIVE_DIDIT_SESSION_STATUSES as readonly string[]).includes(status)


### PR DESCRIPTION
Done. Here's a summary of what was done on the  centralize-Didit-session  branch:

 apps/web/lib/kyc/status.ts 
- Added exported  ACTIVE_DIDIT_SESSION_STATUSES  constant — a  readonly  array of  CanonicalKycStatus[]  containing  ['not_started', 'pending', 'in_review', 'manual_review'] 
-  isActiveDiditSessionStatus  now uses this shared constant via  .includes()  instead of hardcoded  ===  checks

 apps/web/lib/kyc/session-service.ts 
- Extracted  DIDIT_SESSION_COLUMNS  constant for the repeated select string ( 'id, user_id, ...' )
- Replaced all 4 duplicated  .select(...)  calls with  .select(DIDIT_SESSION_COLUMNS) 
- Replaced the hardcoded  ['not_started', 'pending', 'in_review', 'manual_review']  in  findActiveDiditSessionForUser 's  .in()  call with the shared  ACTIVE_DIDIT_SESSION_STATUSES 

closes #1034 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized KYC session status handling for more consistent session lookups and updates.
  - Standardized the set of statuses considered active without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->