### PR TITLE
feat: enforce admin approval, remove translation steps, add story ima…

### DIFF
--- a/apps/web/app/api/admin/projects/route.ts
+++ b/apps/web/app/api/admin/projects/route.ts
@@ -30,7 +30,9 @@ async function handleProjects(request: NextRequest): Promise<NextResponse> {
 	const { searchParams } = new URL(request.url)
 
 	if ([...searchParams.keys()].length === 0) {
-		const projects = await getAllProjects(supabaseServiceRole, [], 'most-recent', 1000)
+		const projects = await getAllProjects(supabaseServiceRole, [], 'most-recent', 1000, {
+			includeAllStatuses: true,
+		})
 		return NextResponse.json(projects)
 	}
 

--- a/apps/web/app/api/projects/[slug]/manage/status/route.ts
+++ b/apps/web/app/api/projects/[slug]/manage/status/route.ts
@@ -60,7 +60,7 @@ export async function PATCH(request: Request, context: { params: Promise<{ slug:
 
 		const { data: project, error: fetchError } = await supabaseServiceRole
 			.from('projects')
-			.select('id, status')
+			.select('id, status, title, kindler_id')
 			.eq('id', projectId)
 			.single()
 
@@ -110,6 +110,50 @@ export async function PATCH(request: Request, context: { params: Promise<{ slug:
 				previousState: currentStatus,
 				newState: nextStatus,
 			})
+		}
+
+		// Non-blocking notifications based on new status
+		if (nextStatus === 'review') {
+			// Notify all admins that a campaign needs review
+			const { data: creatorProfile } = await supabaseServiceRole
+				.from('profiles')
+				.select('display_name, full_name')
+				.eq('id', project.kindler_id)
+				.single()
+			const creatorName = creatorProfile?.display_name ?? creatorProfile?.full_name ?? undefined
+
+			import('~/lib/email/notifications/send-project-review-notification')
+				.then(({ sendProjectReviewRequestNotification }) =>
+					sendProjectReviewRequestNotification({
+						projectTitle: project.title,
+						projectSlug: slug,
+						creatorName,
+					}),
+				)
+				.catch((err) => logger.error('[Status PATCH] Admin review notification error:', err))
+		} else if (nextStatus === 'active') {
+			// Notify creator of approval and notify followers
+			import('~/lib/email/notifications/send-new-project-emails')
+				.then(({ sendProjectActivatedEmails }) =>
+					sendProjectActivatedEmails({
+						projectTitle: project.title,
+						projectSlug: slug,
+						creatorId: project.kindler_id,
+					}),
+				)
+				.catch((err) => logger.error('[Status PATCH] Activation notification error:', err))
+		} else if (nextStatus === 'rejected') {
+			// Notify creator of rejection
+			import('~/lib/email/notification-helpers')
+				.then(({ createInAppNotification }) =>
+					createInAppNotification({
+						userId: project.kindler_id,
+						title: 'Campaign rejected',
+						body: `Your campaign "${project.title}" was not approved. Please review feedback from the admin team and resubmit.`,
+						type: 'warning',
+					}),
+				)
+				.catch((err) => logger.error('[Status PATCH] Rejection notification error:', err))
 		}
 
 		return NextResponse.json({

--- a/apps/web/app/api/projects/[slug]/story-image/route.ts
+++ b/apps/web/app/api/projects/[slug]/story-image/route.ts
@@ -1,0 +1,84 @@
+import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { logger } from '@/lib/logger'
+import { nextAuthOption } from '~/lib/auth/auth-options'
+import { uploadStoryImage } from '~/lib/utils/project-utils'
+
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5 MB
+
+export async function POST(req: Request, { params }: { params: Promise<{ slug: string }> }) {
+	try {
+		const session = await getServerSession(nextAuthOption)
+		const userId = session?.user?.id
+		if (!userId) {
+			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+		}
+
+		const { slug } = await params
+
+		// Resolve project and verify user permissions
+		const { data: project, error: projectError } = await supabaseServiceRole
+			.from('projects')
+			.select('id, kindler_id')
+			.eq('slug', slug)
+			.single()
+
+		if (projectError || !project) {
+			return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+		}
+
+		const isOwner = project.kindler_id === userId
+		if (!isOwner) {
+			const { data: memberData } = await supabaseServiceRole
+				.from('project_members')
+				.select('role')
+				.eq('project_id', project.id)
+				.eq('user_id', userId)
+				.in('role', ['core', 'admin', 'editor'])
+				.single()
+
+			const { data: profile } = await supabaseServiceRole
+				.from('profiles')
+				.select('role')
+				.eq('id', userId)
+				.single()
+
+			if (!memberData && profile?.role !== 'admin') {
+				return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+			}
+		}
+
+		const formData = await req.formData()
+		const file = formData.get('image')
+
+		if (!(file instanceof File)) {
+			return NextResponse.json({ error: 'No image file provided' }, { status: 400 })
+		}
+
+		if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+			return NextResponse.json(
+				{ error: 'Invalid file type. Allowed: JPEG, PNG, WebP, GIF' },
+				{ status: 400 },
+			)
+		}
+
+		if (file.size > MAX_FILE_SIZE) {
+			return NextResponse.json({ error: 'File too large. Maximum size is 5 MB' }, { status: 400 })
+		}
+
+		const url = await uploadStoryImage(slug, file, supabaseServiceRole)
+		if (!url) {
+			return NextResponse.json({ error: 'Upload failed' }, { status: 500 })
+		}
+
+		return NextResponse.json({ url })
+	} catch (err) {
+		logger.error(err)
+		return NextResponse.json(
+			{ error: err instanceof Error ? err.message : 'Unknown error' },
+			{ status: 500 },
+		)
+	}
+}

--- a/apps/web/app/api/projects/create/route.ts
+++ b/apps/web/app/api/projects/create/route.ts
@@ -150,10 +150,10 @@ async function createProjectHandler(req: NextRequest) {
 		await upsertTags(project.id, tags ?? [], supabase)
 
 		if (!developmentOnly) {
-			// Send email + in-app notifications (non-blocking)
-			import('~/lib/email/email-notification-service')
-				.then(({ sendNewProjectEmails }) =>
-					sendNewProjectEmails({
+			// Notify creator that project is awaiting admin review (non-blocking)
+			import('~/lib/email/notifications/send-new-project-emails')
+				.then(({ sendProjectSubmittedForReviewEmail }) =>
+					sendProjectSubmittedForReviewEmail({
 						projectTitle: title,
 						projectSlug: project.slug ?? '',
 						creatorId: userId,

--- a/apps/web/components/sections/projects/content-wizard/content-wizard-step-indicator.tsx
+++ b/apps/web/components/sections/projects/content-wizard/content-wizard-step-indicator.tsx
@@ -4,7 +4,6 @@ import { Check } from 'lucide-react'
 import type { StepValidation } from '~/components/sections/projects/content-wizard/hooks/use-content-wizard-validation'
 import { useI18n } from '~/lib/i18n/context'
 import type { SupportedLocale } from '~/lib/schemas/locale.schemas'
-import { getOppositeLocale } from '~/lib/schemas/locale.schemas'
 import type { ContentWizardStep } from '~/lib/types/project/content-wizard.types'
 import { cn } from '~/lib/utils'
 
@@ -14,10 +13,7 @@ type StepGroup = {
 	steps: { id: ContentWizardStep; label: string }[]
 }
 
-const getStepGroups = (sourceLocale: SupportedLocale, t: (key: string) => string): StepGroup[] => {
-	const opposite = getOppositeLocale(sourceLocale)
-	const oppositeLabel = opposite === 'en' ? 'English' : 'Spanish'
-
+const getStepGroups = (_sourceLocale: SupportedLocale, t: (key: string) => string): StepGroup[] => {
 	return [
 		{
 			id: 'primary',
@@ -27,15 +23,6 @@ const getStepGroups = (sourceLocale: SupportedLocale, t: (key: string) => string
 				{ id: 'basics-primary', label: t('projects.manage.contentWizard.stepBasics') },
 				{ id: 'story-primary', label: t('projects.manage.contentWizard.stepStory') },
 				{ id: 'highlights-primary', label: t('projects.manage.contentWizard.stepHighlights') },
-			],
-		},
-		{
-			id: 'translation',
-			label: `${t('projects.manage.contentWizard.phaseTranslation')} (${oppositeLabel})`,
-			steps: [
-				{ id: 'basics-translation', label: t('projects.manage.contentWizard.stepBasics') },
-				{ id: 'story-translation', label: t('projects.manage.contentWizard.stepStory') },
-				{ id: 'highlights-translation', label: t('projects.manage.contentWizard.stepHighlights') },
 			],
 		},
 		{

--- a/apps/web/components/sections/projects/content-wizard/content-wizard.tsx
+++ b/apps/web/components/sections/projects/content-wizard/content-wizard.tsx
@@ -8,14 +8,12 @@ import { ContentWizardStepIndicator } from '~/components/sections/projects/conte
 import { useContentWizardSave } from '~/components/sections/projects/content-wizard/hooks/use-content-wizard-save'
 import { useContentWizardValidation } from '~/components/sections/projects/content-wizard/hooks/use-content-wizard-validation'
 import { WizardBasicsPrimaryStep } from '~/components/sections/projects/content-wizard/steps/wizard-basics-primary-step'
-import { WizardBasicsTranslationStep } from '~/components/sections/projects/content-wizard/steps/wizard-basics-translation-step'
 import { WizardHighlightsStep } from '~/components/sections/projects/content-wizard/steps/wizard-highlights-step'
 import { WizardLanguageStep } from '~/components/sections/projects/content-wizard/steps/wizard-language-step'
 import { WizardLocationStep } from '~/components/sections/projects/content-wizard/steps/wizard-location-step'
 import { WizardMediaStep } from '~/components/sections/projects/content-wizard/steps/wizard-media-step'
 import { WizardReviewStep } from '~/components/sections/projects/content-wizard/steps/wizard-review-step'
 import { WizardStoryPrimaryStep } from '~/components/sections/projects/content-wizard/steps/wizard-story-primary-step'
-import { WizardStoryTranslationStep } from '~/components/sections/projects/content-wizard/steps/wizard-story-translation-step'
 import { ManageSectionHeader } from '~/components/sections/projects/manage/manage-section-header'
 import { useContentWizard } from '~/hooks/contexts/use-content-wizard.context'
 import { useI18n } from '~/lib/i18n/context'
@@ -30,9 +28,6 @@ const isContentWizardStep = (value: string | null): value is ContentWizardStep =
 		'basics-primary',
 		'story-primary',
 		'highlights-primary',
-		'basics-translation',
-		'story-translation',
-		'highlights-translation',
 		'media',
 		'location',
 		'review',
@@ -60,7 +55,7 @@ export function ContentWizard() {
 		gcTime: 1000 * 60 * 60,
 	})
 
-	const { steps, translationStatus } = useContentWizardValidation(formData)
+	const { steps } = useContentWizardValidation(formData)
 	const { saveStep, isSaving } = useContentWizardSave()
 
 	const hasInitializedStep = useRef(false)
@@ -132,12 +127,6 @@ export function ContentWizard() {
 		[formData, defaultCategoryId, updateFormData, saveStep, mode, goToNextStep],
 	)
 
-	const handleSaveLater = useCallback(() => {
-		if (projectSlug) {
-			router.push(`/projects/${projectSlug}/manage`)
-		}
-	}, [projectSlug, router])
-
 	const handleFinish = useCallback(async () => {
 		await saveStep('review', formData)
 		if (projectSlug) {
@@ -187,36 +176,6 @@ export function ContentWizard() {
 						isSaving={isSaving}
 					/>
 				)
-			case 'basics-translation':
-				return (
-					<WizardBasicsTranslationStep
-						onBack={goToPreviousStep}
-						onContinue={(data) => persistAndAdvance(data, 'basics-translation')}
-						onSaveLater={handleSaveLater}
-						isSaving={isSaving}
-					/>
-				)
-			case 'story-translation':
-				return (
-					<WizardStoryTranslationStep
-						onBack={goToPreviousStep}
-						onContinue={(data) => persistAndAdvance(data, 'story-translation')}
-						onSaveLater={handleSaveLater}
-						isSaving={isSaving}
-					/>
-				)
-			case 'highlights-translation':
-				return (
-					<WizardHighlightsStep
-						variant="translation"
-						onBack={goToPreviousStep}
-						onContinue={(translationHighlights) =>
-							persistAndAdvance({ translationHighlights }, 'highlights-translation')
-						}
-						onSaveLater={handleSaveLater}
-						isSaving={isSaving}
-					/>
-				)
 			case 'media':
 				return (
 					<WizardMediaStep
@@ -246,7 +205,6 @@ export function ContentWizard() {
 		handleLanguageContinue,
 		handleBasicsPrimaryContinue,
 		persistAndAdvance,
-		handleSaveLater,
 		handleFinish,
 		isSaving,
 		formData.translationHighlights,
@@ -257,12 +215,6 @@ export function ContentWizard() {
 			<ManageSectionHeader
 				title={t('projects.manage.contentWizard.title')}
 				description={t('projects.manage.contentWizard.subtitle')}
-				actions={
-					<p className="text-sm text-muted-foreground tabular-nums">
-						{t('projects.manage.contentWizard.translationProgress')}:{' '}
-						<span className="font-medium text-foreground">{translationStatus.overallPercent}%</span>
-					</p>
-				}
 			/>
 
 			<ContentWizardStepIndicator

--- a/apps/web/components/sections/projects/content-wizard/hooks/use-content-wizard-save.ts
+++ b/apps/web/components/sections/projects/content-wizard/hooks/use-content-wizard-save.ts
@@ -71,17 +71,7 @@ export function useContentWizardSave() {
 					return { projectId, projectSlug }
 				}
 
-				case 'basics-translation': {
-					await saveProject({
-						...data,
-						slug: projectSlug,
-						translation: sanitizeProjectTranslationForApi(data.translation),
-					})
-					return { projectId, projectSlug }
-				}
-
-				case 'story-primary':
-				case 'story-translation': {
+				case 'story-primary': {
 					if (!projectId || !projectSlug) {
 						throw new Error('Project must be created before saving story')
 					}
@@ -93,7 +83,6 @@ export function useContentWizardSave() {
 						story: data.pitchStory,
 						pitchDeck: data.pitchDeck,
 						videoUrl: data.pitchVideoUrl,
-						translation: data.pitchTranslation,
 					})
 					return { projectId, projectSlug }
 				}
@@ -103,37 +92,38 @@ export function useContentWizardSave() {
 						throw new Error('Project must be created before saving highlights')
 					}
 
-					// Primary step only — do not persist incomplete translation placeholders
 					await saveHighlights({
 						projectId,
 						projectSlug,
 						highlights: data.highlights,
-					})
-					return { projectId, projectSlug }
-				}
-
-				case 'highlights-translation': {
-					if (!projectId || !projectSlug) {
-						throw new Error('Project must be created before saving highlights')
-					}
-
-					await saveHighlights({
-						projectId,
-						projectSlug,
-						highlights: data.highlights,
-						translationHighlights: data.translationHighlights,
 					})
 					return { projectId, projectSlug }
 				}
 
 				case 'media':
-				case 'location':
+				case 'location': {
+					await saveProject({
+						...data,
+						slug: projectSlug,
+						translation: sanitizeProjectTranslationForApi(data.translation),
+					})
+					return { projectId, projectSlug }
+				}
+
 				case 'review': {
 					await saveProject({
 						...data,
 						slug: projectSlug,
 						translation: sanitizeProjectTranslationForApi(data.translation),
 					})
+					// Submit for admin review (non-blocking — failure should not prevent redirect)
+					if (projectSlug) {
+						fetch(`/api/projects/${projectSlug}/manage/status`, {
+							method: 'PATCH',
+							headers: { 'Content-Type': 'application/json' },
+							body: JSON.stringify({ status: 'review' }),
+						}).catch(() => {})
+					}
 					return { projectId, projectSlug }
 				}
 

--- a/apps/web/components/sections/projects/content-wizard/hooks/use-content-wizard-validation.ts
+++ b/apps/web/components/sections/projects/content-wizard/hooks/use-content-wizard-validation.ts
@@ -1,14 +1,11 @@
 import { useMemo } from 'react'
 import {
 	wizardBasicsPrimarySchema,
-	wizardBasicsTranslationSchema,
 	wizardHighlightsPrimarySchema,
-	wizardHighlightsTranslationSchema,
 	wizardLanguageSchema,
 	wizardLocationSchema,
 	wizardMediaSchema,
 	wizardStoryPrimarySchema,
-	wizardStoryTranslationSchema,
 } from '~/lib/schemas/content-wizard.schemas'
 import type {
 	ContentWizardFormData,
@@ -36,12 +33,6 @@ function validateStep(step: ContentWizardStep, formData: ContentWizardFormData):
 			})
 			return result.success ? [] : result.error.issues.map((i) => i.message)
 		}
-		case 'basics-translation': {
-			const result = wizardBasicsTranslationSchema.safeParse({
-				translation: formData.translation,
-			})
-			return result.success ? [] : result.error.issues.map((i) => i.message)
-		}
 		case 'story-primary': {
 			const result = wizardStoryPrimarySchema.safeParse({
 				title: formData.pitchTitle,
@@ -49,21 +40,9 @@ function validateStep(step: ContentWizardStep, formData: ContentWizardFormData):
 			})
 			return result.success ? [] : result.error.issues.map((i) => i.message)
 		}
-		case 'story-translation': {
-			const result = wizardStoryTranslationSchema.safeParse({
-				pitchTranslation: formData.pitchTranslation,
-			})
-			return result.success ? [] : result.error.issues.map((i) => i.message)
-		}
 		case 'highlights-primary': {
 			const result = wizardHighlightsPrimarySchema.safeParse({
 				highlights: formData.highlights,
-			})
-			return result.success ? [] : result.error.issues.map((i) => i.message)
-		}
-		case 'highlights-translation': {
-			const result = wizardHighlightsTranslationSchema.safeParse({
-				translationHighlights: formData.translationHighlights,
 			})
 			return result.success ? [] : result.error.issues.map((i) => i.message)
 		}
@@ -100,9 +79,6 @@ export function useContentWizardValidation(formData: ContentWizardFormData) {
 			'basics-primary',
 			'story-primary',
 			'highlights-primary',
-			'basics-translation',
-			'story-translation',
-			'highlights-translation',
 			'media',
 			'location',
 			'review',
@@ -129,11 +105,8 @@ export function useContentWizardValidation(formData: ContentWizardFormData) {
 			translationStatus,
 			isFullyValid:
 				steps['basics-primary'].valid &&
-				steps['basics-translation'].valid &&
 				steps['story-primary'].valid &&
-				steps['story-translation'].valid &&
 				steps['highlights-primary'].valid &&
-				steps['highlights-translation'].valid &&
 				steps.location.valid,
 		}
 	}, [formData])

--- a/apps/web/components/sections/projects/content-wizard/steps/wizard-review-step.tsx
+++ b/apps/web/components/sections/projects/content-wizard/steps/wizard-review-step.tsx
@@ -1,11 +1,7 @@
 'use client'
 
-import { Badge } from '~/components/base/badge'
 import { useContentWizard } from '~/hooks/contexts/use-content-wizard.context'
 import { useI18n } from '~/lib/i18n/context'
-import { getOppositeLocale } from '~/lib/schemas/locale.schemas'
-import type { TranslationSectionStatus } from '~/lib/types/project/content-wizard.types'
-import { useContentWizardValidation } from '../hooks/use-content-wizard-validation'
 import { WizardStepShell } from '../wizard-step-shell'
 
 type WizardReviewStepProps = {
@@ -14,34 +10,10 @@ type WizardReviewStepProps = {
 	isSaving?: boolean
 }
 
-const statusLabel = (status: TranslationSectionStatus, t: (key: string) => string): string => {
-	switch (status) {
-		case 'complete':
-			return t('projects.manage.contentWizard.statusComplete')
-		case 'partial':
-			return t('projects.manage.contentWizard.statusInProgress')
-		default:
-			return t('projects.manage.contentWizard.statusNotStarted')
-	}
-}
-
-const statusVariant = (status: TranslationSectionStatus) => {
-	switch (status) {
-		case 'complete':
-			return 'default' as const
-		case 'partial':
-			return 'secondary' as const
-		default:
-			return 'outline' as const
-	}
-}
-
 export function WizardReviewStep({ onFinish, onBack, isSaving = false }: WizardReviewStepProps) {
 	const { t } = useI18n()
 	const { formData } = useContentWizard()
-	const { translationStatus } = useContentWizardValidation(formData)
 	const sourceLocale = formData.sourceLocale ?? 'en'
-	const oppositeLocale = getOppositeLocale(sourceLocale)
 
 	return (
 		<WizardStepShell
@@ -52,48 +24,25 @@ export function WizardReviewStep({ onFinish, onBack, isSaving = false }: WizardR
 			continueLabel={t('projects.manage.contentWizard.finish')}
 			isSaving={isSaving}
 		>
-			<div className="space-y-6">
-				<div className="rounded-lg border bg-muted/30 p-4">
-					<p className="text-sm font-medium">
-						{t('projects.manage.contentWizard.translationProgress')}:{' '}
-						{translationStatus.overallPercent}%
-					</p>
-					<p className="mt-1 text-sm text-muted-foreground">
-						{t('projects.manage.contentWizard.translationProgressDescription')}
-					</p>
-				</div>
-
-				<div className="grid gap-4 sm:grid-cols-2">
-					<ReviewSection
-						title={`${sourceLocale === 'en' ? 'English' : 'Spanish'} — ${t('projects.manage.contentWizard.stepBasics')}`}
-						items={[
-							{ label: 'Title', value: formData.title },
-							{ label: 'Description', value: formData.description },
-						]}
-					/>
-					<ReviewSection
-						title={`${oppositeLocale === 'en' ? 'English' : 'Spanish'} — ${t('projects.manage.contentWizard.stepBasics')}`}
-						items={[
-							{ label: 'Title', value: formData.translation?.title ?? '' },
-							{ label: 'Description', value: formData.translation?.description ?? '' },
-						]}
-					/>
-				</div>
-
-				<div className="flex flex-wrap gap-2">
-					<Badge variant={statusVariant(translationStatus.basics)}>
-						{t('projects.manage.contentWizard.stepBasics')}:{' '}
-						{statusLabel(translationStatus.basics, t)}
-					</Badge>
-					<Badge variant={statusVariant(translationStatus.story)}>
-						{t('projects.manage.contentWizard.stepStory')}:{' '}
-						{statusLabel(translationStatus.story, t)}
-					</Badge>
-					<Badge variant={statusVariant(translationStatus.highlights)}>
-						{t('projects.manage.contentWizard.stepHighlights')}:{' '}
-						{statusLabel(translationStatus.highlights, t)}
-					</Badge>
-				</div>
+			<div className="space-y-4">
+				<ReviewSection
+					title={`${sourceLocale === 'en' ? 'English' : 'Spanish'} — ${t('projects.manage.contentWizard.stepBasics')}`}
+					items={[
+						{ label: 'Title', value: formData.title },
+						{ label: 'Description', value: formData.description },
+					]}
+				/>
+				<ReviewSection
+					title={t('projects.manage.contentWizard.stepStory')}
+					items={[{ label: 'Title', value: formData.pitchTitle }]}
+				/>
+				<ReviewSection
+					title={t('projects.manage.contentWizard.stepHighlights')}
+					items={formData.highlights.map((h, i) => ({
+						label: `Highlight ${i + 1}`,
+						value: h.title,
+					}))}
+				/>
 			</div>
 		</WizardStepShell>
 	)

--- a/apps/web/components/sections/projects/content-wizard/steps/wizard-story-primary-step.tsx
+++ b/apps/web/components/sections/projects/content-wizard/steps/wizard-story-primary-step.tsx
@@ -52,7 +52,7 @@ export function WizardStoryPrimaryStep({
 	isSaving = false,
 }: WizardStoryPrimaryStepProps) {
 	const { t } = useI18n()
-	const { formData } = useContentWizard()
+	const { formData, projectSlug } = useContentWizard()
 
 	const form = useForm<StoryFormValues>({
 		resolver: zodResolver(storyPrimaryFormSchema),
@@ -104,6 +104,7 @@ export function WizardStoryPrimaryStep({
 										value={field.value}
 										onChange={field.onChange}
 										error={form.formState.errors.pitchStory?.message}
+										projectSlug={projectSlug ?? undefined}
 									/>
 								</FormControl>
 								<FormDescription>

--- a/apps/web/components/sections/projects/detail/tabs/overview-tab.tsx
+++ b/apps/web/components/sections/projects/detail/tabs/overview-tab.tsx
@@ -25,13 +25,32 @@ export function OverviewTab({ pitch }: OverviewTabProps) {
 		}
 	}, [])
 
-	// Sanitize user-provided HTML to prevent XSS before parsing/rendering
+	// Sanitize user-provided HTML to prevent XSS before parsing/rendering.
+	// Images from the Supabase story-images bucket are allowed; all other img src values are stripped.
 	const safeStory = useMemo(() => {
 		if (!pitch.story) return ''
 
-		// Only sanitize in the browser where DOMPurify is available
 		if (DOMPurify) {
-			return DOMPurify.sanitize(pitch.story)
+			const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+			const allowedPrefix = `${supabaseUrl}/storage/v1/object/public/project_story_images/`
+
+			DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+				if (node.tagName === 'IMG') {
+					const src = node.getAttribute('src') ?? ''
+					if (!src.startsWith(allowedPrefix)) {
+						node.removeAttribute('src')
+					}
+				}
+			})
+
+			const sanitized = DOMPurify.sanitize(pitch.story, {
+				ADD_TAGS: ['img'],
+				ADD_ATTR: ['src', 'alt', 'width', 'height', 'loading'],
+				FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover'],
+			})
+
+			DOMPurify.removeHooks('afterSanitizeAttributes')
+			return sanitized
 		}
 
 		// Fallback for SSR: return original story (will be sanitized on client hydration)

--- a/apps/web/components/sections/projects/pitch/project-pitch-form.tsx
+++ b/apps/web/components/sections/projects/pitch/project-pitch-form.tsx
@@ -150,6 +150,7 @@ export function ProjectPitchForm({
 												value={field.value}
 												onChange={field.onChange}
 												error={form.formState.errors.story?.message}
+												projectSlug={projectSlug}
 											/>
 										</FormControl>
 										<FormDescription>
@@ -205,6 +206,7 @@ export function ProjectPitchForm({
 													value={field.value ?? ''}
 													onChange={field.onChange}
 													error={form.formState.errors.translation?.story?.message}
+													projectSlug={projectSlug}
 												/>
 											</FormControl>
 											<FormDescription>

--- a/apps/web/components/sections/projects/pitch/rich-text-editor.tsx
+++ b/apps/web/components/sections/projects/pitch/rich-text-editor.tsx
@@ -11,6 +11,7 @@ import {
 	Heading2,
 	Heading3,
 	Heading4,
+	ImageIcon,
 	Italic,
 	Link as LinkIcon,
 	List,
@@ -18,7 +19,8 @@ import {
 	Redo,
 	Undo,
 } from 'lucide-react'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
+import { toast } from 'sonner'
 import { Button } from '~/components/base/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '~/components/base/tooltip'
 import { cn } from '~/lib/utils'
@@ -27,12 +29,16 @@ import { LinkDialog } from './link-dialog'
 // Returns the count of visible characters by collapsing whitespace and trimming the text
 const visibleCharCount = (text: string) => Array.from(text.replace(/\s+/g, ' ').trim()).length
 
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024 // 5 MB
+
 interface RichTextEditorProps {
 	value: string
 	onChange: (value: string) => void
 	placeholder?: string
 	className?: string
 	error?: string
+	projectSlug?: string
 }
 
 export function RichTextEditor({
@@ -41,12 +47,15 @@ export function RichTextEditor({
 	placeholder = 'Start writing your story...',
 	className,
 	error,
+	projectSlug,
 }: RichTextEditorProps) {
 	const [linkDialogOpen, setLinkDialogOpen] = useState(false)
 	const [linkDialogData, setLinkDialogData] = useState({
 		initialUrl: '',
 		selectedText: '',
 	})
+	const [isUploading, setIsUploading] = useState(false)
+	const fileInputRef = useRef<HTMLInputElement>(null)
 
 	const editor = useEditor({
 		extensions: [
@@ -78,7 +87,12 @@ export function RichTextEditor({
 					class: 'text-blue-500 hover:text-blue-700 underline',
 				},
 			}),
-			Image,
+			Image.configure({
+				allowBase64: false,
+				HTMLAttributes: {
+					class: 'max-w-full rounded-lg my-2',
+				},
+			}),
 			Placeholder.configure({
 				placeholder,
 				emptyEditorClass:
@@ -95,6 +109,46 @@ export function RichTextEditor({
 		},
 		immediatelyRender: false,
 	})
+
+	const handleImageFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0]
+		if (!file) return
+		// Reset so the same file can be re-uploaded
+		e.target.value = ''
+
+		if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+			toast.error('Invalid file type. Please upload a JPEG, PNG, WebP, or GIF.')
+			return
+		}
+		if (file.size > MAX_IMAGE_SIZE) {
+			toast.error('Image must be smaller than 5 MB.')
+			return
+		}
+
+		setIsUploading(true)
+		try {
+			const formData = new FormData()
+			formData.append('image', file)
+
+			const response = await fetch(`/api/projects/${projectSlug}/story-image`, {
+				method: 'POST',
+				body: formData,
+			})
+
+			if (!response.ok) {
+				const data = await response.json().catch(() => ({}))
+				toast.error((data as { error?: string }).error ?? 'Image upload failed.')
+				return
+			}
+
+			const { url } = await response.json()
+			editor?.chain().focus().setImage({ src: url, alt: '' }).run()
+		} catch {
+			toast.error('Image upload failed. Please try again.')
+		} finally {
+			setIsUploading(false)
+		}
+	}
 
 	const formatButtons = [
 		{
@@ -197,6 +251,25 @@ export function RichTextEditor({
 							<TooltipContent>{label}</TooltipContent>
 						</Tooltip>
 					))}
+
+					{projectSlug && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									className="h-8 w-8 p-0"
+									onClick={() => fileInputRef.current?.click()}
+									disabled={isUploading || !editor}
+									aria-label="Insert image"
+								>
+									<ImageIcon className="h-4 w-4" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>{isUploading ? 'Uploading…' : 'Insert image'}</TooltipContent>
+						</Tooltip>
+					)}
 				</div>
 
 				<div className="min-h-[200px]">
@@ -221,6 +294,15 @@ export function RichTextEditor({
 					selectedText={linkDialogData.selectedText}
 				/>
 			)}
+
+			<input
+				ref={fileInputRef}
+				type="file"
+				accept="image/jpeg,image/png,image/webp,image/gif"
+				className="hidden"
+				onChange={handleImageFileChange}
+				tabIndex={-1}
+			/>
 		</TooltipProvider>
 	)
 }

--- a/apps/web/lib/email/notifications/send-new-project-emails.tsx
+++ b/apps/web/lib/email/notifications/send-new-project-emails.tsx
@@ -8,7 +8,49 @@ import {
 } from '../notification-helpers'
 import { NewProjectEmail } from '../templates/new-project-email'
 
-export async function sendNewProjectEmails({
+/**
+ * Notifies the creator that their project has been submitted for admin review.
+ * Does NOT notify followers — that happens only when an admin activates the project.
+ */
+export async function sendProjectSubmittedForReviewEmail({
+	projectTitle,
+	projectSlug,
+	creatorId,
+}: {
+	projectTitle: string
+	projectSlug: string
+	creatorId: string
+}) {
+	const creator = await getUserEmailAndName(creatorId)
+	if (creator.email) {
+		await sendEmail({
+			to: creator.email,
+			subject: `Your project "${projectTitle}" is under review`,
+			react: (
+				<NewProjectEmail
+					recipientName={creator.displayName || 'there'}
+					projectTitle={projectTitle}
+					projectSlug={projectSlug}
+					appUrl={appUrl}
+					isCreator
+					isUnderReview
+				/>
+			),
+		})
+	}
+	await createInAppNotification({
+		userId: creatorId,
+		title: 'Project submitted for review',
+		body: `Your project "${projectTitle}" has been submitted and is awaiting admin review.`,
+		type: 'success',
+	})
+}
+
+/**
+ * Notifies followers of a creator when their project becomes active.
+ * Call this only after an admin activates the campaign.
+ */
+export async function sendProjectActivatedEmails({
 	projectTitle,
 	projectSlug,
 	creatorId,
@@ -19,18 +61,19 @@ export async function sendNewProjectEmails({
 	creatorId: string
 	creatorName?: string
 }) {
-	// 1. Email + in-app to project creator
 	const creator = await getUserEmailAndName(creatorId)
+	const creatorDisplayName = creatorName ?? creator.displayName
+
+	// Notify creator that their campaign is now live
 	if (creator.email) {
 		await sendEmail({
 			to: creator.email,
-			subject: `Your project "${projectTitle}" is live on KindFi`,
+			subject: `Your campaign "${projectTitle}" is now live on KindFi`,
 			react: (
 				<NewProjectEmail
 					recipientName={creator.displayName || 'there'}
 					projectTitle={projectTitle}
 					projectSlug={projectSlug}
-					creatorName={creatorName}
 					appUrl={appUrl}
 					isCreator
 				/>
@@ -39,13 +82,11 @@ export async function sendNewProjectEmails({
 	}
 	await createInAppNotification({
 		userId: creatorId,
-		title: 'Project created',
-		body: `Your project "${projectTitle}" has been created. Complete your setup within 7 days.`,
+		title: 'Campaign approved',
+		body: `Your campaign "${projectTitle}" has been approved and is now live.`,
 		type: 'success',
 	})
 
-	// 2. Email to followers of the creator (supporters who want new project alerts)
-	const creatorDisplayName = creatorName ?? creator.displayName
 	const { data: followers } = await supabaseServiceRole
 		.from('user_follows')
 		.select('follower_id')
@@ -81,4 +122,23 @@ export async function sendNewProjectEmails({
 			})
 		}
 	}
+}
+
+/**
+ * @deprecated Use sendProjectSubmittedForReviewEmail instead.
+ * Kept for backwards-compatibility with existing callers.
+ */
+export async function sendNewProjectEmails({
+	projectTitle,
+	projectSlug,
+	creatorId,
+	creatorName,
+}: {
+	projectTitle: string
+	projectSlug: string
+	creatorId: string
+	creatorName?: string
+}) {
+	await sendProjectSubmittedForReviewEmail({ projectTitle, projectSlug, creatorId })
+	await sendProjectActivatedEmails({ projectTitle, projectSlug, creatorId, creatorName })
 }

--- a/apps/web/lib/email/notifications/send-project-review-notification.tsx
+++ b/apps/web/lib/email/notifications/send-project-review-notification.tsx
@@ -1,0 +1,66 @@
+import { logger } from '@/lib/logger'
+import {
+	appUrl,
+	createInAppNotification,
+	getUserEmailAndName,
+	getUserEmailPref,
+	sendEmail,
+} from '~/lib/email/notification-helpers'
+import { ProjectReviewRequestedEmail } from '~/lib/email/templates/project-review-requested-email'
+import { getPlatformAdminIds } from '~/lib/queries/admin/get-platform-admin-ids'
+
+/**
+ * Notifies all platform admins when a creator submits a project for review.
+ */
+export async function sendProjectReviewRequestNotification({
+	projectTitle,
+	projectSlug,
+	creatorName,
+}: {
+	projectTitle: string
+	projectSlug: string
+	creatorName?: string
+}): Promise<void> {
+	const adminIds = await getPlatformAdminIds()
+	if (adminIds.length === 0) {
+		logger.warn('[ProjectReviewNotification] No platform admins found to notify')
+		return
+	}
+
+	const submittedAt = new Date().toLocaleString('en-US', {
+		dateStyle: 'medium',
+		timeStyle: 'short',
+	})
+
+	await Promise.all(
+		adminIds.map(async (adminId) => {
+			const admin = await getUserEmailAndName(adminId)
+
+			await createInAppNotification({
+				userId: adminId,
+				title: 'Campaign review requested',
+				body: `${creatorName ?? 'A creator'} submitted "${projectTitle}" for review.`,
+				type: 'info',
+			})
+
+			if (!admin.email) return
+			const wantsEmail = await getUserEmailPref(adminId)
+			if (!wantsEmail) return
+
+			await sendEmail({
+				to: admin.email,
+				subject: `Campaign review requested: ${projectTitle}`,
+				react: (
+					<ProjectReviewRequestedEmail
+						recipientName={admin.displayName || 'Admin'}
+						projectTitle={projectTitle}
+						projectSlug={projectSlug}
+						creatorName={creatorName}
+						submittedAt={submittedAt}
+						appUrl={appUrl}
+					/>
+				),
+			})
+		}),
+	)
+}

--- a/apps/web/lib/email/templates/new-project-email.tsx
+++ b/apps/web/lib/email/templates/new-project-email.tsx
@@ -18,6 +18,7 @@ interface NewProjectEmailProps {
 	creatorName?: string
 	appUrl: string
 	isCreator?: boolean
+	isUnderReview?: boolean
 }
 
 export function NewProjectEmail({
@@ -27,29 +28,47 @@ export function NewProjectEmail({
 	creatorName,
 	appUrl,
 	isCreator = false,
+	isUnderReview = false,
 }: NewProjectEmailProps) {
 	const projectUrl = `${appUrl}/projects/${projectSlug}`
+
+	const previewText = isUnderReview
+		? `Your project "${projectTitle}" is under review`
+		: isCreator
+			? `Your project "${projectTitle}" is live on KindFi`
+			: `New project "${projectTitle}" needs your support on KindFi`
 
 	return (
 		<Html lang="en">
 			<Head />
-			<Preview>
-				{isCreator
-					? `Your project "${projectTitle}" is live on KindFi`
-					: `New project "${projectTitle}" needs your support on KindFi`}
-			</Preview>
+			<Preview>{previewText}</Preview>
 			<Tailwind>
 				<Body className="bg-gray-50 text-gray-900">
 					<Container className="mx-auto my-8 w-full max-w-[560px]">
 						<Section className="bg-white rounded-2xl p-8 shadow">
 							<Text className="text-2xl font-semibold mb-1">
-								{isCreator ? '🎉 Your project is live!' : '🌟 New project in need'}
+								{isUnderReview
+									? 'Your campaign is under review'
+									: isCreator
+										? 'Your project is live!'
+										: 'New project in need'}
 							</Text>
 							<Text className="text-sm text-gray-500 mb-4">KindFi</Text>
 
 							<Text className="text-base leading-6 mb-3">Hi {recipientName},</Text>
 
-							{isCreator ? (
+							{isUnderReview ? (
+								<>
+									<Text className="text-base leading-6 mb-3">
+										Your campaign <strong>{projectTitle}</strong> has been submitted and is now
+										awaiting review by the KindFi admin team.
+									</Text>
+									<Text className="text-base leading-6 mb-4">
+										We will notify you once a decision has been made. In the meantime, you can
+										continue editing your campaign from your dashboard.
+									</Text>
+								</>
+							) : isCreator ? (
 								<>
 									<Text className="text-base leading-6 mb-3">
 										Your project <strong>{projectTitle}</strong> has been successfully created on
@@ -76,7 +95,11 @@ export function NewProjectEmail({
 								href={projectUrl}
 								className="bg-purple-600 text-white font-semibold py-3 px-6 rounded-lg"
 							>
-								{isCreator ? 'Complete project setup' : 'View project'}
+								{isUnderReview
+									? 'View your campaign'
+									: isCreator
+										? 'Complete project setup'
+										: 'View project'}
 							</Button>
 
 							<Hr className="my-6 border-gray-200" />

--- a/apps/web/lib/email/templates/project-review-requested-email.tsx
+++ b/apps/web/lib/email/templates/project-review-requested-email.tsx
@@ -1,0 +1,69 @@
+import {
+	Body,
+	Button,
+	Container,
+	Head,
+	Hr,
+	Html,
+	Preview,
+	Section,
+	Text,
+} from '@react-email/components'
+import { Tailwind } from '@react-email/tailwind'
+
+interface ProjectReviewRequestedEmailProps {
+	recipientName: string
+	projectTitle: string
+	projectSlug: string
+	creatorName?: string
+	submittedAt: string
+	appUrl: string
+}
+
+export function ProjectReviewRequestedEmail({
+	recipientName,
+	projectTitle,
+	projectSlug,
+	creatorName,
+	submittedAt,
+	appUrl,
+}: ProjectReviewRequestedEmailProps) {
+	const reviewQueueUrl = `${appUrl}/admin/projects`
+
+	return (
+		<Html lang="en">
+			<Head />
+			<Preview>{`New campaign ready for review: ${projectTitle}`}</Preview>
+			<Tailwind>
+				<Body className="bg-gray-50 text-gray-900">
+					<Container className="mx-auto my-8 w-full max-w-[560px]">
+						<Section className="bg-white rounded-2xl p-8 shadow">
+							<Text className="text-2xl font-semibold mb-1">Campaign review requested</Text>
+							<Text className="text-sm text-gray-500 mb-4">KindFi Admin</Text>
+
+							<Text className="text-base leading-6 mb-3">Hi {recipientName},</Text>
+
+							<Text className="text-base leading-6 mb-3">
+								{creatorName ? <strong>{creatorName}</strong> : 'A creator'} submitted the campaign{' '}
+								<strong>{projectTitle}</strong> for review on {submittedAt}. Please review it and
+								either activate or reject the campaign.
+							</Text>
+
+							<Button
+								href={reviewQueueUrl}
+								className="bg-purple-600 text-white font-semibold py-3 px-6 rounded-lg"
+							>
+								Open campaign review queue
+							</Button>
+
+							<Hr className="my-6 border-gray-200" />
+							<Text className="text-sm text-gray-500">
+								Campaign: {projectTitle} ({projectSlug})
+							</Text>
+						</Section>
+					</Container>
+				</Body>
+			</Tailwind>
+		</Html>
+	)
+}

--- a/apps/web/lib/queries/projects/get-all-projects.ts
+++ b/apps/web/lib/queries/projects/get-all-projects.ts
@@ -20,6 +20,7 @@ export type ProjectListItem = Project & {
 
 export type GetAllProjectsOptions = LocalizeOptions & {
 	viewerLocale?: SupportedLocale
+	includeAllStatuses?: boolean
 }
 
 /**
@@ -105,6 +106,10 @@ export async function getAllProjects(
 			isPaginated ? { count: 'exact' } : {},
 		)
 		.order(column, { ascending })
+
+	if (!options?.includeAllStatuses) {
+		query = query.in('status', ['active', 'paused', 'funded'])
+	}
 
 	if (categorySlugs.length > 0) {
 		const { data: categories, error: catErr } = await client

--- a/apps/web/lib/queries/projects/resolve-project-by-slug.ts
+++ b/apps/web/lib/queries/projects/resolve-project-by-slug.ts
@@ -2,10 +2,7 @@ import { supabase as supabaseServiceRole } from '@packages/lib/supabase'
 import { createSupabaseServerClient } from '@packages/lib/supabase-server'
 import { logger } from '@/lib/logger'
 import { getProjectIdBySlug } from '~/lib/api/authorize-project-manage'
-import {
-	canAccessDevelopmentOnlyProject,
-	getProjectDevelopmentOnlyFlag,
-} from '~/lib/queries/projects/development-only-access'
+import { canAccessDevelopmentOnlyProject } from '~/lib/queries/projects/development-only-access'
 import { getProjectBySlug } from '~/lib/queries/projects/get-project-by-slug'
 import type { SupportedLocale } from '~/lib/schemas/locale.schemas'
 import type { LocalizeOptions } from '~/lib/services/content-translation'
@@ -16,6 +13,7 @@ export type ResolveProjectBySlugOptions = LocalizeOptions & {
 
 /**
  * Loads a project detail payload, including development-only rows for authorized viewers.
+ * Draft and review projects are also accessible to their owner and platform admins.
  */
 export async function resolveProjectBySlug(
 	slug: string,
@@ -42,15 +40,39 @@ export async function resolveProjectBySlug(
 		return null
 	}
 
-	const developmentOnly = await getProjectDevelopmentOnlyFlag(projectId)
-	if (!developmentOnly) {
+	// Fetch project metadata needed for both access checks in one query
+	const { data: projectMeta } = await supabaseServiceRole
+		.from('projects')
+		.select('development_only, status, kindler_id')
+		.eq('id', projectId)
+		.single()
+
+	if (!projectMeta) {
 		return null
 	}
 
-	const allowed = await canAccessDevelopmentOnlyProject(projectId, userId)
-	if (!allowed) {
-		return null
+	// Allow development-only project access (existing behavior)
+	if (projectMeta.development_only) {
+		const allowed = await canAccessDevelopmentOnlyProject(projectId, userId)
+		if (allowed) {
+			return getProjectBySlug(supabaseServiceRole, slug, { ...options, localize: false })
+		}
 	}
 
-	return getProjectBySlug(supabaseServiceRole, slug, { ...options, localize: false })
+	// Allow project owner and platform admins to preview draft/review campaigns
+	if (projectMeta.status === 'draft' || projectMeta.status === 'review') {
+		if (projectMeta.kindler_id === userId) {
+			return getProjectBySlug(supabaseServiceRole, slug, { ...options, localize: false })
+		}
+		const { data: profile } = await supabaseServiceRole
+			.from('profiles')
+			.select('role')
+			.eq('id', userId)
+			.single()
+		if (profile?.role === 'admin') {
+			return getProjectBySlug(supabaseServiceRole, slug, { ...options, localize: false })
+		}
+	}
+
+	return null
 }

--- a/apps/web/lib/types/project/content-wizard.types.ts
+++ b/apps/web/lib/types/project/content-wizard.types.ts
@@ -12,9 +12,6 @@ export type ContentWizardStep =
 	| 'basics-primary'
 	| 'story-primary'
 	| 'highlights-primary'
-	| 'basics-translation'
-	| 'story-translation'
-	| 'highlights-translation'
 	| 'media'
 	| 'location'
 	| 'review'
@@ -24,9 +21,6 @@ export const CONTENT_WIZARD_STEPS: ContentWizardStep[] = [
 	'basics-primary',
 	'story-primary',
 	'highlights-primary',
-	'basics-translation',
-	'story-translation',
-	'highlights-translation',
 	'media',
 	'location',
 	'review',

--- a/apps/web/lib/utils/project-translation-status.ts
+++ b/apps/web/lib/utils/project-translation-status.ts
@@ -107,10 +107,7 @@ export function getFirstIncompleteWizardStep(input: {
 }): import('~/lib/types/project/content-wizard.types').ContentWizardStep {
 	if (!input.hasSourceLocale) return 'language'
 	if (!isBasicsSourceComplete(input)) return 'basics-primary'
-	if (!isBasicsTranslationComplete(input.translation)) return 'basics-translation'
 	if (!isStorySourceComplete(input)) return 'story-primary'
-	if (!isStoryTranslationComplete(input.pitchTranslation)) return 'story-translation'
 	if (!isHighlightsListComplete(input.highlights)) return 'highlights-primary'
-	if (!isHighlightsListComplete(input.translationHighlights)) return 'highlights-translation'
 	return 'media'
 }

--- a/apps/web/lib/utils/project-utils.ts
+++ b/apps/web/lib/utils/project-utils.ts
@@ -416,6 +416,25 @@ export async function uploadPitchDeck(
 	})
 }
 
+export async function uploadStoryImage(
+	slug: string,
+	file: File,
+	supabase: TypedSupabaseClient,
+): Promise<string | null> {
+	const adapter = makeSupabaseAdapter(supabase, 'project_story_images')
+	return uploadFile({
+		client: adapter,
+		folder: slug,
+		file,
+		generateFilename: (slug, file) => {
+			const ext = file.name.split('.').pop() || 'jpg'
+			return `${slug}/${uuidv4()}.${ext}`
+		},
+		deleteExisting: false,
+		cacheControl: '31536000', // 1 year — story images are immutable
+	})
+}
+
 export {
 	getVideoProvider,
 	isSupportedVideoUrl,

--- a/services/supabase/migrations/20260827000001_restrict_project_visibility_by_status.sql
+++ b/services/supabase/migrations/20260827000001_restrict_project_visibility_by_status.sql
@@ -1,0 +1,32 @@
+-- Restrict public project visibility to active/paused/funded campaigns.
+-- Draft and review projects remain accessible to:
+--   • Platform admins (role = 'admin')
+--   • The project owner (kindler_id = auth.uid())
+--   • Authorized project members (core / admin / editor roles)
+
+-- Drop the existing permissive public-read policy
+DROP POLICY IF EXISTS "Projects are viewable by everyone" ON projects;
+
+-- Recreate with status guard
+CREATE POLICY "Projects are publicly visible when active"
+  ON projects
+  FOR SELECT
+  USING (
+    -- Public: only active-ish projects, excluding dev-only
+    (status IN ('active', 'paused', 'funded') AND NOT development_only)
+    -- Platform admins see everything
+    OR EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+        AND profiles.role = 'admin'
+    )
+    -- Project owner sees their own project at any status
+    OR kindler_id = auth.uid()
+    -- Authorized project members see the project
+    OR EXISTS (
+      SELECT 1 FROM project_members pm
+      WHERE pm.project_id = projects.id
+        AND pm.user_id = auth.uid()
+        AND pm.role IN ('core', 'admin', 'editor')
+    )
+  );

--- a/services/supabase/migrations/20260827000002_create_story_images_bucket.sql
+++ b/services/supabase/migrations/20260827000002_create_story_images_bucket.sql
@@ -1,0 +1,29 @@
+-- Create a public Supabase Storage bucket for project story images.
+-- Images are served publicly via their hosted URL so they can be embedded
+-- in story HTML without authentication.
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('project_story_images', 'project_story_images', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Allow authenticated users with project-management permissions to upload.
+-- Fine-grained permission enforcement is done at the API layer (story-image route).
+CREATE POLICY "Authenticated users can upload story images"
+  ON storage.objects
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (bucket_id = 'project_story_images');
+
+-- Allow the public to read story images (needed for embedding in project pages).
+CREATE POLICY "Story images are publicly readable"
+  ON storage.objects
+  FOR SELECT
+  TO public
+  USING (bucket_id = 'project_story_images');
+
+-- Allow authenticated users to delete their own story images.
+CREATE POLICY "Authenticated users can delete story images"
+  ON storage.objects
+  FOR DELETE
+  TO authenticated
+  USING (bucket_id = 'project_story_images');


### PR DESCRIPTION

Closes #1003

## Review & publication workflow
- Completing the content wizard now submits the project for review by patching its status to `review` via the existing status transition endpoint (draft → review enforced by isAllowedStatusTransition).
- Public project queries (`getAllProjects`) now filter to `status IN ('active', 'paused', 'funded')` by default; the admin route passes `includeAllStatuses: true` to retain full visibility.
- `resolveProjectBySlug` allows project owners and platform admins to preview their own draft/review campaigns via the service-role client.
- New RLS migration restricts direct Supabase access to active projects, with exceptions for admins, the project owner, and project members.
- Notification flow split: creators receive a "submitted for review" email on creation; followers and the creator receive an "approved / now live" notification only when an admin activates the campaign; creators receive an in-app rejection notification when rejected.
- New `sendProjectReviewRequestNotification` service notifies all platform admins (in-app + email) when a campaign enters review, following the same pattern as milestone-review notifications.
- New `ProjectReviewRequestedEmail` React Email template for admins.

## Localization — source language only
- Removed `basics-translation`, `story-translation`, and `highlights-translation` steps from `ContentWizardStep` type, `CONTENT_WIZARD_STEPS` array, step indicator, validation hook, orchestrator switch, save hook, and resume logic.
- `isFullyValid` no longer requires translation steps; campaign submission is unblocked for creators who only fill source content.
- Wizard review step simplified to a single-column source-language summary; translation progress header removed from the wizard.
- Admin pitch form and manage views retain full translation editing.

## Story image upload
- Added `projectSlug` prop to `RichTextEditor`; when provided an "Insert image" toolbar button appears (ImageIcon with tooltip).
- Hidden file input triggers the OS file picker; client validates MIME type (jpeg/png/webp/gif) and size (≤ 5 MB) before uploading.
- New API route `POST /api/projects/[slug]/story-image` authenticates the user, verifies project-management permissions, validates the file server-side, and uploads to the `project_story_images` Supabase Storage bucket via `uploadStoryImage` in project-utils.
- TipTap Image extension configured with `allowBase64: false` to prevent base64 data from being stored in story HTML.
- `DOMPurify.sanitize` in `overview-tab` updated to allow `<img>` tags whose `src` originates from the known Supabase storage prefix; all other image sources are stripped before rendering.
- New Supabase Storage bucket `project_story_images` (public read, authenticated upload) created via migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload JPEG, PNG, WebP, and GIF images directly into project stories.
  * Receive clearer notifications when projects are submitted, approved, activated, or rejected.
  * Project owners and administrators can preview draft and review-stage projects.

* **Improvements**
  * Simplified the project content wizard to focus on primary-language content.
  * Admin project listings now include projects across all statuses.

* **Bug Fixes & Security**
  * Restricted public visibility for unpublished or development-only projects.
  * Improved story image validation and protection against unsafe image sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->